### PR TITLE
[FTML-79] Strip off category in triple-bracket links

### DIFF
--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -218,7 +218,7 @@ fn test_strip_category() {
 
             assert_eq!(
                 actual, $expected,
-                "Actual stripped URL label doesn't match expected"
+                "Actual stripped URL label doesn't match expected",
             );
         }};
     }

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -213,7 +213,7 @@ fn strip_category(url: &str) -> Option<&str> {
 #[test]
 fn test_strip_category() {
     macro_rules! check {
-        ($input:expr, $expected:expr) => {{
+        ($input:expr, $expected:expr $(,)?) => {{
             let actual = strip_category($input);
 
             assert_eq!(
@@ -234,10 +234,10 @@ fn test_strip_category() {
     check!("component: Fancy Sidebar", Some("Fancy Sidebar"));
     check!(
         "multiple:categories:here:test",
-        Some("categories:here:test")
+        Some("categories:here:test"),
     );
     check!(
         "multiple: categories: here: test",
-        Some("categories: here: test")
+        Some("categories: here: test"),
     );
 }

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -201,12 +201,30 @@ fn build_separate<'p, 'r, 't>(
 /// For instance, `theme: Sigma-9` becomes just `Sigma-9`.
 fn strip_category(url: &str) -> &str {
     match url.find(':') {
-        Some(idx) => &url[idx..].trim_start(),
+        Some(idx) => &url[idx+1..].trim_start(),
         None => url,
     }
 }
 
 #[test]
 fn test_strip_category() {
-    todo!();
+    macro_rules! check {
+        ($input:expr, $expected:expr) => {{
+            let actual = strip_category($input);
+
+            assert_eq!(actual, $expected, "Actual stripped URL label doesn't match expected");
+        }};
+    }
+
+    check!("", "");
+    check!("scp-001", "scp-001");
+    check!("Guide Hub", "Guide Hub");
+    check!("theme:just-girly-things", "just-girly-things");
+    check!("theme: just-girly-things", "just-girly-things");
+    check!("theme: Just Girly Things", "Just Girly Things");
+    check!("component:fancy-sidebar", "fancy-sidebar");
+    check!("component:Fancy Sidebar", "Fancy Sidebar");
+    check!("component: Fancy Sidebar", "Fancy Sidebar");
+    check!("multiple:categories:here:test", "categories:here:test");
+    check!("multiple: categories: here: test", "categories: here: test");
 }

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -129,9 +129,10 @@ fn build_same<'p, 'r, 't>(
         "url" => url,
     );
 
+    let label = cow!(strip_category(url));
     let element = Element::Link {
         url: cow!(url),
-        label: LinkLabel::Url,
+        label: LinkLabel::Url(label),
         target,
     };
 
@@ -192,4 +193,20 @@ fn build_separate<'p, 'r, 't>(
 
     // Return result
     ok!(element)
+}
+
+/// Strip off the category for use in URL triple-bracket links.
+///
+/// The label for a URL link is its URL, but without its category.
+/// For instance, `theme: Sigma-9` becomes just `Sigma-9`.
+fn strip_category(url: &str) -> &str {
+    match url.find(':') {
+        Some(idx) => &url[idx..].trim_start(),
+        None => url,
+    }
+}
+
+#[test]
+fn test_strip_category() {
+    todo!();
 }

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -32,9 +32,10 @@ fn try_consume_fn<'p, 'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as a URL");
 
+    let url = parser.current().slice;
     let element = Element::Link {
-        url: cow!(parser.current().slice),
-        label: LinkLabel::Url,
+        url: cow!(url),
+        label: LinkLabel::Url(cow!(url)),
         target: AnchorTarget::Same,
     };
 

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -32,10 +32,9 @@ fn try_consume_fn<'p, 'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as a URL");
 
-    let url = parser.current().slice;
     let element = Element::Link {
-        url: cow!(url),
-        label: LinkLabel::Url(cow!(url)),
+        url: cow!(parser.current().slice),
+        label: LinkLabel::Url(None),
         target: AnchorTarget::Same,
     };
 

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -30,8 +30,8 @@ pub enum LinkLabel<'a> {
 
     /// URL-mirroring link label.
     ///
-    /// The label for this link is the same as the URL it targets.
-    Url,
+    /// The label for this link is a subslice of the URL it targets.
+    Url(Cow<'a, str>),
 
     /// Article title-based link label.
     ///

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -30,8 +30,9 @@ pub enum LinkLabel<'a> {
 
     /// URL-mirroring link label.
     ///
-    /// The label for this link is a subslice of the URL it targets.
-    Url(Cow<'a, str>),
+    /// If `None`, then the label for this link is the same as the URL.
+    /// If `Some(_)`, then the label is a subslice of the URL it targets.
+    Url(Option<Cow<'a, str>>),
 
     /// Article title-based link label.
     ///

--- a/ftml/test/iframe-fail.json
+++ b/ftml/test/iframe-fail.json
@@ -23,7 +23,9 @@
                             "element": "link",
                             "data": {
                                 "url": "https://example.com",
-                                "label": "url",
+                                "label": {
+                                    "url": null
+                                },
                                 "target": "same"
                             }
                         }

--- a/ftml/test/link-single-fail-newline.json
+++ b/ftml/test/link-single-fail-newline.json
@@ -15,7 +15,9 @@
                             "element": "link",
                             "data": {
                                 "url": "https://example.com/",
-                                "label": "url",
+                                "label": {
+                                    "url": null
+                                },
                                 "target": "same"
                             }
                         },

--- a/ftml/test/link-triple-category-new-tab.json
+++ b/ftml/test/link-triple-category-new-tab.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[[*system:Recent Pages]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "url": "system:Recent Pages",
+                                "label": {
+                                    "url": "Recent Pages"
+                                },
+                                "target": "new-tab"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-category-spaces.json
+++ b/ftml/test/link-triple-category-spaces.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[[system: Recent Pages]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "url": "system: Recent Pages",
+                                "label": {
+                                    "url": "Recent Pages"
+                                },
+                                "target": "same"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-category.json
+++ b/ftml/test/link-triple-category.json
@@ -1,0 +1,29 @@
+{
+    "input": "[[[system:Recent Pages]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "url": "system:Recent Pages",
+                                "label": {
+                                    "url": "Recent Pages"
+                                },
+                                "target": "same"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-new-tab.json
+++ b/ftml/test/link-triple-new-tab.json
@@ -11,7 +11,9 @@
                             "element": "link",
                             "data": {
                                 "url": "SCP-001",
-                                "label": "url",
+                                "label": {
+                                    "url": null
+                                },
                                 "target": "new-tab"
                             }
                         }

--- a/ftml/test/link-triple.json
+++ b/ftml/test/link-triple.json
@@ -11,7 +11,9 @@
                             "element": "link",
                             "data": {
                                 "url": "SCP-001",
-                                "label": "url",
+                                "label": {
+                                    "url": null
+                                },
                                 "target": "same"
                             }
                         }

--- a/ftml/test/link-url.json
+++ b/ftml/test/link-url.json
@@ -11,7 +11,9 @@
                             "element": "link",
                             "data": {
                                 "url": "https://example.com/directory",
-                                "label": "url",
+                                "label": {
+                                    "url": null
+                                },
                                 "target": "same"
                             }
                         },


### PR DESCRIPTION
As demonstrated [here](http://scptestwiki.wikidot.com/triple-link-categories), triple-bracket links remove the category to make it more convenient to specify pages outside of `_default`:
![image](https://user-images.githubusercontent.com/8848022/107839127-c1822600-6d77-11eb-8e70-05e0b004b380.png)

This PR adds this functionality to ftml, changing the type of `LinkLabel::Url` from unit to `Option<Cow<str>>` (the null case being the original use, if the URL is the same as the label), and a helper function `strip_category()` which produces a slice without the category.

This is verified with a test for `strip_category()` and AST tests for the new behavior.