### PR TITLE
Fix JS testing workflow

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "web/**"
   # Run this on push to PRs, regardless of branch
   pull_request:
-  # Only run this if there are changes to the web subrepo
-  paths:
-    - "web/**"
+    paths:
+      - "web/**"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `paths` event filter was being used as a global filter, which is not valid. It has to be applied to both the `push` event and the `pull_request` event.