### PR TITLE
Pass along username in login form when previously logged in

### DIFF
--- a/web/templates/modules/Login/LoginModule.tpl
+++ b/web/templates/modules/Login/LoginModule.tpl
@@ -5,6 +5,7 @@
 
 	{if $user}
 		{t}Hello{/t}, <span style="font-size:130%; font-weight: bold">{$user->getNickName()|escape}</span>
+        <input type="hidden" name="name" value="{$user->getNickName()|escape}" id="login-form-name"/>
 		<br/>
 		<br/>
 	{else}


### PR DESCRIPTION
This fixes that bug where the username is visible but returns invalid username or password when trying to log in.