### PR TITLE
[FTML-69] Allow arbitrary HTML attributes

### DIFF
--- a/ftml/src/parsing/rule/impls/block/arguments.rs
+++ b/ftml/src/parsing/rule/impls/block/arguments.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::parsing::{parse_boolean, ParseWarning, ParseWarningKind, Parser};
+use crate::tree::AttributeMap;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -81,7 +82,13 @@ impl<'t> Arguments<'t> {
         }
     }
 
-    pub fn to_hash_map(&self) -> HashMap<Cow<'t, str>, Cow<'t, str>> {
+    /// Removes the `UniCase` wrappers to produce a separate hash map of keys to values.
+    ///
+    /// This returns a new `HashMap` suitable for inclusion in final `Element`s.
+    /// It does not clone any string allocations, as they are all borrowed
+    /// (or already owned, per `Cow`).
+    /// It only makes a new allocation for the new `HashMap`.
+    pub fn to_hash_map(&self) -> AttributeMap<'t> {
         self.inner
             .iter()
             .map(|(key, value)| (cow!(key.into_inner()), Cow::clone(value)))

--- a/ftml/src/parsing/rule/impls/block/arguments.rs
+++ b/ftml/src/parsing/rule/impls/block/arguments.rs
@@ -80,4 +80,8 @@ impl<'t> Arguments<'t> {
             None => Ok(None),
         }
     }
+
+    pub fn to_hash_map(&self) -> HashMap<Cow<'t, str>, Cow<'t, str>> {
+        self.inner.iter().map(|(key, value)| (cow!(key.into_inner()), Cow::clone(value))).collect()
+    }
 }

--- a/ftml/src/parsing/rule/impls/block/arguments.rs
+++ b/ftml/src/parsing/rule/impls/block/arguments.rs
@@ -82,6 +82,9 @@ impl<'t> Arguments<'t> {
     }
 
     pub fn to_hash_map(&self) -> HashMap<Cow<'t, str>, Cow<'t, str>> {
-        self.inner.iter().map(|(key, value)| (cow!(key.into_inner()), Cow::clone(value))).collect()
+        self.inner
+            .iter()
+            .map(|(key, value)| (cow!(key.into_inner()), Cow::clone(value)))
+            .collect()
     }
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -47,11 +47,6 @@ fn parse_fn<'r, 't>(
 
     let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;
 
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
-
     // Get display arguments
     let show_text = arguments.get("show");
     let hide_text = arguments.get("hide");
@@ -72,14 +67,12 @@ fn parse_fn<'r, 't>(
     // Build element and return
     let element = Element::Collapsible {
         elements,
+        attributes: arguments.to_hash_map(),
         start_open,
         show_text,
         hide_text,
         show_top,
         show_bottom,
-        id,
-        class,
-        style,
     };
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -45,12 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Deletion doesn't allow special variant");
     assert_block_name(&BLOCK_DEL, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;
-
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
+    let arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;
 
     // Get body content, without paragraphs
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_DEL, false)?.into();
@@ -59,9 +54,7 @@ fn parse_fn<'r, 't>(
     let element = Element::StyledContainer(StyledContainer::new(
         StyledContainerType::Deletion,
         elements,
-        id,
-        class,
-        style,
+        arguments.to_hash_map(),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -45,16 +45,11 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Div doesn't allow special variant");
     assert_block_name(&BLOCK_DIV, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
+    let arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it
     let wrap_paragraphs = !name.ends_with('_');
-
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
 
     // Get body content, based on whether we want paragraphs or not
     let (elements, exceptions) = parser
@@ -65,9 +60,7 @@ fn parse_fn<'r, 't>(
     let element = Element::StyledContainer(StyledContainer::new(
         StyledContainerType::Div,
         elements,
-        id,
-        class,
-        style,
+        arguments.to_hash_map(),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -45,12 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Ins doesn't allow special variant");
     assert_block_name(&BLOCK_INS, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_INS, in_head)?;
-
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
+    let arguments = parser.get_head_map(&BLOCK_INS, in_head)?;
 
     // Get body content, without paragraphs
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_INS, false)?.into();
@@ -59,9 +54,7 @@ fn parse_fn<'r, 't>(
     let element = Element::StyledContainer(StyledContainer::new(
         StyledContainerType::Insertion,
         elements,
-        id,
-        class,
-        style,
+        arguments.to_hash_map(),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -45,12 +45,7 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Mark doesn't allow special variant");
     assert_block_name(&BLOCK_MARK, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;
-
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
+    let arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;
 
     // Get body content, without paragraphs
     let (elements, exceptions) = parser.get_body_elements(&BLOCK_MARK, false)?.into();
@@ -59,9 +54,7 @@ fn parse_fn<'r, 't>(
     let element = Element::StyledContainer(StyledContainer::new(
         StyledContainerType::Mark,
         elements,
-        id,
-        class,
-        style,
+        arguments.to_hash_map(),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -36,14 +36,10 @@ fn parse_fn<'r, 't>(
     assert_module_name(&MODULE_JOIN, name);
 
     let button_text = arguments.get("button");
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
+    let attributes = arguments.to_hash_map();
 
     ok!(Module::Join {
         button_text,
-        id,
-        class,
-        style
+        attributes,
     })
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -45,16 +45,11 @@ fn parse_fn<'r, 't>(
     assert_eq!(special, false, "Span doesn't allow special variant");
     assert_block_name(&BLOCK_SPAN, name);
 
-    let mut arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;
+    let arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;
 
     // "span" means we wrap interpret as-is
     // "span_" means we strip out any newlines or paragraph breaks
     let strip_line_breaks = name.ends_with('_');
-
-    // Get styling arguments
-    let id = arguments.get("id");
-    let class = arguments.get("class");
-    let style = arguments.get("style");
 
     // Get body content, without paragraphs
     let (mut elements, exceptions) = parser.get_body_elements(&BLOCK_SPAN, false)?.into();
@@ -82,9 +77,7 @@ fn parse_fn<'r, 't>(
     let element = Element::StyledContainer(StyledContainer::new(
         StyledContainerType::Span,
         elements,
-        id,
-        class,
-        style,
+        arguments.to_hash_map(),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -385,7 +385,7 @@ where
 
                     // Gather argument key string slice
                     let end = self.current();
-                    self.full_text().slice(&self.log(), start, end)
+                    self.full_text().slice_partial(&self.log(), start, end)
                 };
 
                 // Equal sign

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -358,7 +358,7 @@ where
                             // End parsing block head
                             Token::RightBlock => {
                                 args_finished = true;
-                                break
+                                break;
                             }
 
                             // End parsing argument key
@@ -371,9 +371,9 @@ where
 
                             // Invalid token
                             _ => {
-                                return Err(
-                                    self.make_warn(ParseWarningKind::BlockMalformedArguments)
-                                )
+                                return Err(self.make_warn(
+                                    ParseWarningKind::BlockMalformedArguments,
+                                ))
                             }
                         }
                     }

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -335,17 +335,26 @@ where
 
                 // Try to get the argument key
                 // Determines if we stop or keep parsing
-                let current = self.current();
-                let key = match current.token {
-                    Token::Identifier => current.slice,
-                    Token::RightBlock => break,
-                    _ => {
-                        return Err(
-                            self.make_warn(ParseWarningKind::BlockMalformedArguments)
-                        )
-                    }
-                };
-                self.step()?;
+
+                let (key, last) = collect_text_keep(
+                    &self.log(),
+                    self,
+                    self.rule(),
+                    &[
+                        ParseCondition::current(Token::Whitespace),
+                        ParseCondition::current(Token::RightBlock),
+                    ],
+                    &[
+                        ParseCondition::current(Token::LineBreak),
+                        ParseCondition::current(Token::ParagraphBreak),
+                    ],
+                    Some(ParseWarningKind::BlockMalformedArguments),
+                )?;
+
+                if last.token == Token::RightBlock {
+                    // Finished parsing arguments
+                    break;
+                }
 
                 // Equal sign
                 self.get_optional_space()?;

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -22,8 +22,8 @@
 
 use crate::enums::HeadingLevel;
 use crate::tree::Element;
-use ref_map::*;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use strum_macros::IntoStaticStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -66,9 +66,7 @@ pub struct StyledContainer<'t> {
     #[serde(rename = "type")]
     ctype: StyledContainerType,
     elements: Vec<Element<'t>>,
-    id: Option<Cow<'t, str>>,
-    class: Option<Cow<'t, str>>,
-    style: Option<Cow<'t, str>>,
+    attributes: HashMap<Cow<'t, str>, Cow<'t, str>>,
 }
 
 impl<'t> StyledContainer<'t> {
@@ -76,16 +74,12 @@ impl<'t> StyledContainer<'t> {
     pub fn new(
         ctype: StyledContainerType,
         elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
+        attributes: HashMap<Cow<'t, str>, Cow<'t, str>>,
     ) -> Self {
         StyledContainer {
             ctype,
             elements,
-            id,
-            class,
-            style,
+            attributes,
         }
     }
 
@@ -100,18 +94,8 @@ impl<'t> StyledContainer<'t> {
     }
 
     #[inline]
-    pub fn id(&self) -> Option<&str> {
-        self.id.ref_map(|s| s.as_ref())
-    }
-
-    #[inline]
-    pub fn class(&self) -> Option<&str> {
-        self.class.ref_map(|s| s.as_ref())
-    }
-
-    #[inline]
-    pub fn style(&self) -> Option<&str> {
-        self.style.ref_map(|s| s.as_ref())
+    pub fn attributes(&self) -> &HashMap<Cow<'t, str>, Cow<'t, str>> {
+        &self.attributes
     }
 }
 

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -22,9 +22,8 @@
 
 use crate::enums::HeadingLevel;
 use crate::tree::Element;
-use std::borrow::Cow;
-use std::collections::HashMap;
 use strum_macros::IntoStaticStr;
+use super::element::AttributeMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -66,7 +65,7 @@ pub struct StyledContainer<'t> {
     #[serde(rename = "type")]
     ctype: StyledContainerType,
     elements: Vec<Element<'t>>,
-    attributes: HashMap<Cow<'t, str>, Cow<'t, str>>,
+    attributes: AttributeMap<'t>,
 }
 
 impl<'t> StyledContainer<'t> {
@@ -74,7 +73,7 @@ impl<'t> StyledContainer<'t> {
     pub fn new(
         ctype: StyledContainerType,
         elements: Vec<Element<'t>>,
-        attributes: HashMap<Cow<'t, str>, Cow<'t, str>>,
+        attributes: AttributeMap<'t>,
     ) -> Self {
         StyledContainer {
             ctype,
@@ -94,7 +93,7 @@ impl<'t> StyledContainer<'t> {
     }
 
     #[inline]
-    pub fn attributes(&self) -> &HashMap<Cow<'t, str>, Cow<'t, str>> {
+    pub fn attributes(&self) -> &AttributeMap<'t> {
         &self.attributes
     }
 }

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -20,10 +20,10 @@
 
 //! Representation of generic syntax elements which wrap other elements.
 
+use super::AttributeMap;
 use crate::enums::HeadingLevel;
 use crate::tree::Element;
 use strum_macros::IntoStaticStr;
-use super::element::AttributeMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -21,7 +21,10 @@
 use super::{Container, Module, StyledContainer};
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::num::NonZeroU32;
+
+pub type AttributeMap<'t> = HashMap<Cow<'t, str>, Cow<'t, str>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "element", content = "data")]
@@ -81,9 +84,7 @@ pub enum Element<'t> {
     #[serde(rename_all = "kebab-case")]
     Collapsible {
         elements: Vec<Element<'t>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
+        attributes: AttributeMap<'t>,
         start_open: bool,
         show_text: Option<Cow<'t, str>>,
         hide_text: Option<Cow<'t, str>>,

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -18,13 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::AttributeMap;
 use super::{Container, Module, StyledContainer};
 use crate::enums::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::num::NonZeroU32;
-
-pub type AttributeMap<'t> = HashMap<Cow<'t, str>, Cow<'t, str>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "element", content = "data")]

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -28,6 +28,9 @@ pub use self::module::*;
 
 use crate::parsing::{ParseOutcome, ParseWarning};
 use std::borrow::Cow;
+use std::collections::HashMap;
+
+pub type AttributeMap<'t> = HashMap<Cow<'t, str>, Cow<'t, str>>;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]

--- a/ftml/src/tree/module.rs
+++ b/ftml/src/tree/module.rs
@@ -20,6 +20,7 @@
 
 //! Representation of Wikidot modules, along with their context.
 
+use super::AttributeMap;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
 use strum_macros::IntoStaticStr;
@@ -40,9 +41,7 @@ pub enum Module<'t> {
     #[serde(rename_all = "kebab-case")]
     Join {
         button_text: Option<Cow<'t, str>>,
-        id: Option<Cow<'t, str>>,
-        class: Option<Cow<'t, str>>,
-        style: Option<Cow<'t, str>>,
+        attributes: AttributeMap<'t>,
     },
 
     /// Meta-element for modules which perform no action.

--- a/ftml/test/collapsible-empty.json
+++ b/ftml/test/collapsible-empty.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-folded-no.json
+++ b/ftml/test/collapsible-folded-no.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": true,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-folded-yes.json
+++ b/ftml/test/collapsible-folded-yes.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-inline.json
+++ b/ftml/test/collapsible-inline.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-location-both.json
+++ b/ftml/test/collapsible-location-both.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-location-bottom.json
+++ b/ftml/test/collapsible-location-bottom.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-location-neither.json
+++ b/ftml/test/collapsible-location-neither.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-location-top.json
+++ b/ftml/test/collapsible-location-top.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-nested-deep.json
+++ b/ftml/test/collapsible-nested-deep.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,
@@ -31,9 +29,7 @@
                                                 {
                                                     "element": "collapsible",
                                                     "data": {
-                                                        "id": null,
-                                                        "class": null,
-                                                        "style": null,
+                                                        "attributes": {},
                                                         "start-open": false,
                                                         "show-text": null,
                                                         "hide-text": null,
@@ -52,9 +48,7 @@
                                                                         {
                                                                             "element": "collapsible",
                                                                             "data": {
-                                                                                "id": null,
-                                                                                "class": null,
-                                                                                "style": null,
+                                                                                "attributes": {},
                                                                                 "start-open": false,
                                                                                 "show-text": null,
                                                                                 "hide-text": null,

--- a/ftml/test/collapsible-nested.json
+++ b/ftml/test/collapsible-nested.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,
@@ -31,9 +29,7 @@
                                                 {
                                                     "element": "collapsible",
                                                     "data": {
-                                                        "id": null,
-                                                        "class": null,
-                                                        "style": null,
+                                                        "attributes": {},
                                                         "start-open": false,
                                                         "show-text": "+ More Fruit",
                                                         "hide-text": "- Hide Fruit",

--- a/ftml/test/collapsible-styling.json
+++ b/ftml/test/collapsible-styling.json
@@ -10,9 +10,11 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": "fruit",
-                                "class": "collapse-list",
-                                "style": "display: inline-block",
+                                "attributes": {
+                                    "id": "fruit",
+                                    "class": "collapse-list",
+                                    "style": "display: inline-block"
+                                },
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible-text.json
+++ b/ftml/test/collapsible-text.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": "SHOW!",
                                 "hide-text": "HIDE!",

--- a/ftml/test/collapsible-uppercase.json
+++ b/ftml/test/collapsible-uppercase.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[ COLLapsiBLe  ID=\"id\" CLASS = \"class\"  ]]\nCherry\n[[/collapsible]]",
+    "input": "[[ COLLapsiBLe  ID=\"my-id\" CLASS = \"my-class\"  ]]\nCherry\n[[/collapsible]]",
     "tree": {
         "elements": [
             {
@@ -11,8 +11,8 @@
                             "element": "collapsible",
                             "data": {
                                 "attributes": {
-                                    "id": "id",
-                                    "class": "class"
+                                    "ID": "my-id",
+                                    "CLASS": "my-class"
                                 },
                                 "start-open": false,
                                 "show-text": null,

--- a/ftml/test/collapsible-uppercase.json
+++ b/ftml/test/collapsible-uppercase.json
@@ -10,9 +10,10 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": "id",
-                                "class": "class",
-                                "style": null,
+                                "attributes": {
+                                    "id": "id",
+                                    "class": "class"
+                                },
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/collapsible.json
+++ b/ftml/test/collapsible.json
@@ -10,9 +10,7 @@
                         {
                             "element": "collapsible",
                             "data": {
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "start-open": false,
                                 "show-text": null,
                                 "hide-text": null,

--- a/ftml/test/del-alias.json
+++ b/ftml/test/del-alias.json
@@ -18,9 +18,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "deletion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/del-newlines.json
+++ b/ftml/test/del-newlines.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "deletion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "line-break"

--- a/ftml/test/del-style.json
+++ b/ftml/test/del-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[del id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/del]]",
+    "input": "[[del id=\"banana\" class=\"fruit\" style=\"color: yellow;\" my-special-attr=\"yes\"]]Banana[[/del]]",
     "tree": {
         "elements": [
             {
@@ -14,7 +14,8 @@
                                 "attributes": {
                                     "id": "banana",
                                     "class": "fruit",
-                                    "style": "color: yellow;"
+                                    "style": "color: yellow;",
+                                    "my-special-attr": "yes"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/del-style.json
+++ b/ftml/test/del-style.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "deletion",
-                                "id": "banana",
-                                "class": "fruit",
-                                "style": "color: yellow;",
+                                "attributes": {
+                                    "id": "banana",
+                                    "class": "fruit",
+                                    "style": "color: yellow;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/del-uppercase.json
+++ b/ftml/test/del-uppercase.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "deletion",
-                                "id": "apple",
-                                "class": "fruit",
-                                "style": "color: red;",
+                                "attributes": {
+                                    "id": "apple",
+                                    "class": "fruit",
+                                    "style": "color: red;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/del-uppercase.json
+++ b/ftml/test/del-uppercase.json
@@ -12,9 +12,9 @@
                             "data": {
                                 "type": "deletion",
                                 "attributes": {
-                                    "id": "apple",
-                                    "class": "fruit",
-                                    "style": "color: red;"
+                                    "ID": "apple",
+                                    "clASS": "fruit",
+                                    "stylE": "color: red;"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/del.json
+++ b/ftml/test/del.json
@@ -18,9 +18,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "deletion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div-class.json
+++ b/ftml/test/div-class.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": "blockquote",
-                                "style": null,
+                                "attributes": {
+                                    "class": "blockquote"
+                                },
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-empty-2.json
+++ b/ftml/test/div-empty-2.json
@@ -15,9 +15,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/div-empty.json
+++ b/ftml/test/div-empty.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/div-ending.json
+++ b/ftml/test/div-ending.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-id.json
+++ b/ftml/test/div-id.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": "my-div",
-                                "class": null,
-                                "style": null,
+                                "attributes": {
+                                    "id": "my-div"
+                                },
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-inline-empty.json
+++ b/ftml/test/div-inline-empty.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/div-inline.json
+++ b/ftml/test/div-inline.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-multiline.json
+++ b/ftml/test/div-multiline.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-nested-deep.json
+++ b/ftml/test/div-nested-deep.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",
@@ -28,9 +26,7 @@
                                                     "element": "styled-container",
                                                     "data": {
                                                         "type": "div",
-                                                        "id": null,
-                                                        "class": null,
-                                                        "style": null,
+                                                        "attributes": {},
                                                         "elements": [
                                                             {
                                                                 "element": "container",
@@ -45,9 +41,7 @@
                                                                             "element": "styled-container",
                                                                             "data": {
                                                                                 "type": "div",
-                                                                                "id": null,
-                                                                                "class": null,
-                                                                                "style": null,
+                                                                                "attributes": {},
                                                                                 "elements": [
                                                                                     {
                                                                                         "element": "container",
@@ -62,9 +56,7 @@
                                                                                                     "element": "styled-container",
                                                                                                     "data": {
                                                                                                         "type": "div",
-                                                                                                        "id": null,
-                                                                                                        "class": null,
-                                                                                                        "style": null,
+                                                                                                        "attributes": {},
                                                                                                         "elements": [
                                                                                                             {
                                                                                                                 "element": "container",

--- a/ftml/test/div-nested.json
+++ b/ftml/test/div-nested.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",
@@ -44,9 +42,7 @@
                                                     "element": "styled-container",
                                                     "data": {
                                                         "type": "div",
-                                                        "id": null,
-                                                        "class": null,
-                                                        "style": null,
+                                                        "attributes": {},
                                                         "elements": [
                                                             {
                                                                 "element": "container",

--- a/ftml/test/div-paragraphs.json
+++ b/ftml/test/div-paragraphs.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-style.json
+++ b/ftml/test/div-style.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": "display: flex",
+                                "attributes": {
+                                    "style": "display: flex"
+                                },
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div-style.json
+++ b/ftml/test/div-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[div style=\"display: flex\"]]\nApple\n[[/div]]",
+    "input": "[[div style=\"display: flex\" data-fruit=\"red\"]]\nApple\n[[/div]]",
     "tree": {
         "elements": [
             {
@@ -12,7 +12,8 @@
                             "data": {
                                 "type": "div",
                                 "attributes": {
-                                    "style": "display: flex"
+                                    "style": "display: flex",
+                                    "data-fruit": "red"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/div.json
+++ b/ftml/test/div.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",

--- a/ftml/test/div2-class.json
+++ b/ftml/test/div2-class.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": "blockquote",
-                                "style": null,
+                                "attributes": {
+                                    "class": "blockquote"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-empty-2.json
+++ b/ftml/test/div2-empty-2.json
@@ -15,9 +15,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/div2-empty.json
+++ b/ftml/test/div2-empty.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/div2-ending.json
+++ b/ftml/test/div2-ending.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-id.json
+++ b/ftml/test/div2-id.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": "my-div",
-                                "class": null,
-                                "style": null,
+                                "attributes": {
+                                    "id": "my-div"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-inline.json
+++ b/ftml/test/div2-inline.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-multiline.json
+++ b/ftml/test/div2-multiline.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-nested-deep.json
+++ b/ftml/test/div2-nested-deep.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",
@@ -23,9 +21,7 @@
                                         "element": "styled-container",
                                         "data": {
                                             "type": "div",
-                                            "id": null,
-                                            "class": null,
-                                            "style": null,
+                                            "attributes": {},
                                             "elements": [
                                                 {
                                                     "element": "text",
@@ -35,9 +31,7 @@
                                                     "element": "styled-container",
                                                     "data": {
                                                         "type": "div",
-                                                        "id": null,
-                                                        "class": null,
-                                                        "style": null,
+                                                        "attributes": {},
                                                         "elements": [
                                                             {
                                                                 "element": "text",
@@ -47,9 +41,7 @@
                                                                 "element": "styled-container",
                                                                 "data": {
                                                                     "type": "div",
-                                                                    "id": null,
-                                                                    "class": null,
-                                                                    "style": null,
+                                                                    "attributes": {},
                                                                     "elements": [
                                                                         {
                                                                             "element": "text",

--- a/ftml/test/div2-nested.json
+++ b/ftml/test/div2-nested.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "container",
@@ -39,9 +37,7 @@
                                         "element": "styled-container",
                                         "data": {
                                             "type": "div",
-                                            "id": null,
-                                            "class": null,
-                                            "style": null,
+                                            "attributes": {},
                                             "elements": [
                                                 {
                                                     "element": "text",

--- a/ftml/test/div2-style.json
+++ b/ftml/test/div2-style.json
@@ -11,9 +11,9 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": "display: flex",
+                                "attributes": {
+                                    "style": "display: flex"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/div2-style.json
+++ b/ftml/test/div2-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[div_ style=\"display: flex\"]]\nApple\n[[/div]]",
+    "input": "[[div_ style=\"display: flex\" data-fruit=\"red\"]]\nApple\n[[/div]]",
     "tree": {
         "elements": [
             {
@@ -12,7 +12,8 @@
                             "data": {
                                 "type": "div",
                                 "attributes": {
-                                    "style": "display: flex"
+                                    "style": "display: flex",
+                                    "data-fruit": "red"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/div2.json
+++ b/ftml/test/div2.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "div",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/ins-alias.json
+++ b/ftml/test/ins-alias.json
@@ -18,9 +18,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "insertion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/ins-newlines.json
+++ b/ftml/test/ins-newlines.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "insertion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "line-break"

--- a/ftml/test/ins-style.json
+++ b/ftml/test/ins-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[ins id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/ins]]",
+    "input": "[[ins id=\"banana\" class=\"fruit\" style=\"color: yellow;\" _myAttr=\"hi\"]]Banana[[/ins]]",
     "tree": {
         "elements": [
             {
@@ -14,7 +14,8 @@
                                 "attributes": {
                                     "id": "banana",
                                     "class": "fruit",
-                                    "style": "color: yellow;"
+                                    "style": "color: yellow;",
+                                    "_myAttr": "hi"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/ins-style.json
+++ b/ftml/test/ins-style.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "insertion",
-                                "id": "banana",
-                                "class": "fruit",
-                                "style": "color: yellow;",
+                                "attributes": {
+                                    "id": "banana",
+                                    "class": "fruit",
+                                    "style": "color: yellow;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/ins-uppercase.json
+++ b/ftml/test/ins-uppercase.json
@@ -12,9 +12,9 @@
                             "data": {
                                 "type": "insertion",
                                 "attributes": {
-                                    "id": "apple",
-                                    "class": "fruit",
-                                    "style": "color: red;"
+                                    "ID": "apple",
+                                    "clASS": "fruit",
+                                    "stylE": "color: red;"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/ins-uppercase.json
+++ b/ftml/test/ins-uppercase.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "insertion",
-                                "id": "apple",
-                                "class": "fruit",
-                                "style": "color: red;",
+                                "attributes": {
+                                    "id": "apple",
+                                    "class": "fruit",
+                                    "style": "color: red;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/ins.json
+++ b/ftml/test/ins.json
@@ -18,9 +18,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "insertion",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/mark-alias.json
+++ b/ftml/test/mark-alias.json
@@ -19,9 +19,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "mark",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/mark-newlines.json
+++ b/ftml/test/mark-newlines.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "mark",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "line-break"

--- a/ftml/test/mark-style.json
+++ b/ftml/test/mark-style.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "mark",
-                                "id": "banana",
-                                "class": "fruit",
-                                "style": "color: yellow;",
+                                "attributes": {
+                                    "id": "banana",
+                                    "class": "fruit",
+                                    "style": "color: yellow;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/mark-style.json
+++ b/ftml/test/mark-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[mark id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/mark]]",
+    "input": "[[mark id=\"banana\" class=\"fruit\" style=\"color: yellow;\" onclick=\"javascript:thing()\"]]Banana[[/mark]]",
     "tree": {
         "elements": [
             {
@@ -14,7 +14,8 @@
                                 "attributes": {
                                     "id": "banana",
                                     "class": "fruit",
-                                    "style": "color: yellow;"
+                                    "style": "color: yellow;",
+                                    "onclick": "javascript:thing()"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/mark-uppercase.json
+++ b/ftml/test/mark-uppercase.json
@@ -12,9 +12,9 @@
                             "data": {
                                 "type": "mark",
                                 "attributes": {
-                                    "id": "apple",
-                                    "class": "fruit",
-                                    "style": "color: red;"
+                                    "ID": "apple",
+                                    "clASS": "fruit",
+                                    "stylE": "color: red;"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/mark-uppercase.json
+++ b/ftml/test/mark-uppercase.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "mark",
-                                "id": "apple",
-                                "class": "fruit",
-                                "style": "color: red;",
+                                "attributes": {
+                                    "id": "apple",
+                                    "class": "fruit",
+                                    "style": "color: red;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/mark.json
+++ b/ftml/test/mark.json
@@ -19,9 +19,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "mark",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/module-join-button.json
+++ b/ftml/test/module-join-button.json
@@ -13,9 +13,7 @@
                                 "module": "join",
                                 "data": {
                                     "button-text": "Join our site!! ;-)",
-                                    "id": null,
-                                    "class": null,
-                                    "style": null
+                                    "attributes": {}
                                 }
                             }
                         },

--- a/ftml/test/module-join-styling.json
+++ b/ftml/test/module-join-styling.json
@@ -13,9 +13,11 @@
                                 "module": "join",
                                 "data": {
                                     "button-text": null,
-                                    "id": "join-btn",
-                                    "class": "join-module",
-                                    "style": "display: inline-block;"
+                                    "attributes": {
+                                        "id": "join-btn",
+                                        "class": "join-module",
+                                        "style": "display: inline-block;"
+                                    }
                                 }
                             }
                         },

--- a/ftml/test/module-join-styling.json
+++ b/ftml/test/module-join-styling.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[module Join id=\"join-btn\" CLASS =\"join-module\" stYLe= \"display: inline-block;\"]]\nApple",
+    "input": "[[module Join id=\"join-btn\" CLASS =\"join-module\" stYLe= \"display: inline-block;\" data-join=\"\"]]\nApple",
     "tree": {
         "elements": [
             {
@@ -16,7 +16,8 @@
                                     "attributes": {
                                         "id": "join-btn",
                                         "class": "join-module",
-                                        "style": "display: inline-block;"
+                                        "style": "display: inline-block;",
+                                        "data-join": ""
                                     }
                                 }
                             }

--- a/ftml/test/module-join-styling.json
+++ b/ftml/test/module-join-styling.json
@@ -15,8 +15,8 @@
                                     "button-text": null,
                                     "attributes": {
                                         "id": "join-btn",
-                                        "class": "join-module",
-                                        "style": "display: inline-block;",
+                                        "CLASS": "join-module",
+                                        "stYLe": "display: inline-block;",
                                         "data-join": ""
                                     }
                                 }

--- a/ftml/test/module-join-uppercase.json
+++ b/ftml/test/module-join-uppercase.json
@@ -13,9 +13,7 @@
                                 "module": "join",
                                 "data": {
                                     "button-text": null,
-                                    "id": null,
-                                    "class": null,
-                                    "style": null
+                                    "attributes": {}
                                 }
                             }
                         },

--- a/ftml/test/module-join.json
+++ b/ftml/test/module-join.json
@@ -13,9 +13,7 @@
                                 "module": "join",
                                 "data": {
                                     "button-text": null,
-                                    "id": null,
-                                    "class": null,
-                                    "style": null
+                                    "attributes": {}
                                 }
                             }
                         },

--- a/ftml/test/span-empty.json
+++ b/ftml/test/span-empty.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/span-newlines-2.json
+++ b/ftml/test/span-newlines-2.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span-newlines.json
+++ b/ftml/test/span-newlines.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "line-break"

--- a/ftml/test/span-style.json
+++ b/ftml/test/span-style.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": "banana",
-                                "class": "fruit",
-                                "style": "color: yellow;",
+                                "attributes": {
+                                    "id": "banana",
+                                    "class": "fruit",
+                                    "style": "color: yellow;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span-style.json
+++ b/ftml/test/span-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[span id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/span]]",
+    "input": "[[span id=\"banana\" class=\"fruit\" style=\"color: yellow;\" data-fruit=\"!red\"]]Banana[[/span]]",
     "tree": {
         "elements": [
             {
@@ -14,7 +14,8 @@
                                 "attributes": {
                                     "id": "banana",
                                     "class": "fruit",
-                                    "style": "color: yellow;"
+                                    "style": "color: yellow;",
+                                    "data-fruit": "!red"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/span-uppercase.json
+++ b/ftml/test/span-uppercase.json
@@ -12,9 +12,9 @@
                             "data": {
                                 "type": "span",
                                 "attributes": {
-                                    "id": "apple",
-                                    "class": "fruit",
-                                    "style": "color: red;"
+                                    "ID": "apple",
+                                    "clASS": "fruit",
+                                    "stylE": "color: red;"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/span-uppercase.json
+++ b/ftml/test/span-uppercase.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": "apple",
-                                "class": "fruit",
-                                "style": "color: red;",
+                                "attributes": {
+                                    "id": "apple",
+                                    "class": "fruit",
+                                    "style": "color: red;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span.json
+++ b/ftml/test/span.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span2-empty.json
+++ b/ftml/test/span2-empty.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/span2-newlines-2.json
+++ b/ftml/test/span2-newlines-2.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span2-newlines.json
+++ b/ftml/test/span2-newlines.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span2-style.json
+++ b/ftml/test/span2-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[span_ id=\"banana\" class=\"fruit\" style=\"color: yellow;\"]]Banana[[/span]]",
+    "input": "[[span_ id=\"banana\" class=\"fruit\" style=\"color: yellow;\" data-fruit=\"!red\"]]Banana[[/span]]",
     "tree": {
         "elements": [
             {
@@ -14,7 +14,8 @@
                                 "attributes": {
                                     "id": "banana",
                                     "class": "fruit",
-                                    "style": "color: yellow;"
+                                    "style": "color: yellow;",
+                                    "data-fruit": "!red"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/span2-style.json
+++ b/ftml/test/span2-style.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": "banana",
-                                "class": "fruit",
-                                "style": "color: yellow;",
+                                "attributes": {
+                                    "id": "banana",
+                                    "class": "fruit",
+                                    "style": "color: yellow;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span2-uppercase.json
+++ b/ftml/test/span2-uppercase.json
@@ -12,9 +12,9 @@
                             "data": {
                                 "type": "span",
                                 "attributes": {
-                                    "id": "apple",
-                                    "class": "fruit",
-                                    "style": "color: red;"
+                                    "ID": "apple",
+                                    "clASS": "fruit",
+                                    "stylE": "color: red;"
                                 },
                                 "elements": [
                                     {

--- a/ftml/test/span2-uppercase.json
+++ b/ftml/test/span2-uppercase.json
@@ -11,9 +11,11 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": "apple",
-                                "class": "fruit",
-                                "style": "color: red;",
+                                "attributes": {
+                                    "id": "apple",
+                                    "class": "fruit",
+                                    "style": "color: red;"
+                                },
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/span2.json
+++ b/ftml/test/span2.json
@@ -11,9 +11,7 @@
                             "element": "styled-container",
                             "data": {
                                 "type": "span",
-                                "id": null,
-                                "class": null,
-                                "style": null,
+                                "attributes": {},
                                 "elements": [
                                     {
                                         "element": "text",


### PR DESCRIPTION
This PR accomplishes two things:
* Permits dashes and underscores in block argument keys
* Modifies styled elements to accept an arbitrary map of HTML attributes instead

Wikidot is rather restrictive, sometimes arbitrarily so, about which arguments it will pass on to the final HTML tag being created. Instead of this, it was proposed in [FTML-69](https://scuttle.atlassian.net/browse/FTML-69) to allow any other arguments to be passed into the final `Element` being constructed.

This blocks #101 	