### PR TITLE
[FTML-77] Add the [[size]] block

### DIFF
--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -22,6 +22,7 @@ name = "ftml"
 cfg-if = "1"
 enum-map = "0.6"
 lazy_static = "1"
+maplit = "1"
 pest = "2"
 pest_derive = "2"
 ref-map = "0.1"
@@ -38,5 +39,4 @@ void = "1"
 wikidot-normalize = "0.6"
 
 [dev-dependencies]
-maplit = "1"
 sloggers = "1"

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -37,6 +37,9 @@ extern crate enum_map;
 
 #[macro_use]
 extern crate lazy_static;
+
+#[macro_use]
+extern crate maplit;
 extern crate pest;
 
 #[macro_use]
@@ -61,8 +64,6 @@ extern crate wikidot_normalize;
 
 cfg_if! {
     if #[cfg(test)] {
-        #[macro_use]
-        extern crate maplit;
         extern crate sloggers;
     }
 }

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -235,8 +235,6 @@ impl<'r, 't> Parser<'r, 't> {
                 self.remaining = remaining;
                 Ok(current)
             }
-
-            #[cold]
             None => Err(self.make_warn(ParseWarningKind::EndOfInput)),
         }
     }

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -75,6 +75,7 @@ mod lines;
 mod mark;
 mod module;
 mod radio;
+mod size;
 mod span;
 
 pub use self::anchor::BLOCK_ANCHOR;
@@ -95,4 +96,5 @@ pub use self::lines::BLOCK_LINES;
 pub use self::mark::BLOCK_MARK;
 pub use self::module::BLOCK_MODULE;
 pub use self::radio::BLOCK_RADIO;
+pub use self::size::BLOCK_SIZE;
 pub use self::span::BLOCK_SPAN;

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -1,0 +1,67 @@
+/*
+ * parsing/rule/impls/block/blocks/size.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use std::borrow::Cow;
+
+pub const BLOCK_SIZE: BlockRule = BlockRule {
+    name: "block-size",
+    accepts_names: &["size"],
+    accepts_special: false,
+    accepts_newlines: false,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Elements<'t>> {
+    debug!(
+        log,
+        "Parsing size block";
+        "in-head" => in_head,
+        "name" => name,
+    );
+
+    assert_eq!(special, false, "Size doesn't allow special variant");
+    assert_block_name(&BLOCK_SIZE, name);
+
+    let size =
+        parser.get_head_value(&BLOCK_SIZE, in_head, |parser, value| match value {
+            Some(size) => Ok(format!("font-size: {};", size)),
+            None => Err(parser.make_warn(ParseWarningKind::BlockMissingArguments)),
+        })?;
+
+    // Get body content, without paragraphs
+    let (elements, exceptions) = parser.get_body_elements(&BLOCK_SIZE, false)?.into();
+
+    let element = Element::StyledContainer(StyledContainer::new(
+        StyledContainerType::Size,
+        elements,
+        hashmap! {
+            Cow::Borrowed("style") => Cow::Owned(size),
+        },
+    ));
+
+    ok!(element, exceptions)
+}

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -22,7 +22,7 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 19] = [
+pub const BLOCK_RULES: [BlockRule; 20] = [
     BLOCK_ANCHOR,
     BLOCK_BLOCKQUOTE,
     BLOCK_CHECKBOX,
@@ -41,6 +41,7 @@ pub const BLOCK_RULES: [BlockRule; 19] = [
     BLOCK_MARK,
     BLOCK_MODULE,
     BLOCK_RADIO,
+    BLOCK_SIZE,
     BLOCK_SPAN,
 ];
 

--- a/ftml/src/parsing/token/mod.rs
+++ b/ftml/src/parsing/token/mod.rs
@@ -21,15 +21,22 @@
 #[cfg(test)]
 mod test;
 
+mod lexer {
+    // Since pest makes enums automatically that clippy doesn't like
+    #![allow(clippy::upper_case_acronyms)]
+
+    // The actual parser definition, which we will re-export
+    #[derive(Parser, Debug)]
+    #[grammar = "parsing/lexer.pest"]
+    pub struct TokenLexer;
+}
+
+use self::lexer::*;
 use crate::span_wrap::SpanWrap;
 use pest::iterators::Pair;
 use pest::Parser;
 use std::ops::Range;
 use strum_macros::IntoStaticStr;
-
-#[derive(Parser, Debug)]
-#[grammar = "parsing/lexer.pest"]
-struct TokenLexer;
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct ExtractedToken<'a> {

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -168,6 +168,7 @@ pub enum StyledContainerType {
     Deletion,
     Hidden,
     Invisible,
+    Size,
 }
 
 impl StyledContainerType {
@@ -187,6 +188,7 @@ impl StyledContainerType {
             StyledContainerType::Deletion => ("del", None),
             StyledContainerType::Hidden => ("span", Some("hidden")),
             StyledContainerType::Invisible => ("span", Some("invisible")),
+            StyledContainerType::Size => ("span", None),
         }
     }
 }

--- a/ftml/test/size-fail.json
+++ b/ftml/test/size-fail.json
@@ -1,0 +1,85 @@
+{
+    "input": "[[size 12pt]]Durian[[/sz]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "size"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "12pt"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        },
+                        {
+                            "element": "text",
+                            "data": "Durian"
+                        },
+                        {
+                            "element": "text",
+                            "data": "[[/"
+                        },
+                        {
+                            "element": "text",
+                            "data": "sz"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+        {
+            "token": "input-end",
+            "rule": "block-size",
+            "span": [26, 26],
+            "kind": "end-of-input"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [11, 13],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "left-block-end",
+            "rule": "fallback",
+            "span": [19, 22],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [24, 26],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/ftml/test/size-symbol.json
+++ b/ftml/test/size-symbol.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[size 90%]]Apple[[/size]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "size",
+                                "attributes": {
+                                    "style": "font-size: 90%;"
+                                },
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/size-vh.json
+++ b/ftml/test/size-vh.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[size 2vh]]Apple[[/size]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "size",
+                                "attributes": {
+                                    "style": "font-size: 2vh;"
+                                },
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/size.json
+++ b/ftml/test/size.json
@@ -1,0 +1,34 @@
+{
+    "input": "[[size 12pt]]Apple[[/size]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "styled-container",
+                            "data": {
+                                "type": "size",
+                                "attributes": {
+                                    "style": "font-size: 12pt;"
+                                },
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "Apple"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
This adds the `[[size]]` block, which takes its parameter as a CSS font size, and is passed into element's attributes.

There are also changes to resolve new lints that appear in the latest version of clippy.