### PR TITLE
Update channel before pulling igbinary

### DIFF
--- a/install/php-fpm/setup-memcached.sh
+++ b/install/php-fpm/setup-memcached.sh
@@ -22,6 +22,7 @@ apk add \
 		cyrus-sasl-dev
 
 # Install igbinary (memcached's deps)
+pecl channel-update pecl.php.net
 pecl install igbinary
 
 # Install memcached


### PR DESCRIPTION
A user was having issues creating a local Wikijump instance via docker-compose, because this source repository needed updating. It seems to be inconsistent across users, but we may as well ensure it's up-to-date in the install script.