### PR TITLE
Fixes to docker-compose setup and insecure cookie fallback functions

### DIFF
--- a/install/php-fpm/Dockerfile
+++ b/install/php-fpm/Dockerfile
@@ -98,6 +98,7 @@ RUN npm install && \
 
 # Cleanup
 RUN rm -rf /src
+RUN chown -R www-data:www-data .
 
 # Main process
 # Let the upstream ENTRYPOINT handle running php-fpm

--- a/install/php-fpm/Dockerfile
+++ b/install/php-fpm/Dockerfile
@@ -44,7 +44,8 @@ RUN apk add --update --no-cache \
     libmemcached-libs \
     zlib \
     postgresql-dev \
-    tidyhtml-dev
+    tidyhtml-dev \
+    gettext-dev
 
 # Memcached PHP lib
 RUN /src/setup-memcached.sh

--- a/install/php-fpm/setup-memcached.sh
+++ b/install/php-fpm/setup-memcached.sh
@@ -52,4 +52,5 @@ docker-php-ext-install \
 		opcache \
 		pgsql \
 		tidy \
-		gd
+		gd \
+		gettext

--- a/install/php-fpm/wikijump.ini
+++ b/install/php-fpm/wikijump.ini
@@ -69,14 +69,14 @@ ssl = false
 ; GlobalProperties Reference: $HTTP_SCHEMA
 ; TODO: have this be determined by the ssl var
 ; default: https
-schema = https
+schema = http
 
 ; [allow_http]
 ; Purpose: Choose whether or not to allow ANY insecure traffic anywhere on your wiki farm. This is only recommended for
 ;   local development where using SSL is tricky. The expectation in production is SSL is enabled everywhere.
 ; GlobalProperties Reference: $ALLOW_ANY_HTTP
 ; Default: false
-allow_http = false
+allow_http = true
 
 ; [upload_separate_domain]
 ; Purpose: Determine whether uploaded files should be served off the same domain as your trusted content. It is STRONGLY

--- a/web/lib/ozoneframework/php/core/functions.php
+++ b/web/lib/ozoneframework/php/core/functions.php
@@ -306,7 +306,7 @@ function setsecurecookie(string $key, $value, int $expires, string $path, string
                 'expires' => $expires,
                 'path' => $path,
                 'domain' => $domain,
-                'samesite' => 'None'
+                'samesite' => 'Lax' // Default behavior for insecure connections, still works in Firefox.
             ]);
             return;
         }


### PR DESCRIPTION
With this PR a `docker-compose build` and `docker-compose up` gives a working stack that can be connected to on www.wikijump.test and allows for login over HTTP in Firefox, Chromium based browsers still won't work. I want to put the logic for whether or not nginx listens on 443 behind some args because the AWS version won't need it, SSL stuff will be handled by the load balancers.