### PR TITLE
[WJ-335] Include elements in formToArray regardless of depth

### DIFF
--- a/web/web/files--common/javascript/OZONE/utils.ts
+++ b/web/web/files--common/javascript/OZONE/utils.ts
@@ -34,7 +34,7 @@ export const utils = {
 
     // process different form elements (traverse)
     const values: { [name: string]: string } = {};
-    Array.from(form.children).forEach(element => {
+    form.querySelectorAll("textarea, input").forEach(element => {
       if (isTextarea(element)) {
         values[element.name] = element.value;
       }


### PR DESCRIPTION
`OZONE.utils.formToArray` previously iterated through `form` using a nonstandard simple index iteration syntax:

https://github.com/scpwiki/wikijump/blob/321c65aea156163d01ff9b383d49f77a56f8310c/web/files--common/javascript/OZONE.js#L178

When updating this to TypeScript, I replaced this with much more standardised iteration through `form.children`:

https://github.com/scpwiki/wikijump/blob/9500570d16e51372edf94b9be4db9a9a02bbc770/web/web/files--common/javascript/OZONE/utils.ts#L37

This was not correct. `form.children` only included direct children of the form in question, whereas the previous syntax implicitly iterates through all descendant elements.

This PR replaces `form.children` with a `querySelectorAll` that traverses all nested `input` and `textarea` elements:

https://github.com/scpwiki/wikijump/blob/c3d20d475ee2fd552f109b0e86cd9ee3d06a495d/web/web/files--common/javascript/OZONE/utils.ts#L37

This fixes [WJ-335](https://scuttle.atlassian.net/browse/WJ-335) by ensuring that the nested fields in the page edit form are not ignored.
