### PR TITLE
Add new relative links to github action to build and push php-fpm

### DIFF
--- a/.github/workflows/docker-build-push-php.dev.yaml
+++ b/.github/workflows/docker-build-push-php.dev.yaml
@@ -6,7 +6,7 @@ on:
       - develop
     paths:
       - 'web/**'
-      - 'install/php-fpm/**'
+      - 'install/aws/dev/docker/php-fpm/**'
       - '.github/workflows/docker-build-push-php.dev.yml'
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
           uses: aws-actions/amazon-ecr-login@v1
         - name: Build, tag, and push image to Amazon ECR
           id: build-image
-          working-directory: ./install/php-fpm
+          working-directory: ./install/aws/dev/docker/php-fpm
           env:
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
             ECR_REPOSITORY: wikijump-dev/php-fpm


### PR DESCRIPTION
Broken with #92, this correctly sets the working dir for GH Actions.