### PR TITLE
[WJ-173] Fix failed include message

### DIFF
--- a/web/lib/text_wiki/Text/Wiki/Parse/Default/Include.php
+++ b/web/lib/text_wiki/Text/Wiki/Parse/Default/Include.php
@@ -93,8 +93,7 @@ class Text_Wiki_Parse_Include extends Text_Wiki_Parse {
 
 			if($page == null){
 				$pageNameHtml = htmlspecialchars($pageName);
-				$message = sprintf(_('Included page "%s" does not exist ([/%s/edit/true create it now])
-'), $pageNameHtml, $pageNameHtml));
+				$message = sprintf(_('Included page "%s" does not exist ([/%s/edit/true create it now])'), $pageNameHtml, $pageNameHtml);
 				$output = "\n\n".'[[div class="error-block"]]'."\n".$message."\n".'[[/div]]'."\n\n";
 
         		$wiki = $this->wiki;


### PR DESCRIPTION
This PR fixes a syntax error introduced in #75, which was preventing page edits from saving.