### PR TITLE
Fix memcache dependencies

### DIFF
--- a/install/php-fpm/setup-memcached.sh
+++ b/install/php-fpm/setup-memcached.sh
@@ -35,7 +35,7 @@ make "-j$cores"
 make install
 
 # Install memcache
-pecl install --nobuild memcache
+pecl install --nobuild memcache-4.0.5.2
 cd "$(pecl config-get temp_dir)/memcache"
 
 phpize


### PR DESCRIPTION
Fixed an error in memcache dependencies due to the release of PHP 8.0 (stated to install memcache 4.0.5.2 instead of the latest version)

If you have plans to update to PHP 8.0, please decline and close this PR.