### PR TITLE
[FTML-70] Add anchor block

### DIFF
--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -1,0 +1,69 @@
+/*
+ * parsing/rule/impls/block/blocks/anchor.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use crate::enums::AnchorTarget;
+
+pub const BLOCK_ANCHOR: BlockRule = BlockRule {
+    name: "block-anchor",
+    accepts_names: &["a", "anchor"],
+    accepts_special: true,
+    accepts_newlines: false,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Element<'t>> {
+    debug!(
+        log,
+        "Parsing anchor block";
+        "in-head" => in_head,
+        "name" => name,
+        "special" => special,
+    );
+
+    assert_block_name(&BLOCK_ANCHOR, name);
+
+    let arguments = parser.get_head_map(&BLOCK_ANCHOR, in_head)?;
+    let attributes = arguments.to_hash_map();
+
+    // Get anchor target depending on special
+    let target = if special {
+        AnchorTarget::NewTab
+    } else {
+        AnchorTarget::Same
+    };
+
+    // Get body content, without paragraphs
+    let (elements, exceptions) = parser.get_body_elements(&BLOCK_ANCHOR, false)?.into();
+
+    let element = Element::Anchor {
+        elements,
+        attributes,
+        target,
+    };
+
+    ok!(element, exceptions)
+}

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -56,6 +56,7 @@ mod prelude {
     }
 }
 
+mod anchor;
 mod code;
 mod collapsible;
 mod css;
@@ -70,6 +71,7 @@ mod mark;
 mod module;
 mod span;
 
+pub use self::anchor::BLOCK_ANCHOR;
 pub use self::code::BLOCK_CODE;
 pub use self::collapsible::BLOCK_COLLAPSIBLE;
 pub use self::css::BLOCK_CSS;

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -22,7 +22,8 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 13] = [
+pub const BLOCK_RULES: [BlockRule; 14] = [
+    BLOCK_ANCHOR,
     BLOCK_CODE,
     BLOCK_COLLAPSIBLE,
     BLOCK_CSS,

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -93,7 +93,7 @@ fn try_consume_fn<'p, 'r, 't>(
     let element = Element::Link {
         url,
         label: LinkLabel::Text(cow!(label)),
-        anchor: AnchorTarget::Same,
+        target: AnchorTarget::Same,
     };
 
     // Return result

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -59,14 +59,14 @@ fn link_new_tab<'p, 'r, 't>(
     try_consume_link(log, parser, RULE_LINK_SINGLE_NEW_TAB, AnchorTarget::NewTab)
 }
 
-/// Build a single-bracket link with the given anchor.
+/// Build a single-bracket link with the given target.
 fn try_consume_link<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
-    anchor: AnchorTarget,
+    target: AnchorTarget,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Trying to create a single-bracket link"; "anchor" => anchor.name());
+    debug!(log, "Trying to create a single-bracket link"; "target" => target.name());
 
     // Gather path for link
     let url = collect_text(
@@ -118,7 +118,7 @@ fn try_consume_link<'p, 'r, 't>(
     let element = Element::Link {
         url: cow!(url),
         label: LinkLabel::Text(cow!(label)),
-        anchor,
+        target,
     };
 
     // Return result

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -63,14 +63,14 @@ fn link_new_tab<'p, 'r, 't>(
     try_consume_link(log, parser, RULE_LINK_TRIPLE_NEW_TAB, AnchorTarget::NewTab)
 }
 
-/// Build a triple-bracket link with the given anchor.
+/// Build a triple-bracket link with the given target.
 fn try_consume_link<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
-    anchor: AnchorTarget,
+    target: AnchorTarget,
 ) -> ParseResult<'r, 't, Element<'t>> {
-    debug!(log, "Trying to create a triple-bracket link"; "anchor" => anchor.name());
+    debug!(log, "Trying to create a triple-bracket link"; "target" => target.name());
 
     // Gather path for link
     let (url, last) = collect_text_keep(
@@ -105,10 +105,10 @@ fn try_consume_link<'p, 'r, 't>(
     // Determine what token we ended on, i.e. which [[[ variant it is.
     match last.token {
         // [[[name]]] type links
-        Token::RightLink => build_same(log, parser, url, anchor),
+        Token::RightLink => build_same(log, parser, url, target),
 
         // [[[url|label]]] type links
-        Token::Pipe => build_separate(log, parser, rule, url, anchor),
+        Token::Pipe => build_separate(log, parser, rule, url, target),
 
         // Token was already checked in collect_text(), impossible case
         _ => unreachable!(),
@@ -121,7 +121,7 @@ fn build_same<'p, 'r, 't>(
     log: &slog::Logger,
     _parser: &'p mut Parser<'r, 't>,
     url: &'t str,
-    anchor: AnchorTarget,
+    target: AnchorTarget,
 ) -> ParseResult<'r, 't, Element<'t>> {
     debug!(
         log,
@@ -132,7 +132,7 @@ fn build_same<'p, 'r, 't>(
     let element = Element::Link {
         url: cow!(url),
         label: LinkLabel::Url,
-        anchor,
+        target,
     };
 
     ok!(element)
@@ -145,7 +145,7 @@ fn build_separate<'p, 'r, 't>(
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     url: &'t str,
-    anchor: AnchorTarget,
+    target: AnchorTarget,
 ) -> ParseResult<'r, 't, Element<'t>> {
     debug!(
         log,
@@ -187,7 +187,7 @@ fn build_separate<'p, 'r, 't>(
     let element = Element::Link {
         url: cow!(url),
         label,
-        anchor,
+        target,
     };
 
     // Return result

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -35,7 +35,7 @@ fn try_consume_fn<'p, 'r, 't>(
     let element = Element::Link {
         url: cow!(parser.current().slice),
         label: LinkLabel::Url,
-        anchor: AnchorTarget::Same,
+        target: AnchorTarget::Same,
     };
 
     ok!(element)

--- a/ftml/src/test.rs
+++ b/ftml/src/test.rs
@@ -27,6 +27,7 @@ use crate::includes::DebugIncluder;
 use crate::parsing::{ParseWarning, ParseWarningKind, Token};
 use crate::tree::{Element, SyntaxTree};
 use std::borrow::Cow;
+use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use void::ResultVoidExt;
@@ -171,8 +172,7 @@ fn ast() {
             .expect("Unable to get file stem")
             .to_string_lossy();
 
-        let ext = path.extension().expect("Unable to get file extension");
-        if ext != "json" {
+        if path.extension() != Some(OsStr::new("json")) {
             println!("Skipping non-JSON file {}", file_name!(entry));
             return None;
         }

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -81,7 +81,7 @@ pub enum Element<'t> {
     Link {
         url: Cow<'t, str>,
         label: LinkLabel<'t>,
-        anchor: AnchorTarget,
+        target: AnchorTarget,
     },
 
     /// A collapsible, containing content hidden to be opened on click.

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -62,6 +62,16 @@ pub enum Element<'t> {
     /// is up to the render implementation.
     Email(Cow<'t, str>),
 
+    /// An element representing an arbitrary anchor.
+    ///
+    /// This is distinct from link in that it maps to HTML `<a>`,
+    /// and does not necessarily mean a link to some other URL.
+    Anchor {
+        elements: Vec<Element<'t>>,
+        attributes: AttributeMap<'t>,
+        target: AnchorTarget,
+    },
+
     /// An element linking to a different page.
     ///
     /// The "label" field is an optional field denoting what the link should
@@ -140,6 +150,7 @@ impl Element<'_> {
             Element::Text(_) => "Text",
             Element::Raw(_) => "Raw",
             Element::Email(_) => "Email",
+            Element::Anchor { .. } => "Anchor",
             Element::Link { .. } => "Link",
             Element::Collapsible { .. } => "Collapsible",
             Element::Color { .. } => "Color",

--- a/ftml/test/anchor-alias-special-empty.json
+++ b/ftml/test/anchor-alias-special-empty.json
@@ -1,0 +1,28 @@
+{
+    "input": "[[*anchor]][[/anchor]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {},
+                                "target": "new-tab",
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-alias-special.json
+++ b/ftml/test/anchor-alias-special.json
@@ -1,0 +1,43 @@
+{
+    "input": "[[*anchor href=\"http://example.com\" style=\"color: green;\"]]My link[[/anchor]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "http://example.com",
+                                    "style": "color: green;"
+                                },
+                                "target": "new-tab",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-alias-wrap.json
+++ b/ftml/test/anchor-alias-wrap.json
@@ -1,0 +1,48 @@
+{
+    "input": "[[anchor]]Internal //elements//[[/anchor]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {},
+                                "target": "same",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Internal"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "emphasis",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "elements"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-alias.json
+++ b/ftml/test/anchor-alias.json
@@ -1,0 +1,42 @@
+{
+    "input": "[[anchor href=\"/some-page\"]]My link[[/anchor]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "/some-page"
+                                },
+                                "target": "same",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-empty.json
+++ b/ftml/test/anchor-empty.json
@@ -1,0 +1,28 @@
+{
+    "input": "[[a]][[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {},
+                                "target": "same",
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-special-empty.json
+++ b/ftml/test/anchor-special-empty.json
@@ -1,0 +1,28 @@
+{
+    "input": "[[*a]][[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {},
+                                "target": "new-tab",
+                                "elements": [
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-special.json
+++ b/ftml/test/anchor-special.json
@@ -1,0 +1,43 @@
+{
+    "input": "[[*a href=\"https://example.com\" style=\"color: red;\"]]My link[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "https://example.com",
+                                    "style": "color: red;"
+                                },
+                                "target": "new-tab",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor-wrap.json
+++ b/ftml/test/anchor-wrap.json
@@ -1,0 +1,48 @@
+{
+    "input": "[[a]]Internal **elements**[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {},
+                                "target": "same",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Internal"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "container",
+                                        "data": {
+                                            "type": "strong",
+                                            "elements": [
+                                                {
+                                                    "element": "text",
+                                                    "data": "elements"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/anchor.json
+++ b/ftml/test/anchor.json
@@ -1,0 +1,42 @@
+{
+    "input": "[[a href=\"/some-page\"]]My link[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "/some-page"
+                                },
+                                "target": "same",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/iframe-fail.json
+++ b/ftml/test/iframe-fail.json
@@ -24,7 +24,7 @@
                             "data": {
                                 "url": "https://example.com",
                                 "label": "url",
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-anchor-fake.json
+++ b/ftml/test/link-anchor-fake.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Fake link"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-anchor.json
+++ b/ftml/test/link-anchor.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some link"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         },
                         {

--- a/ftml/test/link-single-fail-newline.json
+++ b/ftml/test/link-single-fail-newline.json
@@ -16,7 +16,7 @@
                             "data": {
                                 "url": "https://example.com/",
                                 "label": "url",
-                                "anchor": "same"
+                                "target": "same"
                             }
                         },
                         {

--- a/ftml/test/link-single-new-tab.json
+++ b/ftml/test/link-single-new-tab.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Sandbox: Recent Changes"
                                 },
-                                "anchor": "new-tab"
+                                "target": "new-tab"
                             }
                         }
                     ]

--- a/ftml/test/link-single-url.json
+++ b/ftml/test/link-single-url.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some page"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-single.json
+++ b/ftml/test/link-single.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some link"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         },
                         {

--- a/ftml/test/link-triple-label-new-tab.json
+++ b/ftml/test/link-triple-label-new-tab.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Label"
                                 },
-                                "anchor": "new-tab"
+                                "target": "new-tab"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-label.json
+++ b/ftml/test/link-triple-label.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "My label"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-new-tab.json
+++ b/ftml/test/link-triple-new-tab.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "SCP-001",
                                 "label": "url",
-                                "anchor": "new-tab"
+                                "target": "new-tab"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-title-new-tab.json
+++ b/ftml/test/link-triple-title-new-tab.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "some-page",
                                 "label": "page",
-                                "anchor": "new-tab"
+                                "target": "new-tab"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-title.json
+++ b/ftml/test/link-triple-title.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "some-page",
                                 "label": "page",
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-url-whitespace.json
+++ b/ftml/test/link-triple-url-whitespace.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Example"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-url.json
+++ b/ftml/test/link-triple-url.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Example"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-whitespace-new-tab.json
+++ b/ftml/test/link-triple-whitespace-new-tab.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "My label"
                                 },
-                                "anchor": "new-tab"
+                                "target": "new-tab"
                             }
                         }
                     ]

--- a/ftml/test/link-triple-whitespace.json
+++ b/ftml/test/link-triple-whitespace.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "My label"
                                 },
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-triple.json
+++ b/ftml/test/link-triple.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "SCP-001",
                                 "label": "url",
-                                "anchor": "same"
+                                "target": "same"
                             }
                         }
                     ]

--- a/ftml/test/link-url.json
+++ b/ftml/test/link-url.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "https://example.com/directory",
                                 "label": "url",
-                                "anchor": "same"
+                                "target": "same"
                             }
                         },
                         {


### PR DESCRIPTION
Adds `[[a]]` (aliased to `[[anchor]]`) which allows creating HTML `<a>` tags.

Also renames `anchor` -> `target` for consistency with naming of the new block.