### PR TITLE
[WJ-255] Add Webpack production mode

### DIFF
--- a/web/conf/webpack.common.js
+++ b/web/conf/webpack.common.js
@@ -2,13 +2,13 @@ const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-  entry: './web/files--common/javascript/index.ts',
+  context: path.resolve(__dirname, '../web/files--common/javascript'),
+  entry: './index.ts',
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, 'web/files--common/dist'),
+    path: path.resolve(__dirname, '../web/files--common/dist'),
     libraryTarget: 'window'
   },
-  devtool: "source-map",
   module: {
     rules: [
       { test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }
@@ -16,9 +16,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['.ts', '.js'],
-    alias: { '@': path.resolve(__dirname, 'web/files--common') }
+    alias: { '@': path.resolve(__dirname, '../web/files--common') }
   },
   plugins: [
     new CleanWebpackPlugin()
   ]
-}
+};

--- a/web/conf/webpack.dev.js
+++ b/web/conf/webpack.dev.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map'
+});

--- a/web/conf/webpack.prod.js
+++ b/web/conf/webpack.prod.js
@@ -1,0 +1,16 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const TerserPlugin = require("terser-webpack-plugin");
+
+module.exports = merge(common, {
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: false,
+        terserOptions: { format: { comments: false } }
+      })
+    ]
+  }
+});

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
         "test": "tests"
     },
     "scripts": {
-        "build": "webpack --config webpack.config.js --mode development",
+        "build": "webpack --config conf/webpack.dev.js",
+        "build-prod": "webpack --config conf/webpack.prod.js",
         "test": "jest"
     },
     "repository": {

--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
         "ts-loader": "^8.0.10",
         "typescript": "^4.0.5",
         "webpack": "^5.1.3",
-        "webpack-cli": "^4.0.0"
+        "webpack-cli": "^4.0.0",
+        "webpack-merge": "^5.4.0"
     }
 }

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -11,18 +11,12 @@ module.exports = {
   devtool: "source-map",
   module: {
     rules: [
-      {
-        test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: /node_modules/
-      }
+      { test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }
     ]
   },
   resolve: {
     extensions: ['.ts', '.js'],
-    alias: {
-      '@': path.resolve(__dirname, 'web/files--common')
-    }
+    alias: { '@': path.resolve(__dirname, 'web/files--common') }
   },
   plugins: [
     new CleanWebpackPlugin()


### PR DESCRIPTION
[WJ-255](https://scuttle.atlassian.net/browse/WJ-255)

This PR adds a production mode to Webpack, invoked with `npm run build-prod` (as opposed to the usual `npm run build`). This will output a minified bundle.js and will not produce a source map.

Dev bundle: 485 KiB
Prod bundle: 70.9 KiB

The final deployment should be built using production mode.