### PR TITLE
Bump ftml version to v0.5.0

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -1462,7 +1462,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -1483,7 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -1519,14 +1519,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if 1.0.0",
  "enum-map",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "ftml-http"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "built",
  "clap",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ftml"
 description = "Foundation Text Markup Language - a library to render Wikidot text as HTML"
-repository = "https://github.com/Nu-SCPTheme/ftml"
+repository = "https://github.com/scpwiki/wikijump/tree/develop/ftml"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]

--- a/ftml/ftml-http/Cargo.toml
+++ b/ftml/ftml-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ftml-http"
 description = "Foundation Text Markup Language - server to render Wikidot text as HTML"
-repository = "https://github.com/Nu-SCPTheme/ftml"
+repository = "https://github.com/scpwiki/wikijump/tree/develop/ftml/ftml-http"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]

--- a/ftml/ftml-http/Cargo.toml
+++ b/ftml/ftml-http/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore"]
 
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 


### PR DESCRIPTION
It's been a while since v0.4.0, we should increment the version number. Also fixes the repository link.