### PR TITLE
Replace use of unnecessary word as temporary text element

### DIFF
--- a/web/web/files--common/modules/js/forum/ForumViewThreadModule.old.js
+++ b/web/web/files--common/modules/js/forum/ForumViewThreadModule.old.js
@@ -93,7 +93,7 @@ Wikijump.modules.ForumViewThreadModule.listeners = {
 		var formInner = $("new-post-t").innerHTML;
 		formInner = formInner.replace(/id="/g, 'id="p-');
 
-		editNode.innerHTML = "dupa";
+		editNode.innerHTML = "";
 		OZONE.dom.insertAfter(postContainer,editNode,post);
 
 		OZONE.visuals.scrollTo(editNode);


### PR DESCRIPTION


![shows "dupa" translated as "ass" from polish](https://user-images.githubusercontent.com/8848022/102678865-2b67c000-4179-11eb-9de5-238824220850.png)
