### PR TITLE
[WJ-250] Fix editMode + formatDates

### DIFF
--- a/web/web/files--common/javascript/OZONE/utils.ts
+++ b/web/web/files--common/javascript/OZONE/utils.ts
@@ -228,7 +228,7 @@ export const utils = {
       .replace(/&gt;/g, '>');
   },
 
-  formatDates: function (topElementOrId: string | HTMLElement): void {
+  formatDates: function (topElementOrId?: string | HTMLElement): void {
     /**
      * Within the element of ID topElementId, format all spans with class
      * 'odate' to contain text representing the date.
@@ -241,7 +241,8 @@ export const utils = {
      * would be nice to deprecate that, if possible.
      *
      * @param topElementOrId: The element whose children should be
-     * searched for span.odate, or its ID.
+     * searched for span.odate, or its ID. If not provided, the whole document
+     * is searched.
      */
     const monthNames = [
       'January', 'February', 'March', 'April', 'May', 'June',
@@ -257,20 +258,21 @@ export const utils = {
     ];
     const dayNamesShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-    // Irritatingly, either an ID or an element can be passed to this function
-    let topElement: HTMLElement;
-    if (typeof topElementOrId === 'string') {
-      const el = document.getElementById(topElementOrId);
-      if (el === null) {
-        // XXX Throw error
-        return;
-      }
-      topElement = el;
+    let dateElements: NodeListOf<HTMLSpanElement>;
+    if (topElementOrId === undefined) {
+      dateElements = document.querySelectorAll<HTMLSpanElement>('span.odate');
     } else {
-      topElement = topElementOrId;
+        if (typeof topElementOrId === 'string') {
+          const topElement = document.getElementById(topElementOrId);
+          if (topElement === null) {
+            // TODO Throw error
+            return;
+          }
+          dateElements = topElement.querySelectorAll<HTMLSpanElement>('span.odate');
+        } else {
+          dateElements = topElementOrId.querySelectorAll<HTMLSpanElement>('span.odate');
+        }
     }
-
-    const dateElements = topElement.querySelectorAll('span.odate');
 
     (Array.from(dateElements) as HTMLElement[]).forEach(dateElement => {
       let dateString = "";

--- a/web/web/files--common/javascript/Wikijump/page.ts
+++ b/web/web/files--common/javascript/Wikijump/page.ts
@@ -396,7 +396,8 @@ export const page = {
       }
 
       // init
-      const editMode = response.mode;
+      //@ts-expect-error Shouldn't need to attach to window
+      window.editMode = response.mode;
 
       if (response.locked) {
         // the page has a lock!
@@ -429,7 +430,8 @@ export const page = {
         };
       }
 
-      if (editMode === 'section') {
+      // @ts-expect-error Shouldn't be attached to window
+      if (window.editMode === 'section') {
         if (response.section == null) {
           alert('Section edit error. Section does not exist');
           return;

--- a/web/web/files--common/modules/js/edit/PageEditModule.js
+++ b/web/web/files--common/modules/js/edit/PageEditModule.js
@@ -569,7 +569,7 @@ Wikijump.modules.PageEditModule.utils = {
 
 Wikijump.modules.PageEditModule.init = function(){
 	if(Wikijump.page.vars.locked == true){
-		Wikijump.utils.formatDates();
+		OZONE.utils.formatDates();
 
 	} else {
 

--- a/web/web/files--common/modules/js/files/PageFilesModule.js
+++ b/web/web/files--common/modules/js/files/PageFilesModule.js
@@ -246,4 +246,4 @@ toggleFileOptions = function(fileId){
 }
 
 YAHOO.util.Event.addListener("show-upload-button", "click", Wikijump.modules.PageFilesModule.listeners.showUploadClick);
-Wikijump.utils.formatDates("action-area");
+OZONE.utils.formatDates("action-area");


### PR DESCRIPTION
This PR fixes a couple of bugs introduced in #34.

* `editMode` is now reattached to the `window` object (will be super-fixed in #78) (this specifically was blocking page editing, which I need to test modules)
* Modules that wanted the deprecated `Wikijump.utils.formatDates` have been told to ask for `OZONE.utils.formatDates` instead

This probably works but I'm not going to merge it until I work out how to bind mounts with docker compose.