### PR TITLE
Remove all references to Wikidot\DB\OzoneSession

### DIFF
--- a/web/php/DB/OzoneSessionPeerBase.php
+++ b/web/php/DB/OzoneSessionPeerBase.php
@@ -17,7 +17,7 @@ class OzoneSessionPeerBase extends BaseDBPeer
     protected function internalInit()
     {
         $this->tableName='ozone_session';
-        $this->objectName='Wikidot\\DB\\OzoneSession';
+        $this->objectName='Ozone\\Framework\\DB\\OzoneSession';
         $this->primaryKeyName = 'session_id';
         $this->fieldNames = array( 'session_id' ,  'started' ,  'last_accessed' ,  'ip_address' ,  'ip_address_ssl' ,  'ua_hash' ,  'check_ip' ,  'infinite' ,  'user_id' ,  'serialized_datablock' );
         $this->fieldTypes = array( 'session_id' => 'varchar(60)',  'started' => 'timestamp',  'last_accessed' => 'timestamp',  'ip_address' => 'varchar(90)',  'ip_address_ssl' => 'varchar(90)',  'ua_hash' => 'varchar(256)',  'check_ip' => 'boolean',  'infinite' => 'boolean',  'user_id' => 'int',  'serialized_datablock' => 'bytea');

--- a/web/php/DB/Ucookie.php
+++ b/web/php/DB/Ucookie.php
@@ -2,7 +2,7 @@
 
 namespace Wikidot\DB;
 
-
+use Ozone\Framework\DB\OzoneSession;
 
 
 //please extend this Class

--- a/web/php/DB/UcookieBase.php
+++ b/web/php/DB/UcookieBase.php
@@ -4,7 +4,7 @@ namespace Wikidot\DB;
 
 
 
-
+use Ozone\Framework\DB\OzoneSession;
 use Ozone\Framework\Database\BaseDBObject;
 use Ozone\Framework\Database\Criteria;
 


### PR DESCRIPTION
Since both `OzoneSession` classes extend the same base class, I'm going to be removing `Wikidot\DB\OzoneSession` in a future version. This PR should eliminate any remaining references to it in the code.