### PR TITLE
Use getNamespacedClassFromPath() everywhere

### DIFF
--- a/web/lib/ozoneframework/php/Template/Services/Autoload/TemplateServiceManager.php
+++ b/web/lib/ozoneframework/php/Template/Services/Autoload/TemplateServiceManager.php
@@ -6,6 +6,7 @@ namespace Ozone\Framework\Template\Services\Autoload;
 
 use Ozone\Framework\PathManager;
 use Ozone\Framework\TemplateService;
+use Wikijump\Helpers\LegacyTools;
 
 /**
  * TemplateServiceManager is a TemplateService for accessing
@@ -20,13 +21,14 @@ class TemplateServiceManager extends TemplateService{
 		$this->runData = $runData;
 	}
 
-	public function getService($className){
-		if(isset($this->storage["$className"])){
-			return 	$this->storage["$className"];
+	public function getService($class){
+		if(isset($this->storage["$class"])){
+			return 	$this->storage["$class"];
 		} else {
-			require_once PathManager::ozonePhpServiceOnDemandDir().$className.".php";
-			$instance = new $className($this->runData);
-			$this->storage["$className"] = $instance;
+			require_once PathManager::ozonePhpServiceOnDemandDir().$class.".php";
+			$class = LegacyTools::getNamespacedClassFromPath(PathManager::ozonePhpServiceOnDemandDir().$class.".php");
+			$instance = new $class($this->runData);
+			$this->storage["$class"] = $instance;
 			return $instance;
 		}
 	}

--- a/web/lib/ozoneframework/php/core/AjaxModuleWebFlowController.php
+++ b/web/lib/ozoneframework/php/core/AjaxModuleWebFlowController.php
@@ -87,10 +87,8 @@ class AjaxModuleWebFlowController extends WebFlowController {
 		while ($actionClass != null) {
 
 			require_once (PathManager :: actionClass($actionClass));
-			$tmpa1 = explode('/', $actionClass);
-            $actionClassStripped = end($tmpa1);
-
-			$action = new $actionClassStripped();
+            $class = LegacyTools::getNamespacedClassFromPath(PathManager :: actionClass($actionClass));
+			$action = new $class();
 
 			// action security check
 			$classFile = $runData->getModuleClassPath();

--- a/web/lib/ozoneframework/php/core/AjaxModuleWebFlowController.php
+++ b/web/lib/ozoneframework/php/core/AjaxModuleWebFlowController.php
@@ -5,6 +5,7 @@ namespace Ozone\Framework;
 
 
 use Wikidot\Utils\GlobalProperties;
+use Wikijump\Helpers\LegacyTools;
 
 /**
  * Flow controller for AJAX requests.
@@ -43,11 +44,11 @@ class AjaxModuleWebFlowController extends WebFlowController {
 
 		$template = $runData->getModuleTemplate();
 		$classFile = $runData->getModuleClassPath();
-		$className = $runData->getModuleClassName();
-		$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $className");
+		$class = LegacyTools::getNamespacedClassFromPath($runData->getModuleClassPath());
+		$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $class");
 
 		require_once ($classFile);
-		$module = new $className ();
+		$module = new $class();
 
 		// module security check
 		if(!$module->isAllowed($runData)){
@@ -59,11 +60,10 @@ class AjaxModuleWebFlowController extends WebFlowController {
 
 				// reload the Class again - we do not want the unsecure module to render!
 				$classFile = $runData->getModuleClassPath();
-
-				$className = $runData->getModuleClassName();
-				$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $className");
+                $class = LegacyTools::getNamespacedClassFromPath($runData->getModuleClassPath());
+				$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $class");
 				require_once ($classFile);
-				$module = new $className ();
+				$module = new $class();
 				$runData->setAction(null);
 			}
 		}
@@ -126,13 +126,13 @@ class AjaxModuleWebFlowController extends WebFlowController {
 		// end action process
 
 		// check if template has been changed by the module. if so...
-		if($template != $runData->getModuleTemplate){
+		if($template != $runData->getModuleTemplate()){
 			$classFile = $runData->getModuleClassPath();
-			$className = $runData->getModuleClassName();
-			$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $className");
+			$class = LegacyTools::getNamespacedClassFromPath($runData->getModuleClassPath());
+			$logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $class");
 
 			require_once ($classFile);
-			$module = new $className ();
+			$module = new $class();
 		}
 
 		$module->setTemplate($template);

--- a/web/lib/ozoneframework/php/core/DefaultWebFlowController.php
+++ b/web/lib/ozoneframework/php/core/DefaultWebFlowController.php
@@ -5,6 +5,7 @@ namespace Ozone\Framework;
 
 
 use Wikidot\Utils\GlobalProperties;
+use Wikijump\Helpers\LegacyTools;
 
 /**
  * Default web flow controller.
@@ -36,11 +37,11 @@ class DefaultWebFlowController extends WebFlowController {
 
 		$template = $runData->getScreenTemplate();
 		$classFile = $runData->getScreenClassPath();
-		$className = $runData->getScreenClassName();
-		$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+		$class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+		$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 
 		require_once ($classFile);
-		$screen = new $className ();
+		$screen = new $class();
 
 		// screen security check
 		if(!$screen->isAllowed($runData)){
@@ -53,10 +54,10 @@ class DefaultWebFlowController extends WebFlowController {
 				// reload the Class again - we do not want the unsecure screen to render!
 				$classFile = $runData->getScreenClassPath();
 
-				$className = $runData->getScreenClassName();
-				$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+				$class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+				$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 				require_once ($classFile);
-				$screen = new $className ();
+				$screen = new $class();
 				$runData->setAction(null);
 			}
 		}
@@ -130,11 +131,11 @@ class DefaultWebFlowController extends WebFlowController {
 		// check if template has been changed by the action. if so...
 		if($template != $runData->getScreenTemplate){
 			$classFile = $runData->getScreenClassPath();
-			$className = $runData->getScreenClassName();
-			$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+			$class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+			$logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 
 			require_once ($classFile);
-			$screen = new $className ();
+			$screen = new $class();
 		}
 
 		$rendered = $screen->render($runData);

--- a/web/lib/ozoneframework/php/core/DefaultWebFlowController.php
+++ b/web/lib/ozoneframework/php/core/DefaultWebFlowController.php
@@ -91,10 +91,8 @@ class DefaultWebFlowController extends WebFlowController {
 		while ($actionClass != null) {
 
 			require_once (PathManager :: actionClass($actionClass));
-			$tmpa1 = explode('/', $actionClass);
-            $actionClassStripped = end($tmpa1);
-
-			$action = new $actionClassStripped();
+			$class = LegacyTools::getNamespacedClassFromPath(PathManager :: actionClass($actionClass));
+			$action = new $class();
 
 			$classFile = $runData->getScreenClassPath();
 			if(!$action->isAllowed($runData)){

--- a/web/lib/ozoneframework/php/core/Form.php
+++ b/web/lib/ozoneframework/php/core/Form.php
@@ -176,7 +176,8 @@ class Form {
 			if($this->validatorName == null) {
 				$this -> validatorName = "BaseFormValidator";
 			}
-
+			// As far as I can tell there's only the BaseFormValidator but I might be wrong.
+            $this->validatorName = "Ozone\Framework\\".$this->validatorName;
 			foreach($chain as $rule){
 				$this->isValidArray["$fieldName"]=true;
 				$ruleName = $rule['name'];

--- a/web/lib/ozoneframework/php/core/ModuleProcessor.php
+++ b/web/lib/ozoneframework/php/core/ModuleProcessor.php
@@ -100,7 +100,6 @@ class ModuleProcessor {
 	public function renderModule($templateName, $parameters=null){
 
 		$ttt = ModuleHelpers::findModuleClass($templateName);
-//		$className = $ttt[0];
 		$classPath = $ttt[1];
 		require_once($classPath);
 		$class = LegacyTools::getNamespacedClassFromPath($classPath);

--- a/web/lib/ozoneframework/php/core/Ozone.php
+++ b/web/lib/ozoneframework/php/core/Ozone.php
@@ -80,7 +80,7 @@ class Ozone {
 		$serviceFiles = ls($audir, "*.php");
 		foreach ($serviceFiles as $sf){
 			require_once ($audir.$sf);
-			$class = str_replace('.php', '', $sf);
+            $class = LegacyTools::getNamespacedClassFromPath($audir.$sf);
 			$service = new $class(self::$runData);
 			self :: $smarty->assign($service->serviceName(), $service);
 		}

--- a/web/lib/ozoneframework/php/core/Scheduler.php
+++ b/web/lib/ozoneframework/php/core/Scheduler.php
@@ -3,6 +3,8 @@
 namespace Ozone\Framework;
 
 
+use Wikijump\Helpers\LegacyTools;
+
 /**
  * Scheduler.
  *
@@ -152,7 +154,8 @@ class Scheduler {
 			// load Class
 			$classFile = $this->classPath."/".$jobName.".php";
 			require_once($classFile);
-			$object = new $jobName();
+			$class = LegacyTools::getNamespacedClassFromPath($classFile);
+			$object = new $class();
 			$jobEntry->setJobObject($object);
 
 			$this->addJob($jobEntry);

--- a/web/php/Utils/AjaxModuleWikiFlowController.php
+++ b/web/php/Utils/AjaxModuleWikiFlowController.php
@@ -201,8 +201,7 @@ class AjaxModuleWikiFlowController extends WebFlowController
 
             $template = $runData->getModuleTemplate();
             $classFile = $runData->getModuleClassPath();
-            $className = $runData->getModuleClassName();
-            $logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $className");
+            $logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $class");
             require_once($classFile);
             $class = LegacyTools::getNamespacedClassFromPath($classFile);
             $module = new $class();
@@ -252,11 +251,11 @@ class AjaxModuleWikiFlowController extends WebFlowController
             // check if template has been changed by the module. if so...
             if ($template != $runData->getModuleTemplate()) {
                 $classFile = $runData->getModuleClassPath();
-                $className = $runData->getModuleClassName();
-                $logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $className");
+                $class = LegacyTools::getNamespacedClassFromPath($runData->getModuleClassPath());
+                $logger->debug("processing template: ".$runData->getModuleTemplate().", Class: $class");
 
                 require_once($classFile);
-                $module = new $className();
+                $module = new $class();
             }
 
             $module->setTemplate($template);

--- a/web/php/Utils/FeedFlowController.php
+++ b/web/php/Utils/FeedFlowController.php
@@ -12,6 +12,7 @@ use Ozone\Framework\WebFlowController;
 use Wikidot\DB\SitePeer;
 use Wikidot\DB\MemberPeer;
 use Wikidot\DB\SiteViewerPeer;
+use Wikijump\Helpers\LegacyTools;
 
 class FeedFlowController extends WebFlowController
 {
@@ -114,11 +115,11 @@ class FeedFlowController extends WebFlowController
 
         $template = $runData->getScreenTemplate();
         $classFile = $runData->getScreenClassPath();
-        $className = $runData->getScreenClassName();
-        $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+        $class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+        $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 
         require_once($classFile);
-        $screen = new $className();
+        $screen = new $class();
 
         // check if requires authentication
         if ($screen->getRequiresAuthentication() || $site->getPrivate()) {

--- a/web/php/Utils/KarmaCalculator.php
+++ b/web/php/Utils/KarmaCalculator.php
@@ -7,6 +7,7 @@ use Ozone\Framework\Database\Database;
 use Wikidot\DB\UserKarmaPeer;
 use Wikidot\DB\UserKarma;
 use Wikidot\DB\OzoneUserPeer;
+use Wikijump\Helpers\LegacyTools;
 
 class KarmaCalculator
 {
@@ -21,8 +22,8 @@ class KarmaCalculator
         $files = ls($rulesPath, '*.php');
         foreach ($files as $f) {
             require_once($rulesPath.'/'.$f);
-            $cn = str_replace('.php', '', basename($f));
-            $this->_rules[] = new $cn();
+            $class = LegacyTools::getNamespacedClassFromPath($rulesPath.'/'.$f);
+            $this->_rules[] = new $class();
         }
     }
 

--- a/web/php/Utils/WDDefaultFlowController.php
+++ b/web/php/Utils/WDDefaultFlowController.php
@@ -169,10 +169,8 @@ class WDDefaultFlowController extends WebFlowController
         $logger->debug("processing action $actionClass");
         while ($actionClass != null) {
             require_once(PathManager :: actionClass($actionClass));
-            $tmpa1 = explode('/', $actionClass);
-            $actionClassStripped = end($tmpa1);
-
-            $action = new $actionClassStripped();
+            $class = LegacyTools::getNamespacedClassFromPath(PathManager :: actionClass($actionClass));
+            $action = new $class();
 
             $classFile = $runData->getScreenClassPath();
             if (!$action->isAllowed($runData)) {

--- a/web/php/Utils/WDDefaultFlowController.php
+++ b/web/php/Utils/WDDefaultFlowController.php
@@ -11,6 +11,7 @@ use Ozone\Framework\PathManager;
 use Ozone\Framework\RunData;
 use Ozone\Framework\WebFlowController;
 use Wikidot\DB\SitePeer;
+use Wikijump\Helpers\LegacyTools;
 
 class WDDefaultFlowController extends WebFlowController
 {
@@ -138,11 +139,11 @@ class WDDefaultFlowController extends WebFlowController
 
         $template = $runData->getScreenTemplate();
         $classFile = $runData->getScreenClassPath();
-        $className = $runData->getScreenClassName();
-        $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+        $class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+        $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 
         require_once($classFile);
-        $screen = new $className();
+        $screen = new $class();
 
         // screen security check
         if (!$screen->isAllowed($runData)) {
@@ -154,11 +155,10 @@ class WDDefaultFlowController extends WebFlowController
 
                 // reload the Class again - we do not want the unsecure screen to render!
                 $classFile = $runData->getScreenClassPath();
-
-                $className = $runData->getScreenClassName();
-                $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+                $class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+                $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
                 require_once($classFile);
-                $screen = new $className();
+                $screen = new $class();
                 $runData->setAction(null);
             }
         }
@@ -208,11 +208,11 @@ class WDDefaultFlowController extends WebFlowController
         // check if template has been changed by the action. if so...
         if ($template != $runData->getScreenTemplate) {
             $classFile = $runData->getScreenClassPath();
-            $className = $runData->getScreenClassName();
-            $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $className");
+            $class = LegacyTools::getNamespacedClassFromPath($runData->getScreenClassPath());
+            $logger->debug("processing template: ".$runData->getScreenTemplate().", Class: $class");
 
             require_once($classFile);
-            $screen = new $className();
+            $screen = new $class();
         }
 
         $rendered = $screen->render($runData);

--- a/web/web/quickmodule.php
+++ b/web/web/quickmodule.php
@@ -1,6 +1,7 @@
 <?php
 
 use Ozone\Framework\JSONService;
+use Wikijump\Helpers\LegacyTools;
 
 require ('../php/setup.php');
 
@@ -24,8 +25,8 @@ $moduleName = $_GET['module'];
 $modulePath = WIKIJUMP_ROOT . "/php/QuickModules/" . $moduleName . ".php";
 if (file_exists($modulePath)) {
     require_once ($modulePath);
-
-    $module = new $moduleName();
+    $class = LegacyTools::getNamespacedClassFromPath($modulePath);
+    $module = new $class();
     $response = $module->process($parsedData);
 
     if ($parsedData['callbackIndex'] !== null) {


### PR DESCRIPTION
This PR audits all uses of the string `new $class` as there's a lot of repetitive code in the base that uses that. It replaces a call to various `getThingClassName();` calls that assume no namespacing with the new `LegacyTools::getNamespacedClassFromPath()` method call. It also fixes a call to a nonexistent property that should've been a method call in `AjaxModuleWebFlowController.php`