### PR TITLE
[WJ-387] Disallow logging in via user ID

### DIFF
--- a/web/php/actions/Login2Action.php
+++ b/web/php/actions/Login2Action.php
@@ -20,7 +20,7 @@ class Login2Action extends SmartyAction
         $keepLogged = $pl->getParameterValue("keepLogged");
         $bindIP = $pl->getParameterValue("bindIP");
 
-        // Auth via username.
+        // Auth via username or email.
         $sm = new SecurityManager();
         $user = $sm->authenticateUser($uname, $upass);
         if (!$user) {

--- a/web/php/actions/Login2Action.php
+++ b/web/php/actions/Login2Action.php
@@ -20,24 +20,12 @@ class Login2Action extends SmartyAction
         $keepLogged = $pl->getParameterValue("keepLogged");
         $bindIP = $pl->getParameterValue("bindIP");
 
-        // decrypt! woooohhooooo!!!!!!!!
-
-
-        if ($userId && is_numeric($userId) && $userId >0) {
-            $user = OzoneUserPeer::instance()->selectByPrimaryKey($userId);
-            if ($user == null or password_verify($upass, $user->getPassword()) == false) {
-                $user = null;
-                EventLogger::instance()->logFailedLogin($uname);
-                throw new ProcessException(_("The login and password do not match."), "login_invalid");
-            }
-        } else {
-            // Auth via username.
-            $sm = new SecurityManager();
-            $user = $sm->authenticateUser($uname, $upass);
-            if (!$user) {
-                EventLogger::instance()->logFailedLogin($uname);
-                throw new ProcessException(_("The login and password do not match."), "login_invalid");
-            }
+        // Auth via username.
+        $sm = new SecurityManager();
+        $user = $sm->authenticateUser($uname, $upass);
+        if (!$user) {
+            EventLogger::instance()->logFailedLogin($uname);
+            throw new ProcessException(_("The login and password do not match."), "login_invalid");
         }
 
         $originalUrl = $runData->sessionGet('loginOriginalUrl');


### PR DESCRIPTION
Wikijump apparently allowed people to log in via user ID, a value most people do not know, and a behavior not reflected in mainline Wikidot. As such, it has been removed.

I am not adding a DEADCODE entry because it just used existing code mechanisms to implement this.