### PR TITLE
[FTML-86] Add documentation describing supported ftml blocks and modules.

### DIFF
--- a/ftml/README.md
+++ b/ftml/README.md
@@ -56,6 +56,13 @@ SCP Foundation formatting as mentioned in [Kate McTiriss's Proposal](http://www.
 While the expanded form of the initialism is never explicitly stated, it is clearly implied given the
 name similarity to HTML.
 
+### Syntax
+ftml is intended to be compatible with a subset of Wikidot text deemed to be "well-formed". Wikidot's general syntax documentation will be relevant here, but weird constructions or strange features may not be. During the development process, they are analyzed and either explicitly unimplemented, or implemented through more sensible syntax.
+
+As ftml develops into its own branch of wikitext, pages here will document the syntax separately from Wikidot, with the goal of deprecating Wikidot's documentation entirely.
+
+* [`Blocks.md`](docs/Blocks.md) -- Which blocks (e.g. `[[div]]`) are available in ftml and what options they take.
+
 ### Usage
 There are a couple main exported functions, which correspond to each of the main steps in the wikitext process.
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -10,7 +10,7 @@ Blocks have five variable properties worth noting:
 2. Their name may end in `_`. This is referred to as the "modifier" flag. This underscore is ignored if found in the tail.
 3. The block may have a number of arguments before ending in `]]`.
 4. The block may accept delimited newlines. This is explained in more detail below.
-5. The block may have a body. It has contents that is terminated by `[[/name]]` (where `name` is the block name).
+5. The block may have a body. It has contents that is terminated by `[[/name]]` (where `name` is the block name), referred to as the tail.
 
 Whether particular blocks accept these variables is noted in the table below. If a block does not permit that variance, then it will not parse. For instance, if a block does not permit special variance but a `*` is added anyways.
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -45,7 +45,25 @@ Banana
 
 ### Blocks
 
-(TODO)
+| Block Name  | Accepted Names        | Special? | Variant? | Newlines? | AST Output | HTML Output | Notes |
+|-------------|-----------------------|----------|----------|-----------|------------|-------------|-------|
+| Anchor      | `a`, `anchor`         | No       | Yes      | No        | `Element::Anchor` | `<a>` | Variant strips trailing and leading newlines from output. |
+| Blockquote  | `blockquote`, `quote` | No       | No       | Yes       | `Element::Container(Blockquote)` | `<blockquote>` | |
+| Bold        | `b`, `bold`, `strong` | No       | No       | No        | `Element::Container(Bold)` | `<strong>` | |
+| Checkbox    | `checkbox`            | Yes      | No       | No        | `Element::CheckBox` | `<input type="checkbox">` | If special is set, the checkbox begins checked. |
+| Code        | `code`                | No       | No       | Yes       | `Element::Code` | `<div class="code">` | |
+| Collapsible | `collapsible`         | No       | No       | Yes       | `Element::Collapsible` | `<div class="collapsible-block">` | |
+| CSS         | `css`                 | No       | No       | Yes       | - | `<style>` | Outputs contents as CSS. Alias for `[[module CSS]]`. |
+| Deletion    | `del`, `deletion`     | No       | No       | No        | `Element::Container(Deletion)` | `<del>` | |
+| Div         | `div`                 | No       | Yes      | Yes       | `Element::Container(Div)` | `<div>` | Variant strips trailing and leading newlines from output. |
+| Hidden      | `hidden`              | No       | No       | Yes       | `Element::Container(Hidden)` | `<span class="hidden">` | |
+| HTML        | `html`                | No       | No       | Yes       | `Element::Html` | `<iframe>` | Embeds this as an HTML snippet on `wjfiles.com`, hosted in an iframe. |
+| Iframe      | `iframe`              | No       | No       | Yes       | `Element::Iframe` | `<iframe>` |
+| Include     | `include`             | No       | No       | Yes       | - | - | Handled in the preprocessor. Includes the contents from the target page here, as if pasted in. |
+| Insertion   | `ins`, `insertion`    | No       | No       | No        | `Element::Container(Insertion)` | `<ins>` | |
+| Invisible   | `invisible`           | No       | No       | Yes       | `Element::Container(Invisible)` | `<span class="invisible">` |
+| Italics     | `i`, `italics`, `em`, `emphasis` | No | No | No         | `Element::Container(Italics)` | `<em>` | |
+| Lines       | `lines`, `newlines`   | No       | No       | Yes       | `Element::LineBreaks` | `<br>` | |
 
 ### Modules
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -97,7 +97,7 @@ Here is a table showing the options each block has with regards to its construct
 | Module      | `module`                         | No       | No        | Yes       | (See below)   | (See below) |
 | Monospace   | `tt`, `mono`, `monospace`        | No       | No        | No        | Map           | Elements  |
 | Radio       | `radio`, `radio-button`          | Yes      | No        | No        | Name + Map    | None      |
-| Size        | `size`                           | No       | No        | No        | Map           | Elements  |
+| Size        | `size`                           | No       | No        | No        | Value         | Elements  |
 | Span        | `span`                           | No       | Yes       | No        | Map           | Elements  |
 | Strikethrough | `s`, `strikethrough`           | No       | No        | No        | Map           | Elements  |
 | Subscript   | `sub`, `subscript`               | No       | No        | No        | Map           | Elements  |

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -509,6 +509,137 @@ This text is [[mark]]highlighted![[/mark]]
 [[tt]]This output looks like it came from a typewriter or computer terminal.[[/tt]]
 ```
 
+### Radio
+
+**Accepts variants:**
+* Special &emdash; Element starts selected
+
+**Abstract Syntax Tree Output:** `Element::RadioButton`
+
+**HTML Output:** `<input type="radio">`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+Favorite kind of music:
+
+[[radio]] Disco
+[[radio]] Dance
+[[radio]] Rap
+[[*radio]] Noise
+```
+
+### Size
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Size)`
+
+**HTML Output:** `<span style="font-size: XXX;">`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is regular, but [[size 250%]]this text is much larger[[/size]].
+```
+
+### Span
+
+**Accepts variants:**
+* Modifier &emdash; Strips leading and trailing newlines
+
+**Abstract Syntax Tree Output:** `Element::Span`
+
+**HTML Output:** `<span>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is in a span: [[span class="fruit"]]banana[[/span]]
+```
+
+### Strikethrough
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Strikethrough)`
+
+**HTML Output:** `<s>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is [[s]]struck through![[/s]]
+```
+
+### Subscript
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Subscript)`
+
+**HTML Output:** `<sub>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+Let this variable be called x[[sub]]A[[/sub]].
+```
+
+### Superscript
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Superscript)`
+
+**HTML Output:** `<sup>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+Thus, the result is n[[sup]]2[[/sup]].
+```
+
+### Underline
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Underline)`
+
+**HTML Output:** `<u>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+[[u]]Testing log 7192-45:[[/u]]
+```
+
 ## Modules
 
 The table below follows essentially the same schema as for blocks in general, with a few changes. [As noted above](#blocks), all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -149,7 +149,7 @@ Some text here.
 **Accepts variants:**
 * None
 
-**Abstract Syntax Tree Output:** `Element::Bold`
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Bold)`
 
 **HTML Output:** `<strong>`
 
@@ -246,6 +246,267 @@ Overseers die.
     color: purple;
 }
 [[/css]]
+```
+
+### Deletion
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Deletion)`
+
+**HTML Output:** `<del>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+I [[del]]don't[[/del]] like that haircut.
+```
+
+### Div
+
+**Accepts variants:**
+* Modifier &emdash; Strips leading and trailing newlines
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Div)`
+
+**HTML Output:** `<div>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+[[div_ class="blockquote" style="border: none;"]]
+Some text __here!__
+[[/div]]
+```
+
+### Hidden
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Hidden)`
+
+**HTML Output:** `<span class="hidden">`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is **visible**.
+
+[[hidden]]
+This text is not.
+[[/hidden]]
+```
+
+### HTML
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Html`
+
+**HTML Output:** `<iframe>`
+
+**Arguments:**
+* None
+
+**Example:**
+
+```
+[[html]]
+<h2>Exciting!</h2>
+
+<p>
+This HTML will appear in an iframe hosted on wjfiles!
+</p>
+[[/html]]
+```
+
+### Iframe
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Iframe`
+
+**HTML Output:** `<iframe>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+My website:
+
+[[iframe https://example.com/ class="website"]]
+```
+
+### Include
+
+This is not a typical block, as it is handled in the preprocessor. Parsing here is handled differently.
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** N/A
+
+**HTML Output:** N/A
+
+**Arguments:**
+* All arguments are passed as variables to the included page
+
+**Example:**
+
+```
+[[include theme:black-highlighter-theme]]
+
+[[include component:fancy-object-class
+    class=Keter |
+    classification=4 |
+    taskforce=MTF-Eta-10 ("See No Evil")
+]]
+```
+
+### Insertion
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Insertion)`
+
+**HTML Output:** `<ins>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+I would like some [[ins]]anchovy[[/ins]] pizza please, thank you.
+```
+
+### Invisible
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Invisible)`
+
+**HTML Output:** `<span class="invisible">`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text appears [[invisible]]but still takes up space, and can be selected.[[/invisible]]
+
+More correct and much more portable than setting the font color to "white".
+```
+
+### Italics
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Italics)`
+
+**HTML Output:** `<em>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is regular, but [[em]]this text is emphasized[[/em]].
+```
+
+### Lines
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::LineBreaks`
+
+**HTML Output:** `<br>`
+
+**Arguments:**
+* Value: positive integer &emdash; Number of line breaks to output
+
+**Example:**
+
+```
+[[newlines 4]]
+
+[!-- Much easier than spamming "@@@@"s --]
+```
+
+### Mark
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Mark)`
+
+**HTML Output:** `<mark>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+This text is [[mark]]highlighted![[/mark]]
+```
+
+### Modules
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** Depends on the module type
+
+**HTML Output:** Depends on the module type
+
+**Arguments:**
+* See documentation for specific modules
+
+**Example:**
+
+```
+[[module NameOfModuleHere someArgument="yes"]]
+```
+
+### Monospace
+
+**Accepts variants:**
+* None
+
+**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Monospace)`
+
+**HTML Output:** `<tt>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+[[tt]]This output looks like it came from a typewriter or computer terminal.[[/tt]]
 ```
 
 ## Modules

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -652,3 +652,5 @@ The table below follows essentially the same schema as for blocks in general, wi
 | Join         | `Module::Join`       | `<div class="join-box">`                  | |
 | PageTree     | `Module::PageTree`   | `<div class="pagetree-module-box"> <ul>`  | |
 | Rate         | `Module::Rate`       | `<div class="page-rate-widget-box">`      | |
+
+TODO: add individual doc sections for each module

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -11,7 +11,7 @@ How the bodies of a block are interpreted depend on its type. They fall into one
 | None            | `[[include]]` | Has no body. This block terminates at its head. |
 | Raw text        | `[[code]]`    | Interprets the entire block body as raw text. Syntax is not parsed. |
 | Nested elements | `[[div]]`     | Interprets block contents as elements in a certain context. These are then nested in the block. |
-| Other           |               | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
+| Other           | N/A           | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
 
 Of note that while `[[module]]` is its own block, it requires specifying a module name, and this behaves similarly to other blocks in that their attributes are determined by the module name.
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -109,7 +109,7 @@ Each of the blocks will be described in more detail below:
 ### Anchor
 
 **Accepts variants:**
-* Modifier &emdash; Strips leading and trailing newlines.
+* Modifier &mdash; Strips leading and trailing newlines.
 
 **Abstract Syntax Tree Output:** `Element::Anchor`
 
@@ -165,7 +165,7 @@ Some [[b]]text![[/b]]
 ### Checkbox
 
 **Accepts variants:**
-* Special &emdash; Element starts checked
+* Special &mdash; Element starts checked
 
 **Abstract Syntax Tree Output:** `Element::CheckBox`
 
@@ -193,7 +193,7 @@ Some [[b]]text![[/b]]
 **HTML Output:** `<div class="code">`
 
 **Arguments:**
-* `type` &emdash; What language this block is in, both for its Content-Type and syntax highlighting.
+* `type` &mdash; What language this block is in, both for its Content-Type and syntax highlighting.
 
 **Example:**
 
@@ -213,10 +213,10 @@ This text is **not** rendered as Wikitext, but output as-is!
 **HTML Output:** `<div class="collapsible-block">`
 
 **Arguments:**
-* `show` &emdash; The text to present when text is collapsed (i.e. can be shown)
-* `hide` &emdash; The text to present when text is expanded (i.e. can be hidden)
-* `folded` &emdash; Boolean. `true` means start collapsed (default), `false` means start expanded
-* `hideLocation` &emdash; One of `top`, `bottom`, `both`, or `neither`. Shows in what locations the hide collapsible link in.
+* `show` &mdash; The text to present when text is collapsed (i.e. can be shown)
+* `hide` &mdash; The text to present when text is expanded (i.e. can be hidden)
+* `folded` &mdash; Boolean. `true` means start collapsed (default), `false` means start expanded
+* `hideLocation` &mdash; One of `top`, `bottom`, `both`, or `neither`. Shows in what locations the hide collapsible link in.
 
 **Example:**
 
@@ -269,7 +269,7 @@ I [[del]]don't[[/del]] like that haircut.
 ### Div
 
 **Accepts variants:**
-* Modifier &emdash; Strips leading and trailing newlines
+* Modifier &mdash; Strips leading and trailing newlines
 * Newlines
 
 **Abstract Syntax Tree Output:** `Element::Container(ContainerType::Div)`
@@ -445,7 +445,7 @@ This text is regular, but [[em]]this text is emphasized[[/em]].
 **HTML Output:** `<br>`
 
 **Arguments:**
-* Value: positive integer &emdash; Number of line breaks to output
+* Value: positive integer &mdash; Number of line breaks to output
 
 **Example:**
 
@@ -512,7 +512,7 @@ This text is [[mark]]highlighted![[/mark]]
 ### Radio
 
 **Accepts variants:**
-* Special &emdash; Element starts selected
+* Special &mdash; Element starts selected
 
 **Abstract Syntax Tree Output:** `Element::RadioButton`
 
@@ -553,7 +553,7 @@ This text is regular, but [[size 250%]]this text is much larger[[/size]].
 ### Span
 
 **Accepts variants:**
-* Modifier &emdash; Strips leading and trailing newlines
+* Modifier &mdash; Strips leading and trailing newlines
 
 **Abstract Syntax Tree Output:** `Element::Span`
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -147,7 +147,7 @@ Some text here.
 ### Bold
 
 **Accepts variants:**
-* (none)
+* None
 
 **Abstract Syntax Tree Output:** `Element::Bold`
 
@@ -224,6 +224,28 @@ This text is **not** rendered as Wikitext, but output as-is!
 [[collapsible show="+ Spoilers for Ouroboros" hide="- Spoilers!" hideLocation="bottom"]]
 Overseers die.
 [[/collapsible]]
+```
+
+### CSS
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** None. Appends to list of styles.
+
+**HTML Output:** `<style>`
+
+**Arguments:**
+* None
+
+**Example:**
+
+```
+[[css]]
+#page-title {
+    color: purple;
+}
+[[/css]]
 ```
 
 ## Modules

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -18,12 +18,12 @@ Whether particular blocks accept these variables is noted in the table below. If
 
 Blocks may have one of the following approaches when parsing arguments:
 
-| Name             | Example block       | Description |
-|------------------|---------------------|-------------|
-| None             | `[[CSS]]`           | Accepts no arguments. Tokens which are not `]]` will result in parsing failure. |
-| Value            | `[[size 50%]]`      | All of the text until `]]` is interpreted as a single text value. |
-| Map              | `[[span id="abc"]]` | Accepts an arbitrary mapping of `key="value"` arguments. Values must be double-quoted, and may contain escapes (e.g. `\"`, `\n`). |
-| Name Map         | `[[iframe https://example.com/ style="width: 100%;"]]` | Accepts a single text value terminated by a space, then an arbitrary mapping as described above. |
+| Name             | Example block       | Method | Description |
+|------------------|---------------------|--------|-------------|
+| None             | `[[CSS]]`           | `BlockParser::get_head_none()` | Accepts no arguments. Tokens which are not `]]` will result in parsing failure. |
+| Value            | `[[size 50%]]`      | `BlockParser::get_head_value()` | All of the text until `]]` is interpreted as a single text value. |
+| Map              | `[[span id="abc"]]` | `BlockParser::get_head_map()` | Accepts an arbitrary mapping of `key="value"` arguments. Values must be double-quoted, and may contain escapes (e.g. `\"`, `\n`). |
+| Name Map         | `[[iframe https://example.com/ style="width: 100%;"]]` | `BlockParser::get_head_name_map()` | Accepts a single text value terminated by a space, then an arbitrary mapping as described above. |
 
 ### Newlines
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -25,6 +25,8 @@ Blocks may have one of the following approaches when parsing arguments:
 | Map              | `[[span id="abc"]]` | `BlockParser::get_head_map()` | Accepts an arbitrary mapping of `key="value"` arguments. Values must be double-quoted, and may contain escapes (e.g. `\"`, `\n`). |
 | Name + Map       | `[[iframe https://example.com/ style="width: 100%;"]]` | `BlockParser::get_head_name_map()` | Accepts a single text value terminated by a space, then an arbitrary mapping as described above. |
 
+Like block names, argument keys are case-insensitive.
+
 ### Newlines
 
 Blocks may accept deliminated newlines. While these blocks can be used inline, separating them on their own lines will not produce line breaks. For instance:

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -65,7 +65,7 @@ Banana
 | Italics     | `i`, `italics`, `em`, `emphasis` | No | No | No         | `Element::Container(Italics)` | `<em>` | |
 | Lines       | `lines`, `newlines`   | No       | No       | Yes       | `Element::LineBreaks` | `<br>` | |
 | Mark        | `mark`, `highlight`   | No       | No       | No        | `Element::Container(Mark)` | `<mark>` | |
-| Module      | `module`              | No       | No       | Yes       | - | - | See section below on modules. |
+| Module      | `module`              | No       | No       | Yes       | - | - | See [section below](#modules) on modules. |
 | Monospace   | `tt`, `mono`, `monospace` | No   | No       | No        | `Element::Container(Monospace)` | `<tt>` | |
 | Radio       | `radio`, `radio-button` | Yes    | No       | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
 | Size        | `size`                | No       | No       | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
@@ -77,7 +77,7 @@ Banana
 
 ### Modules
 
-The table below follows essentially the same schema as for blocks in general, with a few changes. As noted above, all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).
+The table below follows essentially the same schema as for blocks in general, with a few changes. [As noted above](#blocks), all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).
 
 | Module Name  | AST Output           | HTML Output                               | Notes |
 |--------------|----------------------|-------------------------------------------|-------|

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -70,6 +70,8 @@ Of note that while `[[module]]` is its own block, it requires specifying a modul
 
 ## Blocks
 
+Here is a table showing the options each block has with regards to its construction:
+
 | Block Name  | Accepted Names        | Special? | Modifier? | Newlines? | AST Output | HTML Output | Notes |
 |-------------|-----------------------|----------|-----------|-----------|------------|-------------|-------|
 | Anchor      | `a`, `anchor`         | No       | Yes       | No        | `Element::Anchor` | `<a>` | Modifier strips trailing and leading newlines from output. |

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -1,23 +1,33 @@
 ## Syntax Documentation: Blocks
 
-ftml uses the term "block" to refer to the syntactical construction beginning in `[[`, containing some text, and ending in `]]`.
+ftml uses the term "block" to refer to the syntactical construction beginning in `[[`, containing some text, and ending in `]]`. Examples include `[[div]]`, `[[module]]`, and `[[span]]`.
 
-Blocks may start with `[[*` (referred to in the code as its `special` flag), have a case-insensitive name, and then optional arguments until it terminates in `]]`. Some blocks require a body, and some only exist as a head. All bodies are terminated by `[[/name]]` (where `name` being the case-insensitive block name).
+The text after the `[[` is the name of the block. These are always case-insensitive.
 
-How the bodies of a block are interpreted depend on its type. They fall into one of the following categories:
+Blocks have five variable properties worth noting:
 
-| Name            | Example block | Description |
-|-----------------|---------------|-------------|
-| None            | `[[include]]` | Has no body. This block terminates at its head. |
-| Raw text        | `[[code]]`    | Interprets the entire block body as raw text. Syntax is not parsed. |
-| Nested elements | `[[div]]`     | Interprets block contents as elements in a certain context. These are then nested in the block. |
-| Other           | N/A           | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
+1. The block may start with `[[*` rather than `[[`. This is referred to as the "special" flag.
+2. Their name may end in `_`. This is referred to as the "modifier" flag. This underscore is ignored if found in the tail.
+3. The block may have a number of arguments before ending in `]]`.
+4. The block may accept delimited newlines. This is explained in more detail below.
+5. The block may have a body. It has contents that is terminated by `[[/name]]` (where `name` is the block name).
 
-Of note that while `[[module]]` is its own block, it requires specifying a module name, and this behaves similarly to other blocks in that their attributes are determined by the module name.
+Whether particular blocks accept these variables is noted in the table below. If a block does not permit that variance, then it will not parse. For instance, if a block does not permit special variance but a `*` is added anyways.
 
-Blocks may also have a variant, which means that terminating the name in `_` produces modified behavior. Only the presence of the trailing `_` in the head is used to determine the block's behavior.
+### Arguments
 
-Finally, blocks may accept deliminated newlines. While these blocks can be used inline, separating them on their own lines will not produce line breaks. For instance:
+Blocks may have one of the following approaches when parsing arguments:
+
+| Name             | Example block       | Description |
+|------------------|---------------------|-------------|
+| None             | `[[CSS]]`           | Accepts no arguments. Tokens which are not `]]` will result in parsing failure. |
+| Value            | `[[size 50%]]`      | All of the text until `]]` is interpreted as a single text value. |
+| Map              | `[[span id="abc"]]` | Accepts an arbitrary mapping of `key="value"` arguments. Values must be double-quoted, and may contain escapes (e.g. `\"`, `\n`). |
+| Name Map         | `[[iframe https://example.com/ style="width: 100%;"]]` | Accepts a single text value terminated by a space, then an arbitrary mapping as described above. |
+
+### Newlines
+
+Blocks may accept deliminated newlines. While these blocks can be used inline, separating them on their own lines will not produce line breaks. For instance:
 
 The `[[div]]` block accepts separate newlines. These two constructions are the same:
 
@@ -43,39 +53,54 @@ Banana
 [[/span]]
 ```
 
-### Blocks
+### Body
 
-| Block Name  | Accepted Names        | Special? | Variant? | Newlines? | AST Output | HTML Output | Notes |
-|-------------|-----------------------|----------|----------|-----------|------------|-------------|-------|
-| Anchor      | `a`, `anchor`         | No       | Yes      | No        | `Element::Anchor` | `<a>` | Variant strips trailing and leading newlines from output. |
-| Blockquote  | `blockquote`, `quote` | No       | No       | Yes       | `Element::Container(Blockquote)` | `<blockquote>` | |
-| Bold        | `b`, `bold`, `strong` | No       | No       | No        | `Element::Container(Bold)` | `<strong>` | |
-| Checkbox    | `checkbox`            | Yes      | No       | No        | `Element::CheckBox` | `<input type="checkbox">` | If special is set, the checkbox begins checked. |
-| Code        | `code`                | No       | No       | Yes       | `Element::Code` | `<div class="code">` | |
-| Collapsible | `collapsible`         | No       | No       | Yes       | `Element::Collapsible` | `<div class="collapsible-block">` | |
-| CSS         | `css`                 | No       | No       | Yes       | - | `<style>` | Outputs contents as CSS. Alias for `[[module CSS]]`. |
-| Deletion    | `del`, `deletion`     | No       | No       | No        | `Element::Container(Deletion)` | `<del>` | |
-| Div         | `div`                 | No       | Yes      | Yes       | `Element::Container(Div)` | `<div>` | Variant strips trailing and leading newlines from output. |
-| Hidden      | `hidden`              | No       | No       | Yes       | `Element::Container(Hidden)` | `<span class="hidden">` | |
-| HTML        | `html`                | No       | No       | Yes       | `Element::Html` | `<iframe>` | Embeds this as an HTML snippet on `wjfiles.com`, hosted in an iframe. |
-| Iframe      | `iframe`              | No       | No       | Yes       | `Element::Iframe` | `<iframe>` |
-| Include     | `include`             | No       | No       | Yes       | - | - | Handled in the preprocessor. Includes the contents from the target page here, as if pasted in. |
-| Insertion   | `ins`, `insertion`    | No       | No       | No        | `Element::Container(Insertion)` | `<ins>` | |
-| Invisible   | `invisible`           | No       | No       | Yes       | `Element::Container(Invisible)` | `<span class="invisible">` |
-| Italics     | `i`, `italics`, `em`, `emphasis` | No | No | No         | `Element::Container(Italics)` | `<em>` | |
-| Lines       | `lines`, `newlines`   | No       | No       | Yes       | `Element::LineBreaks` | `<br>` | |
-| Mark        | `mark`, `highlight`   | No       | No       | No        | `Element::Container(Mark)` | `<mark>` | |
-| Module      | `module`              | No       | No       | Yes       | - | - | See [section below](#modules) on modules. |
-| Monospace   | `tt`, `mono`, `monospace` | No   | No       | No        | `Element::Container(Monospace)` | `<tt>` | |
-| Radio       | `radio`, `radio-button` | Yes    | No       | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
-| Size        | `size`                | No       | No       | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
-| Span        | `span`                | No       | Yes      | No        | `Element::Container(Span)` | `<span>` | Variant strips trailing and leading newlines from output. |
-| Strikethrough | `s`, `strikethrough` | No      | No       | No        | `Element::Container(Strikethrough)` | `<s>` | |
-| Subscript   | `sub`, `subscript`    | No       | No       | No        | `Element::Container(Subscript)` | `<sub>` | |
-| Superscript | `sup`, `super`, `superscript` | No | No     | No        | `Element::Container(Superscript)` | `<sup>` | |
-| Underline   | `u`, `underline`      | No       | No       | No        | `Element::Container(Underline)` | `<u>` | |
+How the bodies of a block are interpreted depend on its type. They fall into one of the following categories:
 
-### Modules
+| Name            | Example block | Description |
+|-----------------|---------------|-------------|
+| None            | `[[include]]` | Has no body. This block terminates at its head. |
+| Raw text        | `[[code]]`    | Interprets the entire block body as raw text. Syntax is not parsed. |
+| Nested elements | `[[div]]`     | Interprets block contents as elements in a certain context. These are then nested in the block. |
+| Other           | N/A           | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
+
+### Module
+
+Of note that while `[[module]]` is its own block, it requires specifying a module name, and this behaves similarly to other blocks in that their attributes are determined by the module name.
+
+## Blocks
+
+| Block Name  | Accepted Names        | Special? | Modifier? | Newlines? | AST Output | HTML Output | Notes |
+|-------------|-----------------------|----------|-----------|-----------|------------|-------------|-------|
+| Anchor      | `a`, `anchor`         | No       | Yes       | No        | `Element::Anchor` | `<a>` | Modifier strips trailing and leading newlines from output. |
+| Blockquote  | `blockquote`, `quote` | No       | No        | Yes       | `Element::Container(Blockquote)` | `<blockquote>` | |
+| Bold        | `b`, `bold`, `strong` | No       | No        | No        | `Element::Container(Bold)` | `<strong>` | |
+| Checkbox    | `checkbox`            | Yes      | No        | No        | `Element::CheckBox` | `<input type="checkbox">` | If special is set, the checkbox begins checked. |
+| Code        | `code`                | No       | No        | Yes       | `Element::Code` | `<div class="code">` | |
+| Collapsible | `collapsible`         | No       | No        | Yes       | `Element::Collapsible` | `<div class="collapsible-block">` | |
+| CSS         | `css`                 | No       | No        | Yes       | - | `<style>` | Outputs contents as CSS. Alias for `[[module CSS]]`. |
+| Deletion    | `del`, `deletion`     | No       | No        | No        | `Element::Container(Deletion)` | `<del>` | |
+| Div         | `div`                 | No       | Yes       | Yes       | `Element::Container(Div)` | `<div>` | Modifier strips trailing and leading newlines from output. |
+| Hidden      | `hidden`              | No       | No        | Yes       | `Element::Container(Hidden)` | `<span class="hidden">` | |
+| HTML        | `html`                | No       | No        | Yes       | `Element::Html` | `<iframe>` | Embeds this as an HTML snippet on `wjfiles.com`, hosted in an iframe. |
+| Iframe      | `iframe`              | No       | No        | Yes       | `Element::Iframe` | `<iframe>` |
+| Include     | `include`             | No       | No        | Yes       | - | - | Handled in the preprocessor. Includes the contents from the target page here, as if pasted in. |
+| Insertion   | `ins`, `insertion`    | No       | No        | No        | `Element::Container(Insertion)` | `<ins>` | |
+| Invisible   | `invisible`           | No       | No        | Yes       | `Element::Container(Invisible)` | `<span class="invisible">` |
+| Italics     | `i`, `italics`, `em`, `emphasis` | No | No |  No         | `Element::Container(Italics)` | `<em>` | |
+| Lines       | `lines`, `newlines`   | No       | No        | Yes       | `Element::LineBreaks` | `<br>` | |
+| Mark        | `mark`, `highlight`   | No       | No        | No        | `Element::Container(Mark)` | `<mark>` | |
+| Module      | `module`              | No       | No        | Yes       | - | - | See [section below](#modules) on modules. |
+| Monospace   | `tt`, `mono`, `monospace` | No   | No        | No        | `Element::Container(Monospace)` | `<tt>` | |
+| Radio       | `radio`, `radio-button` | Yes    | No        | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
+| Size        | `size`                | No       | No        | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
+| Span        | `span`                | No       | Yes       | No        | `Element::Container(Span)` | `<span>` | Modifier strips trailing and leading newlines from output. |
+| Strikethrough | `s`, `strikethrough` | No      | No        | No        | `Element::Container(Strikethrough)` | `<s>` | |
+| Subscript   | `sub`, `subscript`    | No       | No        | No        | `Element::Container(Subscript)` | `<sub>` | |
+| Superscript | `sup`, `super`, `superscript` | No | No      | No        | `Element::Container(Superscript)` | `<sup>` | |
+| Underline   | `u`, `underline`      | No       | No        | No        | `Element::Container(Underline)` | `<u>` | |
+
+## Modules
 
 The table below follows essentially the same schema as for blocks in general, with a few changes. [As noted above](#blocks), all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -8,11 +8,11 @@ Blocks have five variable properties worth noting:
 
 1. The block may start with `[[*` rather than `[[`. This is referred to as the "special" flag.
 2. Their name may end in `_`. This is referred to as the "modifier" flag. This underscore is ignored if found in the tail.
-3. The block may have a number of arguments before ending in `]]`.
-4. The block may accept delimited newlines. This is explained in more detail below.
+3. The block may have some arguments before ending in `]]`.
+4. The block may accept delimited newlines. This is explained in more detail [below](#newlines).
 5. The block may have a body. It has contents that is terminated by `[[/name]]` (where `name` is the block name), referred to as the tail.
 
-Whether particular blocks accept these variables is noted in the table below. If a block does not permit that variance, then it will not parse. For instance, if a block does not permit special variance but a `*` is added anyways.
+Whether particular blocks accept these variables is noted in the table below. If a block does not permit that variance, then it will fail to parse.
 
 ### Arguments
 
@@ -62,7 +62,7 @@ How the bodies of a block are interpreted depend on its type. They fall into one
 | None            | `[[include]]` | Has no body. This block terminates at its head. |
 | Raw text        | `[[code]]`    | Interprets the entire block body as raw text. Syntax is not parsed. |
 | Nested elements | `[[div]]`     | Interprets block contents as elements in a certain context. These are then nested in the block. |
-| Other           | N/A           | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
+| Other           | N/A           | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML for instance. |
 
 ### Module
 
@@ -78,19 +78,19 @@ Of note that while `[[module]]` is its own block, it requires specifying a modul
 | Checkbox    | `checkbox`            | Yes      | No        | No        | `Element::CheckBox` | `<input type="checkbox">` | If special is set, the checkbox begins checked. |
 | Code        | `code`                | No       | No        | Yes       | `Element::Code` | `<div class="code">` | |
 | Collapsible | `collapsible`         | No       | No        | Yes       | `Element::Collapsible` | `<div class="collapsible-block">` | |
-| CSS         | `css`                 | No       | No        | Yes       | - | `<style>` | Outputs contents as CSS. Alias for `[[module CSS]]`. |
+| CSS         | `css`                 | No       | No        | Yes       | N/A | `<style>` | Outputs contents as CSS. Alias for `[[module CSS]]`. |
 | Deletion    | `del`, `deletion`     | No       | No        | No        | `Element::Container(Deletion)` | `<del>` | |
 | Div         | `div`                 | No       | Yes       | Yes       | `Element::Container(Div)` | `<div>` | Modifier strips trailing and leading newlines from output. |
 | Hidden      | `hidden`              | No       | No        | Yes       | `Element::Container(Hidden)` | `<span class="hidden">` | |
 | HTML        | `html`                | No       | No        | Yes       | `Element::Html` | `<iframe>` | Embeds this as an HTML snippet on `wjfiles.com`, hosted in an iframe. |
 | Iframe      | `iframe`              | No       | No        | Yes       | `Element::Iframe` | `<iframe>` |
-| Include     | `include`             | No       | No        | Yes       | - | - | Handled in the preprocessor. Includes the contents from the target page here, as if pasted in. |
+| Include     | `include`             | No       | No        | Yes       | N/A | N/A | Handled in the preprocessor. Includes the contents from the target page here, as if pasted in. |
 | Insertion   | `ins`, `insertion`    | No       | No        | No        | `Element::Container(Insertion)` | `<ins>` | |
 | Invisible   | `invisible`           | No       | No        | Yes       | `Element::Container(Invisible)` | `<span class="invisible">` |
 | Italics     | `i`, `italics`, `em`, `emphasis` | No | No |  No         | `Element::Container(Italics)` | `<em>` | |
 | Lines       | `lines`, `newlines`   | No       | No        | Yes       | `Element::LineBreaks` | `<br>` | |
 | Mark        | `mark`, `highlight`   | No       | No        | No        | `Element::Container(Mark)` | `<mark>` | |
-| Module      | `module`              | No       | No        | Yes       | - | - | See [section below](#modules) on modules. |
+| Module      | `module`              | No       | No        | Yes       | N/A | N/A | See [section below](#modules) on modules. |
 | Monospace   | `tt`, `mono`, `monospace` | No   | No        | No        | `Element::Container(Monospace)` | `<tt>` | |
 | Radio       | `radio`, `radio-button` | Yes    | No        | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
 | Size        | `size`                | No       | No        | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
@@ -108,7 +108,7 @@ The table below follows essentially the same schema as for blocks in general, wi
 |--------------|----------------------|-------------------------------------------|-------|
 | Backlinks    | `Module::Backlinks`  | `<div class="backlinks-module-box"> <ul>` | |
 | Categories   | `Module::Categories` | `<div class="categories-module-box">`     | |
-| CSS          | -                    | `<style>`                                 | Outputs contents as CSS. Alias for `[[css]]`. |
+| CSS          | N/A                  | `<style>`                                 | Outputs contents as CSS. Alias for `[[css]]`. |
 | Join         | `Module::Join`       | `<div class="join-box">`                  | |
 | PageTree     | `Module::PageTree`   | `<div class="pagetree-module-box"> <ul>`  | |
 | Rate         | `Module::Rate`       | `<div class="page-rate-widget-box">`      | |

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -542,7 +542,7 @@ Favorite kind of music:
 **HTML Output:** `<span style="font-size: XXX;">`
 
 **Arguments:**
-* All accepted attributes
+* None
 
 **Example:**
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -65,7 +65,7 @@ Banana
 | Italics     | `i`, `italics`, `em`, `emphasis` | No | No | No         | `Element::Container(Italics)` | `<em>` | |
 | Lines       | `lines`, `newlines`   | No       | No       | Yes       | `Element::LineBreaks` | `<br>` | |
 | Mark        | `mark`, `highlight`   | No       | No       | No        | `Element::Container(Mark)` | `<mark>` | |
-| Module      | `module`              | No       | No       | -         | - | - | See section below on modules. |
+| Module      | `module`              | No       | No       | Yes       | - | - | See section below on modules. |
 | Monospace   | `tt`, `mono`, `monospace` | No   | No       | No        | `Element::Container(Monospace)` | `<tt>` | |
 | Radio       | `radio`, `radio-button` | Yes    | No       | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
 | Size        | `size`                | No       | No       | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
@@ -77,4 +77,13 @@ Banana
 
 ### Modules
 
-(TODO)
+The table below follows essentially the same schema as for blocks in general, with a few changes. As noted above, all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).
+
+| Module Name  | AST Output           | HTML Output                               | Notes |
+|--------------|----------------------|-------------------------------------------|-------|
+| Backlinks    | `Module::Backlinks`  | `<div class="backlinks-module-box"> <ul>` | |
+| Categories   | `Module::Categories` | `<div class="categories-module-box">`     | |
+| CSS          | -                    | `<style>`                                 | Outputs contents as CSS. Alias for `[[css]]`. |
+| Join         | `Module::Join`       | `<div class="join-box">`                  | |
+| PageTree     | `Module::PageTree`   | `<div class="pagetree-module-box"> <ul>`  | |
+| Rate         | `Module::Rate`       | `<div class="page-rate-widget-box">`      | |

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -64,6 +64,16 @@ Banana
 | Invisible   | `invisible`           | No       | No       | Yes       | `Element::Container(Invisible)` | `<span class="invisible">` |
 | Italics     | `i`, `italics`, `em`, `emphasis` | No | No | No         | `Element::Container(Italics)` | `<em>` | |
 | Lines       | `lines`, `newlines`   | No       | No       | Yes       | `Element::LineBreaks` | `<br>` | |
+| Mark        | `mark`, `highlight`   | No       | No       | No        | `Element::Container(Mark)` | `<mark>` | |
+| Module      | `module`              | No       | No       | -         | - | - | See section below on modules. |
+| Monospace   | `tt`, `mono`, `monospace` | No   | No       | No        | `Element::Container(Monospace)` | `<tt>` | |
+| Radio       | `radio`, `radio-button` | Yes    | No       | No        | `Element::RadioButton` | `<input type="radio">` | If special is set, the radio button begins selected. |
+| Size        | `size`                | No       | No       | No        | `Element::Container(Size)` | `<span style="font-size: XXX;">` | |
+| Span        | `span`                | No       | Yes      | No        | `Element::Container(Span)` | `<span>` | Variant strips trailing and leading newlines from output. |
+| Strikethrough | `s`, `strikethrough` | No      | No       | No        | `Element::Container(Strikethrough)` | `<s>` | |
+| Subscript   | `sub`, `subscript`    | No       | No       | No        | `Element::Container(Subscript)` | `<sub>` | |
+| Superscript | `sup`, `super`, `superscript` | No | No     | No        | `Element::Container(Superscript)` | `<sup>` | |
+| Underline   | `u`, `underline`      | No       | No       | No        | `Element::Container(Underline)` | `<u>` | |
 
 ### Modules
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -114,7 +114,7 @@ Each of the blocks will be described in more detail below:
 **HTML Output:** `<a>`
 
 **Arguments:**
-* All accepted attributes are passed as-is
+* All accepted attributes
 
 **Example:**
 
@@ -132,7 +132,7 @@ Each of the blocks will be described in more detail below:
 **HTML Output:** `<blockquote>`
 
 **Arguments:**
-* All accepted attributes are passed as-is
+* All accepted attributes
 
 **Example:**
 
@@ -140,6 +140,65 @@ Each of the blocks will be described in more detail below:
 [[blockquote]]
 Some text here.
 [[/blockquote]]
+```
+
+### Bold
+
+**Accepts:**
+* (none)
+
+**Abstract Syntax Tree Output:** `Element::Bold`
+
+**HTML Output:** `<strong>`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+Some [[b]]text![[/b]]
+```
+
+### Checkbox
+
+**Accepts:**
+* Special &emdash; Element starts checked
+
+**Abstract Syntax Tree Output:** `Element::CheckBox`
+
+**HTML Output:** `<input type="checkbox">`
+
+**Arguments:**
+* All accepted attributes
+
+**Example:**
+
+```
+[[checkbox Apple]]
+[[*checkbox Blueberry]]
+[[checkbox Cherry]]
+[[checkbox Durian]]
+```
+
+### Code
+
+**Accepts:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Code`
+
+**HTML Output:** `<div class="code">`
+
+**Arguments:**
+* `type` &emdash; What language this block is in, both for its Content-Type and syntax highlighting.
+
+**Example:**
+
+```
+[[code]]
+This text is **not** rendered as Wikitext, but output as-is!
+[[/code]]
 ```
 
 ## Modules

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -1,0 +1,24 @@
+## Syntax Documentation: Blocks
+
+ftml uses the term "block" to refer to the syntactical construction beginning in `[[`, containing some text, and ending in `]]`.
+
+Blocks may start with `[[*` (referred to in the code as its `special` flag), have a case-insensitive name, and then optional arguments until it terminates in `]]`. Some blocks require a body, and some only exist as a head. All bodies are terminated by `[[/name]]` (where `name` being the case-insensitive block name).
+
+How the bodies of a block are interpreted depend on its type. They fall into one of the following categories:
+
+| Name            | Example block | Description |
+|-----------------|---------------|-------------|
+| None            | `[[include]]` | Has no body. This block terminates at its head. |
+| Raw text        | `[[code]]`    | Interprets the entire block body as raw text. Syntax is not parsed. |
+| Nested elements | `[[div]]`     | Interprets block contents as elements in a certain context. These are then nested in the block. |
+| Other           |               | Uses some other means of interpreting its body. Some Wikidot blocks allow passing YAML, for instance. |
+
+Of note that while `[[module]]` is its own block, it requires specifying a module name, and this behaves similarly to other blocks in that their attributes are determined by the module name.
+
+### Blocks
+
+(TODO)
+
+### Modules
+
+(TODO)

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -114,7 +114,7 @@ Each of the blocks will be described in more detail below:
 **HTML Output:** `<a>`
 
 **Arguments:**
-* TODO
+* All accepted attributes are passed as-is
 
 **Example:**
 
@@ -132,7 +132,7 @@ Each of the blocks will be described in more detail below:
 **HTML Output:** `<blockquote>`
 
 **Arguments:**
-* TODO
+* All accepted attributes are passed as-is
 
 **Example:**
 

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -15,6 +15,34 @@ How the bodies of a block are interpreted depend on its type. They fall into one
 
 Of note that while `[[module]]` is its own block, it requires specifying a module name, and this behaves similarly to other blocks in that their attributes are determined by the module name.
 
+Blocks may also have a variant, which means that terminating the name in `_` produces modified behavior. Only the presence of the trailing `_` in the head is used to determine the block's behavior.
+
+Finally, blocks may accept deliminated newlines. While these blocks can be used inline, separating them on their own lines will not produce line breaks. For instance:
+
+The `[[div]]` block accepts separate newlines. These two constructions are the same:
+
+```
+[[div]]Apple[[/div]]
+```
+
+```
+[[div]]
+Apple
+[[/div]]
+```
+
+The `[[span]]` block does not accept separate newlines. These two constructions are different, as the latter will add line breaks for each newline in the source:
+
+```
+[[span]]Banana[[/span]]
+```
+
+```
+[[span]]
+Banana
+[[/span]]
+```
+
 ### Blocks
 
 (TODO)

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -108,17 +108,14 @@ Each of the blocks will be described in more detail below:
 
 ### Anchor
 
-**Accepts variants:**
-* Modifier &mdash; Strips leading and trailing newlines.
+Outputs: `Element::Anchor` / `<a>`
 
-**Abstract Syntax Tree Output:** `Element::Anchor`
+Accepts `_` modifier: Strips leading and trailing newlines.
 
-**HTML Output:** `<a>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[a href="/scp-4000/noredirect/true" target="_blank" class="dual-link"]]Fae[[/a]]
@@ -126,17 +123,14 @@ Each of the blocks will be described in more detail below:
 
 ### Blockquote
 
-**Accepts variants:**
-* Newlines
+Outputs: `Element::Container(ContainerType::Blockqote)` / `<blockquote>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Blockqote)`
+Accepts newline separation.
 
-**HTML Output:** `<blockquote>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[blockquote]]
@@ -146,17 +140,12 @@ Some text here.
 
 ### Bold
 
-**Accepts variants:**
-* None
+Outputs: `Element::Container(ContainerType::Bold)` / `<strong>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Bold)`
-
-**HTML Output:** `<strong>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 Some [[b]]text![[/b]]
@@ -164,17 +153,14 @@ Some [[b]]text![[/b]]
 
 ### Checkbox
 
-**Accepts variants:**
-* Special &mdash; Element starts checked
+Outputs: `Element::CheckBox` / `<input type="checkbox">`
 
-**Abstract Syntax Tree Output:** `Element::CheckBox`
+Accepts `*` special: Element starts checked.
 
-**HTML Output:** `<input type="checkbox">`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[checkbox Apple]]
@@ -185,17 +171,14 @@ Some [[b]]text![[/b]]
 
 ### Code
 
-**Accepts variants:**
-* Newlines
+Outputs: `Element::Code` / `<div class="code">`
 
-**Abstract Syntax Tree Output:** `Element::Code`
+Accepts newline separation.
 
-**HTML Output:** `<div class="code">`
-
-**Arguments:**
+Arguments:
 * `type` &mdash; What language this block is in, both for its Content-Type and syntax highlighting.
 
-**Example:**
+Example:
 
 ```
 [[code]]
@@ -205,20 +188,17 @@ This text is **not** rendered as Wikitext, but output as-is!
 
 ### Collapsible
 
-**Accepts variants:**
-* Newlines
+Output: `Element::Collapsible` / `<div class="collapsible-block">`
 
-**Abstract Syntax Tree Output:** `Element::Collapsible`
+Accepts newline separation.
 
-**HTML Output:** `<div class="collapsible-block">`
-
-**Arguments:**
+Arguments:
 * `show` &mdash; The text to present when text is collapsed (i.e. can be shown)
 * `hide` &mdash; The text to present when text is expanded (i.e. can be hidden)
 * `folded` &mdash; Boolean. `true` means start collapsed (default), `false` means start expanded
 * `hideLocation` &mdash; One of `top`, `bottom`, `both`, or `neither`. Shows in what locations the hide collapsible link in.
 
-**Example:**
+Example:
 
 ```
 [[collapsible show="+ Spoilers for Ouroboros" hide="- Spoilers!" hideLocation="bottom"]]
@@ -228,17 +208,14 @@ Overseers die.
 
 ### CSS
 
-**Accepts variants:**
-* Newlines
+Output: None / `<style>`
 
-**Abstract Syntax Tree Output:** None. Appends to list of styles.
+Accepts newline separation.
 
-**HTML Output:** `<style>`
-
-**Arguments:**
+Arguments:
 * None
 
-**Example:**
+Example:
 
 ```
 [[css]]
@@ -250,17 +227,12 @@ Overseers die.
 
 ### Deletion
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Deletion)` / `<del>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Deletion)`
-
-**HTML Output:** `<del>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 I [[del]]don't[[/del]] like that haircut.
@@ -268,18 +240,15 @@ I [[del]]don't[[/del]] like that haircut.
 
 ### Div
 
-**Accepts variants:**
-* Modifier &mdash; Strips leading and trailing newlines
-* Newlines
+Output: `Element::Container(ContainerType::Div)` / `<div>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Div)`
+Accepts `_` modifier: Strips leading and trailing newlines.  
+Accepts newline separation.
 
-**HTML Output:** `<div>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[div_ class="blockquote" style="border: none;"]]
@@ -289,17 +258,14 @@ Some text __here!__
 
 ### Hidden
 
-**Accepts variants:**
-* Newlines
+Output: `Element::Container(ContainerType::Hidden)` / `<span class="hidden">`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Hidden)`
+Accepts newline separation.
 
-**HTML Output:** `<span class="hidden">`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text is **visible**.
@@ -311,17 +277,14 @@ This text is not.
 
 ### HTML
 
-**Accepts variants:**
-* Newlines
+Output: `Element::Html` / `<iframe>`
 
-**Abstract Syntax Tree Output:** `Element::Html`
+Accepts newline separation.
 
-**HTML Output:** `<iframe>`
-
-**Arguments:**
+Arguments:
 * None
 
-**Example:**
+Example:
 
 ```
 [[html]]
@@ -335,17 +298,14 @@ This HTML will appear in an iframe hosted on wjfiles!
 
 ### Iframe
 
-**Accepts variants:**
-* Newlines
+Output:`Element::Iframe` /`<iframe>`
 
-**Abstract Syntax Tree Output:** `Element::Iframe`
+Accepts newline separation.
 
-**HTML Output:** `<iframe>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 My website:
@@ -355,19 +315,16 @@ My website:
 
 ### Include
 
-This is not a typical block, as it is handled in the preprocessor. Parsing here is handled differently.
+This is not a typical block, as it is handled in the preprocessor. Parsing here is handled differently, but this block is still documented for completion sake.
 
-**Accepts variants:**
-* Newlines
+Output: N/A
 
-**Abstract Syntax Tree Output:** N/A
+Accepts newline separation.
 
-**HTML Output:** N/A
-
-**Arguments:**
+Arguments:
 * All arguments are passed as variables to the included page
 
-**Example:**
+Example:
 
 ```
 [[include theme:black-highlighter-theme]]
@@ -381,17 +338,12 @@ This is not a typical block, as it is handled in the preprocessor. Parsing here 
 
 ### Insertion
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Insertion)` / `<ins>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Insertion)`
-
-**HTML Output:** `<ins>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 I would like some [[ins]]anchovy[[/ins]] pizza please, thank you.
@@ -399,17 +351,14 @@ I would like some [[ins]]anchovy[[/ins]] pizza please, thank you.
 
 ### Invisible
 
-**Accepts variants:**
-* Newlines
+Output: `Element::Container(ContainerType::Invisible)` / `<span class="invisible">`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Invisible)`
+Accepts newline separation.
 
-**HTML Output:** `<span class="invisible">`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text appears [[invisible]]but still takes up space, and can be selected.[[/invisible]]
@@ -419,17 +368,12 @@ More correct and much more portable than setting the font color to "white".
 
 ### Italics
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Italics)` / `<em>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Italics)`
-
-**HTML Output:** `<em>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text is regular, but [[em]]this text is emphasized[[/em]].
@@ -437,17 +381,14 @@ This text is regular, but [[em]]this text is emphasized[[/em]].
 
 ### Lines
 
-**Accepts variants:**
-* Newlines
+Output: `Element::LineBreaks` / `<br>`
 
-**Abstract Syntax Tree Output:** `Element::LineBreaks`
+Accepts newline separation.
 
-**HTML Output:** `<br>`
-
-**Arguments:**
+Arguments:
 * Value: positive integer &mdash; Number of line breaks to output
 
-**Example:**
+Example:
 
 ```
 [[newlines 4]]
@@ -457,17 +398,12 @@ This text is regular, but [[em]]this text is emphasized[[/em]].
 
 ### Mark
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Mark)` / `<mark>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Mark)`
-
-**HTML Output:** `<mark>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text is [[mark]]highlighted![[/mark]]
@@ -475,17 +411,14 @@ This text is [[mark]]highlighted![[/mark]]
 
 ### Modules
 
-**Accepts variants:**
-* Newlines
+Output: `Element::Module` / Depends on the module type
 
-**Abstract Syntax Tree Output:** Depends on the module type
+Accepts newline separation.
 
-**HTML Output:** Depends on the module type
-
-**Arguments:**
+Arguments:
 * See documentation for specific modules
 
-**Example:**
+Example:
 
 ```
 [[module NameOfModuleHere someArgument="yes"]]
@@ -493,17 +426,12 @@ This text is [[mark]]highlighted![[/mark]]
 
 ### Monospace
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Monospace)` / `<tt>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Monospace)`
-
-**HTML Output:** `<tt>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[tt]]This output looks like it came from a typewriter or computer terminal.[[/tt]]
@@ -511,17 +439,14 @@ This text is [[mark]]highlighted![[/mark]]
 
 ### Radio
 
-**Accepts variants:**
-* Special &mdash; Element starts selected
+Accepts `*` special: Element starts selected.
 
-**Abstract Syntax Tree Output:** `Element::RadioButton`
+Output: `Element::RadioButton` / `<input type="radio">`
 
-**HTML Output:** `<input type="radio">`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 Favorite kind of music:
@@ -534,17 +459,12 @@ Favorite kind of music:
 
 ### Size
 
-**Accepts variants:**
+Output: `Element::Container(ContainerType::Size)` / `<span style="font-size: XXX;">`
+
+Arguments:
 * None
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Size)`
-
-**HTML Output:** `<span style="font-size: XXX;">`
-
-**Arguments:**
-* None
-
-**Example:**
+Example:
 
 ```
 This text is regular, but [[size 250%]]this text is much larger[[/size]].
@@ -552,17 +472,14 @@ This text is regular, but [[size 250%]]this text is much larger[[/size]].
 
 ### Span
 
-**Accepts variants:**
-* Modifier &mdash; Strips leading and trailing newlines
+Output:`Element::Span` / `<span>`
 
-**Abstract Syntax Tree Output:** `Element::Span`
+Accepts `_` modifier: Strips leading and trailing newlines.
 
-**HTML Output:** `<span>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text is in a span: [[span class="fruit"]]banana[[/span]]
@@ -570,17 +487,12 @@ This text is in a span: [[span class="fruit"]]banana[[/span]]
 
 ### Strikethrough
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Strikethrough)` / `<s>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Strikethrough)`
-
-**HTML Output:** `<s>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 This text is [[s]]struck through![[/s]]
@@ -588,17 +500,12 @@ This text is [[s]]struck through![[/s]]
 
 ### Subscript
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Subscript)` / `<sub>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Subscript)`
-
-**HTML Output:** `<sub>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 Let this variable be called x[[sub]]A[[/sub]].
@@ -606,17 +513,12 @@ Let this variable be called x[[sub]]A[[/sub]].
 
 ### Superscript
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Superscript)` / `<sup>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Superscript)`
-
-**HTML Output:** `<sup>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 Thus, the result is n[[sup]]2[[/sup]].
@@ -624,17 +526,12 @@ Thus, the result is n[[sup]]2[[/sup]].
 
 ### Underline
 
-**Accepts variants:**
-* None
+Output: `Element::Container(ContainerType::Underline)` / `<u>`
 
-**Abstract Syntax Tree Output:** `Element::Container(ContainerType::Underline)`
-
-**HTML Output:** `<u>`
-
-**Arguments:**
+Arguments:
 * All accepted attributes
 
-**Example:**
+Example:
 
 ```
 [[u]]Testing log 7192-45:[[/u]]
@@ -644,7 +541,7 @@ Thus, the result is n[[sup]]2[[/sup]].
 
 The table below follows essentially the same schema as for blocks in general, with a few changes. [As noted above](#blocks), all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).
 
-| Module Name  | AST Output           | HTML Output                               | Notes |
+| Module Name  | AST Output           | htmlOutput                               | Notes |
 |--------------|----------------------|-------------------------------------------|-------|
 | Backlinks    | `Module::Backlinks`  | `<div class="backlinks-module-box"> <ul>` | |
 | Categories   | `Module::Categories` | `<div class="categories-module-box">`     | |

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -203,6 +203,29 @@ This text is **not** rendered as Wikitext, but output as-is!
 [[/code]]
 ```
 
+### Collapsible
+
+**Accepts variants:**
+* Newlines
+
+**Abstract Syntax Tree Output:** `Element::Collapsible`
+
+**HTML Output:** `<div class="collapsible-block">`
+
+**Arguments:**
+* `show` &emdash; The text to present when text is collapsed (i.e. can be shown)
+* `hide` &emdash; The text to present when text is expanded (i.e. can be hidden)
+* `folded` &emdash; Boolean. `true` means start collapsed (default), `false` means start expanded
+* `hideLocation` &emdash; One of `top`, `bottom`, `both`, or `neither`. Shows in what locations the hide collapsible link in.
+
+**Example:**
+
+```
+[[collapsible show="+ Spoilers for Ouroboros" hide="- Spoilers!" hideLocation="bottom"]]
+Overseers die.
+[[/collapsible]]
+```
+
 ## Modules
 
 The table below follows essentially the same schema as for blocks in general, with a few changes. [As noted above](#blocks), all modules accept separate newlines and do not accept special or variant flags. Additionally, the list of accepted names is the same as the module name (but case-insensitive).

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -108,7 +108,7 @@ Each of the blocks will be described in more detail below:
 
 ### Anchor
 
-**Accepts:**
+**Accepts variants:**
 * Modifier &emdash; Strips leading and trailing newlines.
 
 **Abstract Syntax Tree Output:** `Element::Anchor`
@@ -126,7 +126,7 @@ Each of the blocks will be described in more detail below:
 
 ### Blockquote
 
-**Accepts:**
+**Accepts variants:**
 * Newlines
 
 **Abstract Syntax Tree Output:** `Element::Container(ContainerType::Blockqote)`
@@ -146,7 +146,7 @@ Some text here.
 
 ### Bold
 
-**Accepts:**
+**Accepts variants:**
 * (none)
 
 **Abstract Syntax Tree Output:** `Element::Bold`
@@ -164,7 +164,7 @@ Some [[b]]text![[/b]]
 
 ### Checkbox
 
-**Accepts:**
+**Accepts variants:**
 * Special &emdash; Element starts checked
 
 **Abstract Syntax Tree Output:** `Element::CheckBox`
@@ -185,7 +185,7 @@ Some [[b]]text![[/b]]
 
 ### Code
 
-**Accepts:**
+**Accepts variants:**
 * Newlines
 
 **Abstract Syntax Tree Output:** `Element::Code`


### PR DESCRIPTION
This adds documentation about block terminology and construction, and then lists all block names and their properties in a table, followed by them listed individually with argument information.

I'm not sure if this is the best way to format this, so before I try doing any documenting for modules, I want to get some feedback first.