### PR TITLE
Set AnchorTarget optionally if it's not overwriting

### DIFF
--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -55,9 +55,9 @@ fn parse_fn<'r, 't>(
 
     // Get anchor target depending on special
     let target = if special {
-        AnchorTarget::NewTab
+        Some(AnchorTarget::NewTab)
     } else {
-        AnchorTarget::Same
+        None
     };
 
     // Get body content, without paragraphs

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -24,7 +24,7 @@
 //! or is a fake link.
 
 use super::prelude::*;
-use crate::tree::{AnchorTarget, LinkLabel};
+use crate::tree::LinkLabel;
 use std::borrow::Cow;
 use wikidot_normalize::normalize;
 
@@ -93,7 +93,7 @@ fn try_consume_fn<'p, 'r, 't>(
     let element = Element::Link {
         url,
         label: LinkLabel::Text(cow!(label)),
-        target: AnchorTarget::Same,
+        target: None,
     };
 
     // Return result

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -45,7 +45,7 @@ fn link<'p, 'r, 't>(
 
     check_step(parser, Token::LeftBracket)?;
 
-    try_consume_link(log, parser, RULE_LINK_SINGLE, AnchorTarget::Same)
+    try_consume_link(log, parser, RULE_LINK_SINGLE, None)
 }
 
 fn link_new_tab<'p, 'r, 't>(
@@ -56,7 +56,12 @@ fn link_new_tab<'p, 'r, 't>(
 
     check_step(parser, Token::LeftBracketSpecial)?;
 
-    try_consume_link(log, parser, RULE_LINK_SINGLE_NEW_TAB, AnchorTarget::NewTab)
+    try_consume_link(
+        log,
+        parser,
+        RULE_LINK_SINGLE_NEW_TAB,
+        Some(AnchorTarget::NewTab),
+    )
 }
 
 /// Build a single-bracket link with the given target.
@@ -64,9 +69,13 @@ fn try_consume_link<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
-    target: AnchorTarget,
+    target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create a single-bracket link"; "target" => target.name());
+    debug!(
+        log,
+        "Trying to create a single-bracket link";
+        "target" => target.map(|t| t.name()),
+    );
 
     // Gather path for link
     let url = collect_text(

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -50,7 +50,7 @@ fn link<'p, 'r, 't>(
 
     check_step(parser, Token::LeftLink)?;
 
-    try_consume_link(log, parser, RULE_LINK_TRIPLE, AnchorTarget::Same)
+    try_consume_link(log, parser, RULE_LINK_TRIPLE, None)
 }
 
 fn link_new_tab<'p, 'r, 't>(
@@ -61,7 +61,12 @@ fn link_new_tab<'p, 'r, 't>(
 
     check_step(parser, Token::LeftLinkSpecial)?;
 
-    try_consume_link(log, parser, RULE_LINK_TRIPLE_NEW_TAB, AnchorTarget::NewTab)
+    try_consume_link(
+        log,
+        parser,
+        RULE_LINK_TRIPLE_NEW_TAB,
+        Some(AnchorTarget::NewTab),
+    )
 }
 
 /// Build a triple-bracket link with the given target.
@@ -69,9 +74,13 @@ fn try_consume_link<'p, 'r, 't>(
     log: &slog::Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
-    target: AnchorTarget,
+    target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create a triple-bracket link"; "target" => target.name());
+    debug!(
+        log,
+        "Trying to create a triple-bracket link";
+        "target" => target.map(|t| t.name()),
+    );
 
     // Gather path for link
     let (url, last) = collect_text_keep(
@@ -122,7 +131,7 @@ fn build_same<'p, 'r, 't>(
     log: &slog::Logger,
     _parser: &'p mut Parser<'r, 't>,
     url: &'t str,
-    target: AnchorTarget,
+    target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
         log,
@@ -150,7 +159,7 @@ fn build_separate<'p, 'r, 't>(
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     url: &'t str,
-    target: AnchorTarget,
+    target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
         log,

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::tree::{AnchorTarget, LinkLabel};
+use crate::tree::LinkLabel;
 
 pub const RULE_URL: Rule = Rule {
     name: "url",
@@ -35,7 +35,7 @@ fn try_consume_fn<'p, 'r, 't>(
     let element = Element::Link {
         url: cow!(parser.current().slice),
         label: LinkLabel::Url(None),
-        target: AnchorTarget::Same,
+        target: None,
     };
 
     ok!(element)

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -70,7 +70,7 @@ pub enum Element<'t> {
     Anchor {
         elements: Vec<Element<'t>>,
         attributes: AttributeMap<'t>,
-        target: AnchorTarget,
+        target: Option<AnchorTarget>,
     },
 
     /// An element linking to a different page.
@@ -82,7 +82,7 @@ pub enum Element<'t> {
     Link {
         url: Cow<'t, str>,
         label: LinkLabel<'t>,
-        target: AnchorTarget,
+        target: Option<AnchorTarget>,
     },
 
     /// An ordered or unordered list.

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -73,13 +73,6 @@ pub enum Element<'t> {
         target: AnchorTarget,
     },
 
-    /// An ordered or unordered list.
-    List {
-        #[serde(rename = "type")]
-        ltype: ListType,
-        items: Vec<ListItem<'t>>,
-    },
-
     /// An element linking to a different page.
     ///
     /// The "label" field is an optional field denoting what the link should
@@ -90,6 +83,13 @@ pub enum Element<'t> {
         url: Cow<'t, str>,
         label: LinkLabel<'t>,
         target: AnchorTarget,
+    },
+
+    /// An ordered or unordered list.
+    List {
+        #[serde(rename = "type")]
+        ltype: ListType,
+        items: Vec<ListItem<'t>>,
     },
 
     /// A radio button.
@@ -171,8 +171,8 @@ impl Element<'_> {
             Element::Raw(_) => "Raw",
             Element::Email(_) => "Email",
             Element::Anchor { .. } => "Anchor",
-            Element::List { .. } => "List",
             Element::Link { .. } => "Link",
+            Element::List { .. } => "List",
             Element::RadioButton { .. } => "RadioButton",
             Element::CheckBox { .. } => "CheckBox",
             Element::Collapsible { .. } => "Collapsible",

--- a/ftml/test/anchor-alias-wrap.json
+++ b/ftml/test/anchor-alias-wrap.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor-alias.json
+++ b/ftml/test/anchor-alias.json
@@ -13,7 +13,7 @@
                                 "attributes": {
                                     "href": "/some-page"
                                 },
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor-empty.json
+++ b/ftml/test/anchor-empty.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/anchor-wrap.json
+++ b/ftml/test/anchor-wrap.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor.json
+++ b/ftml/test/anchor.json
@@ -13,7 +13,7 @@
                                 "attributes": {
                                     "href": "/some-page"
                                 },
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-alias-wrap.json
+++ b/ftml/test/anchor2-alias-wrap.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-alias.json
+++ b/ftml/test/anchor2-alias.json
@@ -13,7 +13,7 @@
                                 "attributes": {
                                     "href": "/some-page"
                                 },
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-empty.json
+++ b/ftml/test/anchor2-empty.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                 ]
                             }

--- a/ftml/test/anchor2-newlines-2.json
+++ b/ftml/test/anchor2-newlines-2.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-newlines.json
+++ b/ftml/test/anchor2-newlines.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-paragraph.json
+++ b/ftml/test/anchor2-paragraph.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2-wrap.json
+++ b/ftml/test/anchor2-wrap.json
@@ -11,7 +11,7 @@
                             "element": "anchor",
                             "data": {
                                 "attributes": {},
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/anchor2.json
+++ b/ftml/test/anchor2.json
@@ -13,7 +13,7 @@
                                 "attributes": {
                                     "href": "/some-page"
                                 },
-                                "target": "same",
+                                "target": null,
                                 "elements": [
                                     {
                                         "element": "text",

--- a/ftml/test/iframe-fail.json
+++ b/ftml/test/iframe-fail.json
@@ -26,7 +26,7 @@
                                 "label": {
                                     "url": null
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-anchor-fake.json
+++ b/ftml/test/link-anchor-fake.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Fake link"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-anchor.json
+++ b/ftml/test/link-anchor.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some link"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         },
                         {

--- a/ftml/test/link-single-fail-newline.json
+++ b/ftml/test/link-single-fail-newline.json
@@ -18,7 +18,7 @@
                                 "label": {
                                     "url": null
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         },
                         {

--- a/ftml/test/link-single-url.json
+++ b/ftml/test/link-single-url.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some page"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-single.json
+++ b/ftml/test/link-single.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Some link"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         },
                         {

--- a/ftml/test/link-triple-category-spaces.json
+++ b/ftml/test/link-triple-category-spaces.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "url": "Recent Pages"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-category.json
+++ b/ftml/test/link-triple-category.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "url": "Recent Pages"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-label.json
+++ b/ftml/test/link-triple-label.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "My label"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-title.json
+++ b/ftml/test/link-triple-title.json
@@ -12,7 +12,7 @@
                             "data": {
                                 "url": "some-page",
                                 "label": "page",
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-url-whitespace.json
+++ b/ftml/test/link-triple-url-whitespace.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Example"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-url.json
+++ b/ftml/test/link-triple-url.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "Example"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple-whitespace.json
+++ b/ftml/test/link-triple-whitespace.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "text": "My label"
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-triple.json
+++ b/ftml/test/link-triple.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "url": null
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         }
                     ]

--- a/ftml/test/link-url.json
+++ b/ftml/test/link-url.json
@@ -14,7 +14,7 @@
                                 "label": {
                                     "url": null
                                 },
-                                "target": "same"
+                                "target": null
                             }
                         },
                         {


### PR DESCRIPTION
As [discussed here](https://github.com/scpwiki/wikijump/pull/123#discussion_r590018307), we want a renderer to know whether to override an anchor target or just leave it to carry the default. We accomplish this by making the field `Option<AnchorTarget>` instead of `AnchorTarget`. This PR also edits all AST tests to comply with the change.