### PR TITLE
[WJ-153] Allow inline use of newline blocks

### DIFF
--- a/ftml/src/parsing/exception.rs
+++ b/ftml/src/parsing/exception.rs
@@ -130,6 +130,9 @@ pub enum ParseWarningKind {
     /// Some required arguments where missing when parsing the block.
     BlockMissingArguments,
 
+    /// This block expects a line break here.
+    BlockExpectedLineBreak,
+
     /// This block expected to end its body here.
     BlockExpectedEnd,
 

--- a/ftml/src/parsing/exception.rs
+++ b/ftml/src/parsing/exception.rs
@@ -130,9 +130,6 @@ pub enum ParseWarningKind {
     /// Some required arguments where missing when parsing the block.
     BlockMissingArguments,
 
-    /// This block expects a line break here.
-    BlockExpectedLineBreak,
-
     /// This block expected to end its body here.
     BlockExpectedEnd,
 

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_CODE, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
     let language = arguments.get("type");
 
     let code = parser.get_body_text(&BLOCK_CODE)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -24,7 +24,6 @@ pub const BLOCK_CODE: BlockRule = BlockRule {
     name: "block-code",
     accepts_names: &["code"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -24,6 +24,7 @@ pub const BLOCK_CODE: BlockRule = BlockRule {
     name: "block-code",
     accepts_names: &["code"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -39,7 +40,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_CODE, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;
     let language = arguments.get("type");
 
     let code = parser.get_body_text(&BLOCK_CODE)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -24,7 +24,7 @@ pub const BLOCK_CODE: BlockRule = BlockRule {
     name: "block-code",
     accepts_names: &["code"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -25,7 +25,6 @@ pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
     accepts_names: &["collapsible"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -25,6 +25,7 @@ pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
     accepts_names: &["collapsible"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
     assert_block_name(&BLOCK_COLLAPSIBLE, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -25,7 +25,7 @@ pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
     accepts_names: &["collapsible"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
     assert_block_name(&BLOCK_COLLAPSIBLE, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -24,6 +24,7 @@ pub const BLOCK_CSS: BlockRule = BlockRule {
     name: "block-css",
     accepts_names: &["css"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -39,7 +40,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_CSS, name);
 
-    parser.get_head_none(in_head)?;
+    parser.get_head_none(&BLOCK_CSS, in_head)?;
 
     let css = parser.get_body_text(&BLOCK_CSS)?;
     let exceptions = vec![ParseException::Style(cow!(css))];

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -24,7 +24,7 @@ pub const BLOCK_CSS: BlockRule = BlockRule {
     name: "block-css",
     accepts_names: &["css"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_CSS, name);
 
-    parser.get_head_none(&BLOCK_CSS, in_head)?;
+    parser.get_head_none(in_head)?;
 
     let css = parser.get_body_text(&BLOCK_CSS)?;
     let exceptions = vec![ParseException::Style(cow!(css))];

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -24,7 +24,6 @@ pub const BLOCK_CSS: BlockRule = BlockRule {
     name: "block-css",
     accepts_names: &["css"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -24,7 +24,6 @@ pub const BLOCK_DEL: BlockRule = BlockRule {
     name: "block-del",
     accepts_names: &["del", "deletion"],
     accepts_special: false,
-    newline_separator: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Deletion doesn't allow special variant");
     assert_block_name(&BLOCK_DEL, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -24,7 +24,7 @@ pub const BLOCK_DEL: BlockRule = BlockRule {
     name: "block-del",
     accepts_names: &["del", "deletion"],
     accepts_special: false,
-    newline_separator: false,
+    accepts_newlines: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -24,6 +24,7 @@ pub const BLOCK_DEL: BlockRule = BlockRule {
     name: "block-del",
     accepts_names: &["del", "deletion"],
     accepts_special: false,
+    newline_separator: false,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Deletion doesn't allow special variant");
     assert_block_name(&BLOCK_DEL, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -24,7 +24,7 @@ pub const BLOCK_DIV: BlockRule = BlockRule {
     name: "block-div",
     accepts_names: &["div", "div_"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -24,7 +24,6 @@ pub const BLOCK_DIV: BlockRule = BlockRule {
     name: "block-div",
     accepts_names: &["div", "div_"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Div doesn't allow special variant");
     assert_block_name(&BLOCK_DIV, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -24,6 +24,7 @@ pub const BLOCK_DIV: BlockRule = BlockRule {
     name: "block-div",
     accepts_names: &["div", "div_"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Div doesn't allow special variant");
     assert_block_name(&BLOCK_DIV, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -33,6 +33,7 @@ pub const BLOCK_INCLUDE: BlockRule = BlockRule {
     name: "block-include",
     accepts_names: &["include"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -33,7 +33,7 @@ pub const BLOCK_INCLUDE: BlockRule = BlockRule {
     name: "block-include",
     accepts_names: &["include"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -33,7 +33,6 @@ pub const BLOCK_INCLUDE: BlockRule = BlockRule {
     name: "block-include",
     accepts_names: &["include"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Ins doesn't allow special variant");
     assert_block_name(&BLOCK_INS, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_INS, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -24,7 +24,6 @@ pub const BLOCK_INS: BlockRule = BlockRule {
     name: "block-ins",
     accepts_names: &["ins", "insertion"],
     accepts_special: false,
-    newline_separator: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -24,6 +24,7 @@ pub const BLOCK_INS: BlockRule = BlockRule {
     name: "block-ins",
     accepts_names: &["ins", "insertion"],
     accepts_special: false,
+    newline_separator: false,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Ins doesn't allow special variant");
     assert_block_name(&BLOCK_INS, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_INS, in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -24,7 +24,7 @@ pub const BLOCK_INS: BlockRule = BlockRule {
     name: "block-ins",
     accepts_names: &["ins", "insertion"],
     accepts_special: false,
-    newline_separator: false,
+    accepts_newlines: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -25,6 +25,7 @@ pub const BLOCK_LINES: BlockRule = BlockRule {
     name: "block-lines",
     accepts_names: &["lines", "newlines"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -40,7 +41,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_LINES, name);
 
-    let count = parser.get_head_value(in_head, parse_count)?;
+    let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;
 
     ok!(Element::LineBreaks(count))
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -25,7 +25,6 @@ pub const BLOCK_LINES: BlockRule = BlockRule {
     name: "block-lines",
     accepts_names: &["lines", "newlines"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -40,7 +40,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Code doesn't allow special variant");
     assert_block_name(&BLOCK_LINES, name);
 
-    let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;
+    let count = parser.get_head_value(in_head, parse_count)?;
 
     ok!(Element::LineBreaks(count))
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -25,7 +25,7 @@ pub const BLOCK_LINES: BlockRule = BlockRule {
     name: "block-lines",
     accepts_names: &["lines", "newlines"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -24,6 +24,7 @@ pub const BLOCK_MARK: BlockRule = BlockRule {
     name: "block-mark",
     accepts_names: &["mark", "highlight"],
     accepts_special: false,
+    newline_separator: false,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Mark doesn't allow special variant");
     assert_block_name(&BLOCK_MARK, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -24,7 +24,6 @@ pub const BLOCK_MARK: BlockRule = BlockRule {
     name: "block-mark",
     accepts_names: &["mark", "highlight"],
     accepts_special: false,
-    newline_separator: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Mark doesn't allow special variant");
     assert_block_name(&BLOCK_MARK, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // Get styling arguments
     let id = arguments.get("id");

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -24,7 +24,7 @@ pub const BLOCK_MARK: BlockRule = BlockRule {
     name: "block-mark",
     accepts_names: &["mark", "highlight"],
     accepts_special: false,
-    newline_separator: false,
+    accepts_newlines: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -26,6 +26,7 @@ pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
     accepts_names: &["module", "module654"],
     accepts_special: false,
+    newline_separator: true,
     parse_fn,
 };
 
@@ -42,7 +43,7 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_MODULE, name);
 
     // Get module name and arguments
-    let (subname, arguments) = parser.get_head_name_map(in_head)?;
+    let (subname, arguments) = parser.get_head_name_map(&BLOCK_MODULE, in_head)?;
 
     // Get the module rule for this name
     let module_rule = match get_module_rule_with_name(subname) {

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -26,7 +26,6 @@ pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
     accepts_names: &["module", "module654"],
     accepts_special: false,
-    newline_separator: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -42,7 +42,7 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_MODULE, name);
 
     // Get module name and arguments
-    let (subname, arguments) = parser.get_head_name_map(&BLOCK_MODULE, in_head)?;
+    let (subname, arguments) = parser.get_head_name_map(in_head)?;
 
     // Get the module rule for this name
     let module_rule = match get_module_rule_with_name(subname) {

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -26,7 +26,7 @@ pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
     accepts_names: &["module", "module654"],
     accepts_special: false,
-    newline_separator: true,
+    accepts_newlines: true,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Span doesn't allow special variant");
     assert_block_name(&BLOCK_SPAN, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;
+    let mut arguments = parser.get_head_map(in_head)?;
 
     // "span" means we wrap interpret as-is
     // "span_" means we strip out any newlines or paragraph breaks

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -24,7 +24,7 @@ pub const BLOCK_SPAN: BlockRule = BlockRule {
     name: "block-span",
     accepts_names: &["span", "span_"],
     accepts_special: false,
-    newline_separator: false,
+    accepts_newlines: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -24,6 +24,7 @@ pub const BLOCK_SPAN: BlockRule = BlockRule {
     name: "block-span",
     accepts_names: &["span", "span_"],
     accepts_special: false,
+    newline_separator: false,
     parse_fn,
 };
 
@@ -44,7 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Span doesn't allow special variant");
     assert_block_name(&BLOCK_SPAN, name);
 
-    let mut arguments = parser.get_head_map(in_head)?;
+    let mut arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;
 
     // "span" means we wrap interpret as-is
     // "span_" means we strip out any newlines or paragraph breaks

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -24,7 +24,6 @@ pub const BLOCK_SPAN: BlockRule = BlockRule {
     name: "block-span",
     accepts_names: &["span", "span_"],
     accepts_special: false,
-    newline_separator: false,
     parse_fn,
 };
 

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -61,8 +61,9 @@ pub struct BlockRule {
     /// `[[user aismallard]]` and `[[*user aismallard]]`.
     accepts_special: bool,
 
-    /// Whether this block wants its head and tail to be separated by newlines.
-    newline_separator: bool,
+    /// Whether this block allows its head and tail to be separated by newlines.
+    /// These newlines will be consumed and not be interpreted as line breaks.
+    accepts_newlines: bool,
 
     /// Function which implements the processing for this rule.
     parse_fn: BlockParseFn,
@@ -95,7 +96,7 @@ impl Debug for BlockRule {
             .field("name", &self.name)
             .field("accepts_names", &self.accepts_names)
             .field("accepts_special", &self.accepts_special)
-            .field("newline_separator", &self.newline_separator)
+            .field("accepts_newlines", &self.accepts_newlines)
             .field("parse_fn", &(self.parse_fn as *const ()))
             .finish()
     }

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -61,8 +61,21 @@ pub struct BlockRule {
     /// `[[user aismallard]]` and `[[*user aismallard]]`.
     accepts_special: bool,
 
-    /// Whether this block allows its head and tail to be separated by newlines.
+    /// Whether this block optionally allows its head and tail to be separated by newlines.
     /// These newlines will be consumed and not be interpreted as line breaks.
+    ///
+    /// For instance, `[[div]]`, which can be declared on separate lines, or inline, without
+    /// those newlines becoming part of the resultant element:
+    ///
+    /// ```text
+    /// [[div]]
+    /// My fancy div!
+    /// [[/div]]
+    /// ```
+    ///
+    /// ```text
+    /// [[div]]My fancy inline div![[/div]]
+    /// ```
     accepts_newlines: bool,
 
     /// Function which implements the processing for this rule.

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -61,9 +61,6 @@ pub struct BlockRule {
     /// `[[user aismallard]]` and `[[*user aismallard]]`.
     accepts_special: bool,
 
-    /// Whether this block wants its head and tail to be separated by newlines.
-    newline_separator: bool,
-
     /// Function which implements the processing for this rule.
     parse_fn: BlockParseFn,
 }
@@ -95,7 +92,6 @@ impl Debug for BlockRule {
             .field("name", &self.name)
             .field("accepts_names", &self.accepts_names)
             .field("accepts_special", &self.accepts_special)
-            .field("newline_separator", &self.newline_separator)
             .field("parse_fn", &(self.parse_fn as *const ()))
             .finish()
     }

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -61,6 +61,9 @@ pub struct BlockRule {
     /// `[[user aismallard]]` and `[[*user aismallard]]`.
     accepts_special: bool,
 
+    /// Whether this block wants its head and tail to be separated by newlines.
+    newline_separator: bool,
+
     /// Function which implements the processing for this rule.
     parse_fn: BlockParseFn,
 }
@@ -92,6 +95,7 @@ impl Debug for BlockRule {
             .field("name", &self.name)
             .field("accepts_names", &self.accepts_names)
             .field("accepts_special", &self.accepts_special)
+            .field("newline_separator", &self.newline_separator)
             .field("parse_fn", &(self.parse_fn as *const ()))
             .finish()
     }

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -321,7 +321,6 @@ where
     // Block head / argument parsing
     pub fn get_head_map(
         &mut self,
-        block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<Arguments<'t>, ParseWarning> {
         debug!(&self.log(), "Looking for key value arguments, then ']]'");
@@ -365,13 +364,12 @@ where
             }
         }
 
-        self.get_head_block(block_rule, in_head)?;
+        self.get_head_block(in_head)?;
         Ok(map)
     }
 
     pub fn get_head_name_map(
         &mut self,
-        block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(&'t str, Arguments<'t>), ParseWarning> {
         debug!(
@@ -393,14 +391,13 @@ where
             self.get_block_name_internal(ParseWarningKind::ModuleMissingName)?;
 
         // Get arguments and end of block
-        let arguments = self.get_head_map(block_rule, in_head)?;
+        let arguments = self.get_head_map(in_head)?;
 
         Ok((subname, arguments))
     }
 
     pub fn get_head_value<F, T>(
         &mut self,
-        block_rule: &BlockRule,
         in_head: bool,
         convert: F,
     ) -> Result<T, ParseWarning>
@@ -436,26 +433,24 @@ where
         let value = convert(self, argument)?;
 
         // Set to false because the collection will always end the block
-        self.get_head_block(block_rule, false)?;
+        self.get_head_block(false)?;
         Ok(value)
     }
 
     pub fn get_head_none(
         &mut self,
-        block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseWarning> {
         debug!(&self.log(), "No arguments, looking for end of head block");
 
         self.get_optional_space()?;
-        self.get_head_block(block_rule, in_head)?;
+        self.get_head_block(in_head)?;
         Ok(())
     }
 
     // Helper function to finish up the head block
     fn get_head_block(
         &mut self,
-        block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseWarning> {
         trace!(&self.log(), "Getting end of the head block");

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -468,6 +468,9 @@ where
             )?;
         }
 
+        // Allow the block to have trailing whitespace
+        self.get_optional_space()?;
+
         // Allow a line break to terminate the block
         self.get_optional_line_break()?;
 

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -73,11 +73,9 @@ where
         Ok(())
     }
 
-    pub fn get_line_break(&mut self) -> Result<(), ParseWarning> {
-        debug!(&self.log(), "Looking for line break");
-
-        self.get_token(Token::LineBreak, ParseWarningKind::BlockExpectedLineBreak)?;
-        Ok(())
+    pub fn get_optional_line_break(&mut self) -> Result<(), ParseWarning> {
+        debug!(&self.log(), "Looking for optional line break");
+        self.get_optional_token(Token::LineBreak)
     }
 
     #[inline]
@@ -162,10 +160,10 @@ where
     ) -> Option<&'r ExtractedToken<'t>> {
         self.save_evaluate_fn(|parser| {
             // Check that the end block is on a new line, if required
-            if block_rule.newline_separator {
+            if block_rule.accepts_newlines {
                 // Only check after the first, to permit empty blocks
                 if !first_iteration {
-                    parser.get_line_break()?;
+                    parser.get_optional_line_break()?;
                 }
             }
 
@@ -234,7 +232,7 @@ where
     /// This requires that the has already been parsed using
     /// one of the "get argument" methods.
     ///
-    /// The `newline_separator` argument designates whether this
+    /// The `accepts_newlines` argument designates whether this
     /// block assumes multiline construction (e.g. `[[div]]`, `[[code]]`)
     /// or not (e.g. `[[span]]`).
     pub fn get_body_text(
@@ -475,8 +473,8 @@ where
         //
         // It's fine if we're at the end of the input,
         // it could be an empty block type.
-        if self.current().token != Token::InputEnd && block_rule.newline_separator {
-            self.get_line_break()?;
+        if self.current().token != Token::InputEnd && block_rule.accepts_newlines {
+            self.get_optional_line_break()?;
         }
 
         Ok(())

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -89,11 +89,7 @@ fn block_skip<'r, 't>(
             None => return Ok(false),
         };
 
-        // Now, if it wants newlines, ignore this newline.
-        // The rule will succeed.
-        //
-        // If it doesn't, let the rule fail. Then it will pass on to a fallback.
-        Ok(block.newline_separator)
+        Ok(true)
     });
 
     if result {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -83,13 +83,11 @@ fn block_skip<'r, 't>(
         // Get the block's name
         let (name, _) = parser.get_block_name(false)?;
 
-        // Get the associated block rule
-        let block = match get_block_rule_with_name(name) {
-            Some(block) => block,
-            None => return Ok(false),
-        };
-
-        Ok(true)
+        // If there's a block rule, then it's valid
+        match get_block_rule_with_name(name) {
+            Some(_) => Ok(true),
+            None => Ok(false),
+        }
     });
 
     if result {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -84,16 +84,7 @@ fn block_skip<'r, 't>(
         let (name, _) = parser.get_block_name(false)?;
 
         // Get the associated block rule
-        let block = match get_block_rule_with_name(name) {
-            Some(block) => block,
-            None => return Ok(false),
-        };
-
-        // Now, if it wants newlines, ignore this newline.
-        // The rule will succeed.
-        //
-        // If it doesn't, let the rule fail. Then it will pass on to a fallback.
-        Ok(block.newline_separator)
+        Ok(get_block_rule_with_name(name).is_some())
     });
 
     if result {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -84,7 +84,16 @@ fn block_skip<'r, 't>(
         let (name, _) = parser.get_block_name(false)?;
 
         // Get the associated block rule
-        Ok(get_block_rule_with_name(name).is_some())
+        let block = match get_block_rule_with_name(name) {
+            Some(block) => block,
+            None => return Ok(false),
+        };
+
+        // Now, if it wants newlines, ignore this newline.
+        // The rule will succeed.
+        //
+        // If it doesn't, let the rule fail. Then it will pass on to a fallback.
+        Ok(block.newline_separator)
     });
 
     if result {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -84,10 +84,7 @@ fn block_skip<'r, 't>(
         let (name, _) = parser.get_block_name(false)?;
 
         // If there's a block rule, then it's valid
-        match get_block_rule_with_name(name) {
-            Some(_) => Ok(true),
-            None => Ok(false),
-        }
+        Ok(get_block_rule_with_name(name).is_some())
     });
 
     if result {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -83,8 +83,11 @@ fn block_skip<'r, 't>(
         // Get the block's name
         let (name, _) = parser.get_block_name(false)?;
 
-        // If there's a block rule, then it's valid
-        Ok(get_block_rule_with_name(name).is_some())
+        // Get the block rule: if it accepts newlines, then we consume here
+        match get_block_rule_with_name(name) {
+            Some(block_rule) => Ok(block_rule.accepts_newlines),
+            None => Ok(false),
+        }
     });
 
     if result {

--- a/ftml/test/code-inline-empty.json
+++ b/ftml/test/code-inline-empty.json
@@ -10,7 +10,7 @@
                         {
                             "element": "code",
                             "data": {
-                                "contents": "text here",
+                                "contents": "",
                                 "language": null
                             }
                         }

--- a/ftml/test/code-inline-empty.json
+++ b/ftml/test/code-inline-empty.json
@@ -1,0 +1,26 @@
+{
+    "input": "[[code]][[/code]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "code",
+                            "data": {
+                                "contents": "text here",
+                                "language": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/code-inline.json
+++ b/ftml/test/code-inline.json
@@ -1,0 +1,26 @@
+{
+    "input": "[[code]]text here[[/code]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "code",
+                            "data": {
+                                "contents": "text here",
+                                "language": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/collapsible-inline.json
+++ b/ftml/test/collapsible-inline.json
@@ -1,0 +1,46 @@
+{
+    "input": "[[collapsible]]Apple[[/collapsible]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "collapsible",
+                            "data": {
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "start-open": false,
+                                "show-text": null,
+                                "hide-text": null,
+                                "show-top": true,
+                                "show-bottom": false,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/css-inline.json
+++ b/ftml/test/css-inline.json
@@ -1,0 +1,12 @@
+{
+    "input": "[[css]]a { color: blue; }[[/css]]",
+    "tree": {
+        "elements": [
+        ],
+        "styles": [
+            "a { color: blue; }"
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/del-newlines.json
+++ b/ftml/test/del-newlines.json
@@ -16,9 +16,6 @@
                                 "style": null,
                                 "elements": [
                                     {
-                                        "element": "line-break"
-                                    },
-                                    {
                                         "element": "text",
                                         "data": "Apple"
                                     },
@@ -28,9 +25,6 @@
                                     {
                                         "element": "text",
                                         "data": "Banana"
-                                    },
-                                    {
-                                        "element": "line-break"
                                     }
                                 ]
                             }

--- a/ftml/test/del-newlines.json
+++ b/ftml/test/del-newlines.json
@@ -16,6 +16,9 @@
                                 "style": null,
                                 "elements": [
                                     {
+                                        "element": "line-break"
+                                    },
+                                    {
                                         "element": "text",
                                         "data": "Apple"
                                     },
@@ -25,6 +28,9 @@
                                     {
                                         "element": "text",
                                         "data": "Banana"
+                                    },
+                                    {
+                                        "element": "line-break"
                                     }
                                 ]
                             }

--- a/ftml/test/div-inline-empty.json
+++ b/ftml/test/div-inline-empty.json
@@ -1,0 +1,30 @@
+{
+    "input": "[[div]][[/div]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "div",
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/div-inline.json
+++ b/ftml/test/div-inline.json
@@ -1,0 +1,42 @@
+{
+    "input": "[[div]]Apple[[/div]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "div",
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "paragraph",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "Apple"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/div2-inline.json
+++ b/ftml/test/div2-inline.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[div_]]Apple[[/div]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "div",
+                                "id": null,
+                                "class": null,
+                                "style": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/module-css-inline.json
+++ b/ftml/test/module-css-inline.json
@@ -1,0 +1,12 @@
+{
+    "input": "[[module css]]a { color: blue; }[[/module]]",
+    "tree": {
+        "elements": [
+        ],
+        "styles": [
+            "a { color: blue; }"
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
To resolve [WJ-153](https://scuttle.atlassian.net/browse/WJ-153), this issue lifts the requirement that newline-separated blocks must have newlines, permitting them to be declared inline.

However they still maintain the newline-consuming behavior, so that existing uses of the syntax does not break.

Newly-accepted syntax:
```
[[div]]Alpha beta gamma[[/div]]
```
Which is equivalent to:
```
[[div]]
Alpha beta gamma
[[/div]]
```