### PR TITLE
Add component and theme to glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -28,3 +28,5 @@ Definitions are not intended to be exhaustive, but rather quickly summarize what
 | Forum category |              | Forum       | A namespace that a collection of forum threads may exist in. They may be visible or not, and have an associated name. |
 | Forum thread   |              | Thread      | A thread of conversation within a particular category, containing zero or more posts. They are either created by a user or by Wikijump. |
 | Forum post     |              | Post        | An individual message sent within a thread. It can be a child or reply to another post, or top-level. These are only created by users. |
+| Component      | Cross-site include (CSI) package | | A page intended to be included on other pages to provide a custom element. |
+| Theme          | Cross-site include (CSI) package | | A page intended to be included on other pages to provide custom styling to change the page's look and feel. |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -29,4 +29,4 @@ Definitions are not intended to be exhaustive, but rather quickly summarize what
 | Forum thread   |              | Thread      | A thread of conversation within a particular category, containing zero or more posts. They are either created by a user or by Wikijump. |
 | Forum post     |              | Post        | An individual message sent within a thread. It can be a child or reply to another post, or top-level. These are only created by users. |
 | Component      | Cross-site include (CSI) package | | A page intended to be included on other pages to provide a custom element. |
-| Theme          | Cross-site include (CSI) package | | A page intended to be included on other pages to provide custom styling to change the page's look and feel. |
+| Theme          | Cross-site include (CSI) package | | A page intended to be included on other pages to provide custom styling that changes the page's look and feel. |


### PR DESCRIPTION
Thanks to @rossjrw, apparently Wikidot conflates components and themes and instead has a strange name for them:

> The CSS module lets you insert CSS code into a wiki page. This is particularly useful for cross-site include (CSI) packages that need to use custom styling for their code. When you use the CSS module in a CSI, that CSS code will be included in all pages that use the CSI.

We won't be using this terminology in Wikijump, but it's good to know what Wikidot calls them.