### PR TITLE
CI/CD for changes to web in develop

### DIFF
--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'web/**'
       - 'install/php-fpm/**'
+      - '.github/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - develop
-      - ghactions-build-php
     paths:
       - 'web/**'
       - 'install/php-fpm/**'
-      - '.github/**'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -52,4 +50,4 @@ jobs:
             task-definition: ${{ steps.task-def.outputs.task-definition }}
             service: wikijump-dev-svc
             cluster: wikijump-dev
-            wait-for-service-stability: false
+            wait-for-service-stability: true

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -52,4 +52,4 @@ jobs:
             task-definition: ${{ steps.task-def.outputs.task-definition }}
             service: wikijump-dev-svc
             cluster: wikijump-dev
-            wait-for-service-stability: true
+            wait-for-service-stability: false

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -30,6 +30,7 @@ jobs:
             ECR_REPOSITORY: wikijump-dev/php-fpm
             IMAGE_TAG: ${{ github.sha }}
           run: |
+            set -ex
             docker build --build-arg MAIN_DOMAIN=wikijump.dev --build-arg FILES_DOMAIN=wjfiles.dev -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
             docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
             echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+        - name: Checkout
+          uses: actions/checkout@v2
         - name: Configure AWS credentials
           uses: aws-actions/configure-aws-credentials@v1
           with:

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -24,7 +24,7 @@ jobs:
           uses: aws-actions/amazon-ecr-login@v1
         - name: Build, tag, and push image to Amazon ECR
           id: build-image
-          working-directory: install/php-fpm
+          working-directory: ./install/php-fpm
           env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
             ECR_REPOSITORY: wikijump-dev/php-fpm

--- a/.github/workflows/docker-build-push.dev.yml
+++ b/.github/workflows/docker-build-push.dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - ghactions-build-php
     paths:
       - 'web/**'
       - 'install/php-fpm/**'
@@ -22,12 +23,13 @@ jobs:
           uses: aws-actions/amazon-ecr-login@v1
         - name: Build, tag, and push image to Amazon ECR
           id: build-image
+          working-directory: install/php-fpm
           env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
             ECR_REPOSITORY: wikijump-dev/php-fpm
             IMAGE_TAG: ${{ github.sha }}
           run: |
-            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+            docker build --build-arg MAIN_DOMAIN=wikijump.dev --build-arg FILES_DOMAIN=wjfiles.dev -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
             docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
             echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         - name: Download task definition

--- a/infra/terraform/dev/deploy/cloudfront.tf
+++ b/infra/terraform/dev/deploy/cloudfront.tf
@@ -28,7 +28,7 @@ resource "aws_cloudfront_distribution" "wikijump_cf_distro" {
     }
   }
 
-    origin {
+  origin {
     domain_name = aws_lb.wikijump_elb.dns_name
     origin_id   = "wikijump-acme-${var.environment}"
 

--- a/infra/terraform/dev/deploy/cloudfront.tf
+++ b/infra/terraform/dev/deploy/cloudfront.tf
@@ -29,20 +29,6 @@ resource "aws_cloudfront_distribution" "wikijump_cf_distro" {
   }
 
   origin {
-    domain_name = aws_lb.wikijump_elb.dns_name
-    origin_id   = "wikijump-acme-${var.environment}"
-
-    custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_protocol_policy   = "http-only"
-      origin_ssl_protocols     = ["TLSv1.2"]
-      origin_keepalive_timeout = 15
-      origin_read_timeout      = 30
-    }
-  }
-
-  origin {
     domain_name = aws_s3_bucket.wikijump_assets.bucket_domain_name
     origin_id   = aws_s3_bucket.wikijump_assets.bucket_domain_name
     s3_origin_config {
@@ -54,27 +40,6 @@ resource "aws_cloudfront_distribution" "wikijump_cf_distro" {
     geo_restriction {
       restriction_type = "none"
     }
-  }
-
-  ordered_cache_behavior {
-    path_pattern     = ".well-known/acme-challenge"
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "wikijump-acme-${var.environment}"
-
-    forwarded_values {
-      query_string = true
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl                = 0
-    default_ttl            = 86400
-    max_ttl                = 31536000
-    compress               = true
-    viewer_protocol_policy = "allow-all"
   }
 
   ordered_cache_behavior {
@@ -128,6 +93,7 @@ resource "aws_cloudfront_distribution" "wikijump_cf_distro" {
 
     forwarded_values {
       query_string = true
+      headers = ["Host"]
 
       cookies {
         forward = "all"

--- a/infra/terraform/dev/deploy/ecs.tf
+++ b/infra/terraform/dev/deploy/ecs.tf
@@ -57,7 +57,7 @@ resource "aws_ecs_capacity_provider" "asg" {
 }
 
 resource "aws_ecs_task_definition" "wikijump_task" {
-  family = "wikijump-${var.environment}-ec2"
+  family                   = "wikijump-${var.environment}-ec2"
   container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"

--- a/infra/terraform/dev/deploy/ecs.tf
+++ b/infra/terraform/dev/deploy/ecs.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_capacity_provider" "asg" {
     managed_scaling {
       maximum_scaling_step_size = 1
       minimum_scaling_step_size = 1
-      status                    = "DISABLED"
+      status                    = "ENABLED"
       target_capacity           = 1
     }
   }

--- a/infra/terraform/dev/deploy/ecs.tf
+++ b/infra/terraform/dev/deploy/ecs.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_task_definition" "wikijump_task" {
     name = "letsencrypt"
 
     efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.traefik_efs.id
+      file_system_id     = data.aws_ssm_parameter.TRAEFIK_EFS_ID.value
       transit_encryption = "ENABLED"
       root_directory     = "/letsencrypt"
       authorization_config {
@@ -86,7 +86,7 @@ resource "aws_ecs_service" "wikijump" {
   cluster                            = aws_ecs_cluster.wikijump-ecs.id
   task_definition                    = aws_ecs_task_definition.wikijump_task.arn
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent         = 100
+  deployment_maximum_percent         = 200
   desired_count                      = 1 # This will be a var as we grow
   force_new_deployment               = var.redeploy_ecs_on_tf_apply
   load_balancer {

--- a/infra/terraform/dev/deploy/ecs.tf
+++ b/infra/terraform/dev/deploy/ecs.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_capacity_provider" "asg" {
     managed_scaling {
       maximum_scaling_step_size = 1
       minimum_scaling_step_size = 1
-      status                    = "ENABLED"
+      status                    = "DISABLED"
       target_capacity           = 1
     }
   }
@@ -85,7 +85,7 @@ resource "aws_ecs_service" "wikijump" {
   name                               = "wikijump-${var.environment}-svc"
   cluster                            = aws_ecs_cluster.wikijump-ecs.id
   task_definition                    = aws_ecs_task_definition.wikijump_task.arn
-  deployment_minimum_healthy_percent = 50
+  deployment_minimum_healthy_percent = 0
   deployment_maximum_percent         = 200
   desired_count                      = 1 # This will be a var as we grow
   force_new_deployment               = var.redeploy_ecs_on_tf_apply

--- a/infra/terraform/dev/deploy/efs.tf
+++ b/infra/terraform/dev/deploy/efs.tf
@@ -1,14 +1,9 @@
-resource "aws_efs_file_system" "traefik_efs" {
-  creation_token = "traefik-certstore-${var.environment}"
-  encrypted      = true
-}
-
 resource "aws_efs_access_point" "access" {
-  file_system_id = aws_efs_file_system.traefik_efs.id
+  file_system_id = data.aws_ssm_parameter.TRAEFIK_EFS_ID.value
 }
 
 resource "aws_efs_mount_target" "traefik_mount" {
-  file_system_id  = aws_efs_file_system.traefik_efs.id
+  file_system_id  = data.aws_ssm_parameter.TRAEFIK_EFS_ID.value
   subnet_id       = aws_subnet.container_subnet.id
   security_groups = [aws_security_group.ecs_nodes.id]
 }

--- a/infra/terraform/dev/deploy/elb.tf
+++ b/infra/terraform/dev/deploy/elb.tf
@@ -13,8 +13,8 @@ resource "aws_lb" "wikijump_elb" {
   enable_deletion_protection = true
 
   access_logs {
-    bucket = aws_s3_bucket.elb_logs.bucket
-    prefix = var.environment
+    bucket  = aws_s3_bucket.elb_logs.bucket
+    prefix  = var.environment
     enabled = false
   }
 }

--- a/infra/terraform/dev/deploy/elb.tf
+++ b/infra/terraform/dev/deploy/elb.tf
@@ -25,6 +25,7 @@ resource "aws_lb_target_group" "elb_target_group_80" {
   protocol    = "TCP"
   vpc_id      = aws_vpc.wikijump_vpc.id
   target_type = "instance"
+  deregistration_delay = 3
   health_check {
     enabled = true
     port    = 8081
@@ -38,6 +39,7 @@ resource "aws_lb_target_group" "elb_target_group_443" {
   protocol    = "TCP"
   vpc_id      = aws_vpc.wikijump_vpc.id
   target_type = "instance"
+  deregistration_delay = 3
   health_check {
     enabled = true
     port    = 8081

--- a/infra/terraform/dev/deploy/launch.tf
+++ b/infra/terraform/dev/deploy/launch.tf
@@ -10,6 +10,7 @@ set -eu
 echo ECS_CLUSTER=wikijump-${var.environment} >> /etc/ecs/ecs.config
 echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
 echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config
+echo ECS_CONTAINER_STOP_TIMEOUT=3s >> /etc/etc/ecs.config
 EOT
   }
 

--- a/infra/terraform/dev/deploy/ssm.tf
+++ b/infra/terraform/dev/deploy/ssm.tf
@@ -17,11 +17,11 @@ resource "aws_ssm_parameter" "URL_UPLOAD_DOMAIN" {
 }
 
 data "aws_ssm_parameter" "WEB_ECR_URL" {
-  name  = "wikijump-${var.environment}-WEB_ECR_URL"
+  name = "wikijump-${var.environment}-WEB_ECR_URL"
 }
 
 data "aws_ssm_parameter" "DB_ECR_URL" {
-  name  = "wikijump-${var.environment}-DB_ECR_URL"
+  name = "wikijump-${var.environment}-DB_ECR_URL"
 }
 
 data "aws_ssm_parameter" "ecs_ami" {

--- a/infra/terraform/dev/deploy/ssm.tf
+++ b/infra/terraform/dev/deploy/ssm.tf
@@ -27,3 +27,7 @@ data "aws_ssm_parameter" "DB_ECR_URL" {
 data "aws_ssm_parameter" "ecs_ami" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
 }
+
+data "aws_ssm_parameter" "TRAEFIK_EFS_ID" {
+  name = "wikijump-${var.environment}-TRAEFIK_EFS_ID"
+}

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -3,8 +3,8 @@ module "cache" {
 
   container_name   = "cache"
   container_image  = var.ecs_cache_image
-  container_memory = var.ecs_cache_memory
-  container_cpu    = var.ecs_cache_cpu
+  # container_memory = var.ecs_cache_memory
+  # container_cpu    = var.ecs_cache_cpu
   essential        = true
 
   log_configuration = {
@@ -22,8 +22,8 @@ module "database" {
 
   container_name   = "database"
   container_image  = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
-  container_memory = var.ecs_db_memory
-  container_cpu    = var.ecs_db_cpu
+  # container_memory = var.ecs_db_memory
+  # container_cpu    = var.ecs_db_cpu
   essential        = true
 
   log_configuration = {
@@ -41,8 +41,8 @@ module "php-fpm" {
 
   container_name   = "php-fpm"
   container_image  = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
-  container_memory = var.ecs_php_memory
-  container_cpu    = var.ecs_php_cpu
+  # container_memory = var.ecs_php_memory
+  # container_cpu    = var.ecs_php_cpu
   essential        = true
 
   log_configuration = {
@@ -92,8 +92,8 @@ module "reverse-proxy" {
 
   container_name   = "reverse-proxy"
   container_image  = var.ecs_traefik_image
-  container_memory = var.ecs_traefik_memory
-  container_cpu    = var.ecs_traefik_cpu
+  # container_memory = var.ecs_traefik_memory
+  # container_cpu    = var.ecs_traefik_cpu
   essential        = true
 
   log_configuration = {

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -70,7 +70,7 @@ module "php-fpm" {
 
   docker_labels = {
     "traefik.enable"                                = "true"
-    "traefik.http.routers.php-fpm.rule"             = "Host(`${var.web_domain}`,`www.${var.web_domain}`)"
+    "traefik.http.routers.php-fpm.rule"             = "Host(`${var.web_domain}`,`www.${var.web_domain}`,`${var.files_domain}`,`www.${var.files_domain}`)"
     "traefik.http.routers.php-fpm.tls"              = "true"
     "traefik.http.routers.php-fpm.tls.certresolver" = "mytlschallenge"
   }

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -128,7 +128,7 @@ module "reverse-proxy" {
     "--entrypoints.web.http.redirections.entryPoint.scheme=https",
     "--entrypoints.web.http.redirections.entrypoint.permanent=true",
     "--entrypoints.web-secure.address=:443",
-    "--certificatesresolvers.mytlschallenge.acme.tlschallenge=true",
+    "--certificatesresolvers.mytlschallenge.acme.httpchallenge.entrypoint=web",
     "--certificatesresolvers.mytlschallenge.acme.email=${var.letsencrypt_email}",
     "--certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json",
     "--ping.entrypoint=ping",

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -128,8 +128,11 @@ module "reverse-proxy" {
     "--entrypoints.web.http.redirections.entryPoint.scheme=https",
     "--entrypoints.web.http.redirections.entrypoint.permanent=true",
     "--entrypoints.web-secure.address=:443",
-    "--certificatesresolvers.mytlschallenge.acme.httpchallenge.entrypoint=web",
-    "--certificatesresolvers.mytlschallenge.acme.email=${var.letsencrypt_email}",
+    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.provider=route53",
+    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.delaybeforecheck=30",
+    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_ACCESS_KEY_ID=${var.route53_access_key}",
+    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_SECRET_ACCESS_KEY=${var.route53_secret_key}",
+    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_REGION=${var.region}",
     "--certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json",
     "--ping.entrypoint=ping",
     "--entrypoints.ping.address=:8081"

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -3,7 +3,7 @@ module "cache" {
 
   container_name   = "cache"
   container_image  = var.ecs_cache_image
-  # container_memory = var.ecs_cache_memory
+  container_memory = var.ecs_cache_memory
   # container_cpu    = var.ecs_cache_cpu
   essential        = true
 
@@ -22,7 +22,7 @@ module "database" {
 
   container_name   = "database"
   container_image  = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
-  # container_memory = var.ecs_db_memory
+  container_memory = var.ecs_db_memory
   # container_cpu    = var.ecs_db_cpu
   essential        = true
 
@@ -41,7 +41,7 @@ module "php-fpm" {
 
   container_name   = "php-fpm"
   container_image  = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
-  # container_memory = var.ecs_php_memory
+  container_memory = var.ecs_php_memory
   # container_cpu    = var.ecs_php_cpu
   essential        = true
 
@@ -92,7 +92,7 @@ module "reverse-proxy" {
 
   container_name   = "reverse-proxy"
   container_image  = var.ecs_traefik_image
-  # container_memory = var.ecs_traefik_memory
+  container_memory = var.ecs_traefik_memory
   # container_cpu    = var.ecs_traefik_cpu
   essential        = true
 

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -70,7 +70,7 @@ module "php-fpm" {
 
   docker_labels = {
     "traefik.enable"                                = "true"
-    "traefik.http.routers.php-fpm.rule"             = "Host(`${var.web_domain}`,`www.${var.web_domain}`,`${var.files_domain}`,`www.${var.files_domain}`)"
+    "traefik.http.routers.php-fpm.rule"             = "Host(`${var.web_domain}`,`www.${var.web_domain}`)"
     "traefik.http.routers.php-fpm.tls"              = "true"
     "traefik.http.routers.php-fpm.tls.certresolver" = "mytlschallenge"
   }

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -1,11 +1,10 @@
 module "cache" {
   source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
 
-  container_name   = "cache"
-  container_image  = var.ecs_cache_image
-  container_memory = var.ecs_cache_memory
-  # container_cpu    = var.ecs_cache_cpu
-  essential        = true
+  container_name               = "cache"
+  container_image              = var.ecs_cache_image
+  container_memory_reservation = var.ecs_cache_memory / 4
+  essential                    = true
 
   log_configuration = {
     logDriver = "awslogs"
@@ -20,11 +19,10 @@ module "cache" {
 module "database" {
   source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
 
-  container_name   = "database"
-  container_image  = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
-  container_memory = var.ecs_db_memory
-  # container_cpu    = var.ecs_db_cpu
-  essential        = true
+  container_name               = "database"
+  container_image              = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
+  container_memory_reservation = var.ecs_db_memory / 4
+  essential                    = true
 
   log_configuration = {
     logDriver = "awslogs"
@@ -39,11 +37,10 @@ module "database" {
 module "php-fpm" {
   source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
 
-  container_name   = "php-fpm"
-  container_image  = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
-  container_memory = var.ecs_php_memory
-  # container_cpu    = var.ecs_php_cpu
-  essential        = true
+  container_name               = "php-fpm"
+  container_image              = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
+  container_memory_reservation = var.ecs_php_memory / 4
+  essential                    = true
 
   log_configuration = {
     logDriver = "awslogs"
@@ -90,11 +87,10 @@ module "php-fpm" {
 module "reverse-proxy" {
   source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
 
-  container_name   = "reverse-proxy"
-  container_image  = var.ecs_traefik_image
-  container_memory = var.ecs_traefik_memory
-  # container_cpu    = var.ecs_traefik_cpu
-  essential        = true
+  container_name               = "reverse-proxy"
+  container_image              = var.ecs_traefik_image
+  container_memory_reservation = var.ecs_traefik_memory / 4
+  essential                    = true
 
   log_configuration = {
     logDriver = "awslogs"

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -5,6 +5,7 @@ module "cache" {
   container_image              = var.ecs_cache_image
   container_memory_reservation = var.ecs_cache_memory / 4
   essential                    = true
+  environment = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -23,6 +24,7 @@ module "database" {
   container_image              = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
   container_memory_reservation = var.ecs_db_memory / 4
   essential                    = true
+  environment = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -41,6 +43,7 @@ module "php-fpm" {
   container_image              = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
   container_memory_reservation = var.ecs_php_memory / 4
   essential                    = true
+  environment = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -91,6 +94,20 @@ module "reverse-proxy" {
   container_image              = var.ecs_traefik_image
   container_memory_reservation = var.ecs_traefik_memory / 4
   essential                    = true
+  environment = [
+    {
+      name = AWS_ACCESS_KEY_ID
+      value = var.route53_access_key
+    },
+    {
+      name = AWS_SECRET_ACCESS_KEY
+      value = var.route53_secret_key
+    },
+    {
+      name = AWS_REGION
+      value = var.region
+    }
+  ]
 
   log_configuration = {
     logDriver = "awslogs"
@@ -130,9 +147,6 @@ module "reverse-proxy" {
     "--entrypoints.web-secure.address=:443",
     "--certificatesresolvers.mytlschallenge.acme.dnschallenge.provider=route53",
     "--certificatesresolvers.mytlschallenge.acme.dnschallenge.delaybeforecheck=30",
-    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_ACCESS_KEY_ID=${var.route53_access_key}",
-    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_SECRET_ACCESS_KEY=${var.route53_secret_key}",
-    "--certificatesresolvers.mytlschallenge.acme.dnschallenge.AWS_REGION=${var.region}",
     "--certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json",
     "--ping.entrypoint=ping",
     "--entrypoints.ping.address=:8081"

--- a/infra/terraform/dev/deploy/task-definitions.tf
+++ b/infra/terraform/dev/deploy/task-definitions.tf
@@ -5,7 +5,7 @@ module "cache" {
   container_image              = var.ecs_cache_image
   container_memory_reservation = var.ecs_cache_memory / 4
   essential                    = true
-  environment = []
+  environment                  = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -24,7 +24,7 @@ module "database" {
   container_image              = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
   container_memory_reservation = var.ecs_db_memory / 4
   essential                    = true
-  environment = []
+  environment                  = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -43,7 +43,7 @@ module "php-fpm" {
   container_image              = "${data.aws_ssm_parameter.WEB_ECR_URL.value}:develop"
   container_memory_reservation = var.ecs_php_memory / 4
   essential                    = true
-  environment = []
+  environment                  = []
 
   log_configuration = {
     logDriver = "awslogs"
@@ -96,15 +96,15 @@ module "reverse-proxy" {
   essential                    = true
   environment = [
     {
-      name = AWS_ACCESS_KEY_ID
+      name  = "AWS_ACCESS_KEY_ID"
       value = var.route53_access_key
     },
     {
-      name = AWS_SECRET_ACCESS_KEY
+      name  = "AWS_SECRET_ACCESS_KEY"
       value = var.route53_secret_key
     },
     {
-      name = AWS_REGION
+      name  = "AWS_REGION"
       value = var.region
     }
   ]

--- a/infra/terraform/dev/deploy/variables.tf
+++ b/infra/terraform/dev/deploy/variables.tf
@@ -100,3 +100,11 @@ variable "letsencrypt_email" {
 variable "redeploy_ecs_on_tf_apply" {
   type = bool
 }
+
+variable "route53_access_key" {
+  type = string
+}
+
+variable "route53_secret_key" {
+  type = string
+}

--- a/infra/terraform/dev/deploy/wikijump.auto.tfvars
+++ b/infra/terraform/dev/deploy/wikijump.auto.tfvars
@@ -36,4 +36,4 @@ ecs_traefik_image  = "traefik:v2.3"
 letsencrypt_email = "info@wikijump.com"
 # If true, ECS will generate a new service with every tf apply, allowing it to perhaps pull in a new version of an image.
 # Otherwise, will only generate a new service when the service or a related piece is modified.
-redeploy_ecs_on_tf_apply = false
+redeploy_ecs_on_tf_apply = true

--- a/infra/terraform/dev/init/init.tf
+++ b/infra/terraform/dev/init/init.tf
@@ -47,3 +47,14 @@ resource "aws_ecr_repository" "db_ecr" {
     scan_on_push = true
   }
 }
+
+resource "aws_efs_file_system" "traefik_efs" {
+  creation_token = "traefik-certstore-${var.environment}"
+  encrypted      = true
+}
+
+resource "aws_ssm_parameter" "TRAEFIK_EFS_ID" {
+  name  = "wikijump-${local.environment}-TRAEFIK_EFS_ID"
+  type  = "String"
+  value = aws_efs_file_system.traefik_efs.id
+}

--- a/infra/terraform/dev/init/init.tf
+++ b/infra/terraform/dev/init/init.tf
@@ -49,7 +49,7 @@ resource "aws_ecr_repository" "db_ecr" {
 }
 
 resource "aws_efs_file_system" "traefik_efs" {
-  creation_token = "traefik-certstore-${var.environment}"
+  creation_token = "traefik-certstore-${local.environment}"
   encrypted      = true
 }
 

--- a/web/web/heartbeat.php
+++ b/web/web/heartbeat.php
@@ -1,1 +1,1 @@
-<?php echo("ok")
+<?php echo("ok");


### PR DESCRIPTION
This is a working config for GitHub Actions and ECS so when changes to web files are pushed to `develop`, GitHub Actions will build new docker images, push them to ECR, and instruct the ECS cluster to use the new images, forcing a new deployment of the cluster. Running time end-to-end is 8-9 minutes.