### PR TITLE
[WJ-252] Create dev docker-compose override

### DIFF
--- a/install/docker-compose.dev.yaml
+++ b/install/docker-compose.dev.yaml
@@ -1,0 +1,15 @@
+services:
+  php-fpm:
+    volumes:
+      - type: bind
+        source: ../web/php
+        target: /var/www/wikijump/web/php
+        read_only: true
+      - type: bind
+        source: ../web/templates
+        target: /var/www/wikijump/web/templates
+        read_only: true
+      - type: bind
+        source: ../web/web
+        target: /var/www/wikijump/web/web
+        read_only: true


### PR DESCRIPTION
This PR adds a docker-compose.dev.yaml that is intended to override the base compose config:

```
docker-compose -p wikijump -f docker-compose.yaml -f docker-compose.dev.yaml up
```

It binds `web/php`, `web/templates` and `web/web` from your machine to the container, meaning that you will be able to see your changes live.

More bindings should be committed to the override as and when they are needed. I chose not to bind the whole `web/` directory because composer complained to me about needing dependencies to install Laravel and that's what Docker is supposed to avoid. (Though please note that, for now, in order for this to work on your local deployment currently, you will need to have compiled the Javascript, because the bind mount will override files in the container with your local files. This could be updated later to only bind `web/web/files--common/dist/bundle.js` or something similar.)