### PR TITLE
Fix Rust build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   </a>
 
   <a href="https://github.com/scpwiki/wikijump/actions?query=workflow%3A%22%5Bftml%5D+Rust%22">
-    <img src="https://github.com/scpwiki/wikijump/workflows/%5Bftml%5D+Rust/badge.svg"
+    <img src="https://github.com/scpwiki/wikijump/workflows/%5Bftml%5D%20Rust/badge.svg"
          alt="Build status">
   </a>
 </p>


### PR DESCRIPTION
The URL for the Rust badge was pointing to a nonexistent image. It's not anymore.