### PR TITLE
[WJ-388] Implement FriendlyCaptcha verification service for account creation

### DIFF
--- a/install/aws/dev/docker/php-fpm/wikijump.ini
+++ b/install/aws/dev/docker/php-fpm/wikijump.ini
@@ -117,7 +117,7 @@ flickr = "asdf1234"
 ; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
 ; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
 ; Default: ""
-friendlycaptcha-site-key = "asdf1234"
+friendlycaptcha-site-key = "FCMT74J3ULGV4PI8"
 
 ; [FriendlyCaptcha]
 ; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api

--- a/install/aws/dev/docker/php-fpm/wikijump.ini
+++ b/install/aws/dev/docker/php-fpm/wikijump.ini
@@ -113,6 +113,17 @@ upload_restrict_html = true
 ; Default: ""
 flickr = "asdf1234"
 
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
+; Default: ""
+friendlycaptcha-site-key = "asdf1234"
+
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_API_KEY
+; Default: ""
+friendlycaptcha-api-key = "foobar1000"
 
 ;;;;
 ; Database Category

--- a/install/aws/prod/docker/php-fpm/wikijump.ini
+++ b/install/aws/prod/docker/php-fpm/wikijump.ini
@@ -117,7 +117,7 @@ flickr = "asdf1234"
 ; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
 ; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
 ; Default: ""
-friendlycaptcha-site-key = "asdf1234"
+friendlycaptcha-site-key = "FCMT74J3ULV8G4ME"
 
 ; [FriendlyCaptcha]
 ; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api

--- a/install/aws/prod/docker/php-fpm/wikijump.ini
+++ b/install/aws/prod/docker/php-fpm/wikijump.ini
@@ -113,6 +113,17 @@ upload_restrict_html = true
 ; Default: ""
 flickr = "asdf1234"
 
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
+; Default: ""
+friendlycaptcha-site-key = "asdf1234"
+
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_API_KEY
+; Default: ""
+friendlycaptcha-api-key = "foobar1000"
 
 ;;;;
 ; Database Category

--- a/install/local/dev/php-fpm/wikijump.ini
+++ b/install/local/dev/php-fpm/wikijump.ini
@@ -117,7 +117,7 @@ flickr = "asdf1234"
 ; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
 ; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
 ; Default: ""
-friendlycaptcha-site-key = "asdf1234"
+friendlycaptcha-site-key = "FCMT74J3ULGV4PI8"
 
 ; [FriendlyCaptcha]
 ; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api

--- a/install/local/dev/php-fpm/wikijump.ini
+++ b/install/local/dev/php-fpm/wikijump.ini
@@ -113,6 +113,17 @@ upload_restrict_html = true
 ; Default: ""
 flickr = "asdf1234"
 
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
+; Default: ""
+friendlycaptcha-site-key = "asdf1234"
+
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_API_KEY
+; Default: ""
+friendlycaptcha-api-key = "foobar1000"
 
 ;;;;
 ; Database Category

--- a/web/conf/wikijump.ini.example
+++ b/web/conf/wikijump.ini.example
@@ -113,6 +113,17 @@ upload_restrict_html = true
 ; Default: ""
 flickr = "asdf1234"
 
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha site-key (public). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_SITE_KEY
+; Default: ""
+friendlycaptcha-site-key = "asdf1234"
+
+; [FriendlyCaptcha]
+; Purpose: FriendlyCaptcha API key (private). More info at: https://docs.friendlycaptcha.com/#/widget_api
+; GlobalProperties Reference: $FR_CAPTCHA_API_KEY
+; Default: ""
+friendlycaptcha-api-key = "foobar1000"
 
 ;;;;
 ; Database Category

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -45,7 +45,7 @@ class CreateAccount2Action extends SmartyAction
         $email = $pl->getParameterValue("email");
         $password = $pl->getParameterValue("password");
         $password2 = $pl->getParameterValue("password2");
-        $captcha = trim($pl->getParameterValue("captcha"));
+        $captcha = $pl->getParameterValue("frc-captcha-solution");
 
         // validate now.
 

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -111,6 +111,7 @@ class CreateAccount2Action extends SmartyAction
         }
 
         // captcha
+        // TODO(aismallard): verify result with FriendlyCaptcha
         $captcha = str_replace('0', 'O', $captcha);
         $captcha = strtoupper($captcha);
         if ($captcha != strtoupper($runData->sessionGet("captchaCode"))) {

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -41,11 +41,10 @@ class CreateAccount2Action extends SmartyAction
 
         // do it manually. change of rules.
         $pl = $runData->getParameterList();
-        $name = ($pl->getParameterValue("name"));
-        $email = ($pl->getParameterValue("email"));
-        $password = ($pl->getParameterValue("password"));
-        $password2 = ($pl->getParameterValue("password2"));
-
+        $name = $pl->getParameterValue("name");
+        $email = $pl->getParameterValue("email");
+        $password = $pl->getParameterValue("password");
+        $password2 = $pl->getParameterValue("password2");
         $captcha = trim($pl->getParameterValue("captcha"));
 
         // validate now.

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -110,11 +110,10 @@ class CreateAccount2Action extends SmartyAction
         }
 
         // captcha
-        // TODO(aismallard): verify result with FriendlyCaptcha
-        $captcha = str_replace('0', 'O', $captcha);
-        $captcha = strtoupper($captcha);
-        if ($captcha != strtoupper($runData->sessionGet("captchaCode"))) {
-            $errors['captcha'] = _("Account creation failed: CAPTCHA does not match.");
+        // verify reslt with FriendlyCaptcha
+        $captchaValid = FriendlyCaptchaHandler::verifySolution($captcha);
+        if (!$captchaValid) {
+            $errors['captcha'] = _("Account creation failed: CAPTCHA was invalid.");
         }
 
         if (!$pl->getParameterValue("tos")) {

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -111,7 +111,6 @@ class CreateAccount2Action extends SmartyAction
         }
 
         // captcha
-        // verify reslt with FriendlyCaptcha
         $captchaValid = FriendlyCaptchaHandler::verifySolution($captcha);
         if (!$captchaValid) {
             $errors['captcha'] = _("Account creation failed: CAPTCHA was invalid.");

--- a/web/php/Actions/CreateAccount2Action.php
+++ b/web/php/Actions/CreateAccount2Action.php
@@ -14,6 +14,7 @@ use Wikidot\DB\SitePeer;
 use Wikidot\DB\CategoryPeer;
 use Wikidot\DB\PagePeer;
 use Wikidot\Utils\Duplicator;
+use Wikidot\Utils\FriendlyCaptchaHandler;
 use Wikidot\Utils\GlobalProperties;
 use Wikidot\Utils\Outdater;
 use Wikidot\Utils\ProcessException;

--- a/web/php/Modules/CreateAccount/CreateAccount0Module.php
+++ b/web/php/Modules/CreateAccount/CreateAccount0Module.php
@@ -36,7 +36,7 @@ class CreateAccount0Module extends SmartyModule
             $runData->sessionAdd("captchaCode", $code);
         }
 
-        $runData->contextAdd("rand", rand(0, 1000));
+        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
 
         $runData->sessionAdd("rstep", 0);
         $this->extraJs[] = '/common--javascript/crypto/rsa.js';

--- a/web/php/Modules/CreateAccount/CreateAccount0Module.php
+++ b/web/php/Modules/CreateAccount/CreateAccount0Module.php
@@ -5,6 +5,7 @@ namespace Wikidot\Modules\CreateAccount;
 
 use Ozone\Framework\SmartyModule;
 use Wikidot\Utils\CryptUtils;
+use Wikidot\Utils\GlobalProperties;
 use Wikidot\Utils\ProcessException;
 
 class CreateAccount0Module extends SmartyModule
@@ -36,7 +37,7 @@ class CreateAccount0Module extends SmartyModule
             $runData->sessionAdd("captchaCode", $code);
         }
 
-        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
+        $runData->contextAdd('captchaSiteKey', GlobalProperties::$FR_CAPTCHA_SITE_KEY);
 
         $runData->sessionAdd("rstep", 0);
         $this->extraJs[] = '/common--javascript/crypto/rsa.js';

--- a/web/php/Modules/CreateAccount2/CreateAccountModule.php
+++ b/web/php/Modules/CreateAccount2/CreateAccountModule.php
@@ -4,6 +4,7 @@ namespace Wikidot\Modules\CreateAccount2;
 
 
 use Ozone\Framework\SmartyModule;
+use Wikidot\Utils\GlobalProperties;
 use Wikidot\Utils\ProcessException;
 
 class CreateAccountModule extends SmartyModule
@@ -43,7 +44,7 @@ class CreateAccountModule extends SmartyModule
             $runData->sessionAdd("captchaCode", $code);
         }
         $runData->contextAdd('evcode', $code);
-        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
+        $runData->contextAdd('captchaSiteKey', GlobalProperties::$FR_CAPTCHA_SITE_KEY);
         $runData->sessionAdd("rstep", 0);
 
         $pl = $runData->getParameterList();

--- a/web/php/Modules/CreateAccount2/CreateAccountModule.php
+++ b/web/php/Modules/CreateAccount2/CreateAccountModule.php
@@ -43,8 +43,7 @@ class CreateAccountModule extends SmartyModule
             $runData->sessionAdd("captchaCode", $code);
         }
         $runData->contextAdd('evcode', $code);
-        $runData->contextAdd("rand", rand(0, 1000));
-
+        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
         $runData->sessionAdd("rstep", 0);
 
         $pl = $runData->getParameterList();

--- a/web/php/Modules/NewSite/NewSiteModule.php
+++ b/web/php/Modules/NewSite/NewSiteModule.php
@@ -33,5 +33,7 @@ class NewSiteModule extends SmartyModule
         $c->addOrderAscending('site_id');
         $templates = SitePeer::instance()->select($c);
         $runData->contextAdd('templates', $templates);
+
+        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
     }
 }

--- a/web/php/Modules/NewSite/NewSiteModule.php
+++ b/web/php/Modules/NewSite/NewSiteModule.php
@@ -6,6 +6,7 @@ use Ozone\Framework\Database\Criteria;
 use Wikidot\DB\SitePeer;
 
 use Ozone\Framework\SmartyModule;
+use Wikidot\Utils\GlobalProperties;
 use Wikidot\Utils\WDStringUtils;
 
 class NewSiteModule extends SmartyModule
@@ -34,6 +35,6 @@ class NewSiteModule extends SmartyModule
         $templates = SitePeer::instance()->select($c);
         $runData->contextAdd('templates', $templates);
 
-        $runData->contextAdd('captchaSiteKey', 'FCMT74J3ULGV4PI8'); // TODO: get this dynamically based on environment (dev vs prod)
+        $runData->contextAdd('captchaSiteKey', GlobalProperties::$FR_CAPTCHA_SITE_KEY);
     }
 }

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -14,5 +14,13 @@ class FriendlyCaptchaHandler
         );
 
         // TODO(aismallard): verify result with FriendlyCaptcha
+        // see https://docs.friendlycaptcha.com/#/installation?id=_3-verifying-the-captcha-solution-on-the-server
+
+        $response = array(
+            'success' => true,
+            'errorCodes' => ['invalid_solution'],
+        );
+
+        return $response->success;
     }
 }

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -41,6 +41,18 @@ class FriendlyCaptchaHandler
         $body = $response->getBody();
         $result = json_decode($body);
 
+        // The JSON response looks like the following:
+        //
+        // {
+        //     "success": false,
+        //     "errorCodes": [
+        //         "invalid_solution",
+        //         "timeout_or_duplicate"
+        //     ]
+        // }
+        //
+        // The "errorCodes" field may be absent if "success" is true.
+
         if (!$result->success) {
             // TODO log $result->errorCodes
         }

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -2,12 +2,13 @@
 
 namespace Wikidot\Utils;
 
+use GuzzleHttp\Client;
 use Wikidot\Utils\GlobalProperties;
 
 class FriendlyCaptchaHandler
 {
     public static function verifySolution($solution) {
-        $client = new GuzzleHttp\Client();
+        $client = new Client();
 
         // Send POST request
         $response = $client->request(
@@ -37,11 +38,13 @@ class FriendlyCaptchaHandler
             return true;
         }
 
-        $body = $response->json();
-        if (!$body->success) {
-            // TODO log $body->errorCodes
+        $body = $response->getBody();
+        $result = json_decode($body);
+
+        if (!$result->success) {
+            // TODO log $result->errorCodes
         }
 
-        return $response->success;
+        return $result->success;
     }
 }

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -21,6 +21,24 @@ class FriendlyCaptchaHandler
             'errorCodes' => ['invalid_solution'],
         );
 
+        if (!$response->success) {
+            // TODO: log $response->errorCodes
+        }
+
+        if ($responseCode != 200) {
+            // FriendlyCaptcha will always send 200 OK if the request was properly formed,
+            // regardless of whether
+            //
+            // If another code (e.g. 401) is received, it indicates an error on our end or
+            // FriendlyCaptcha's end. In such a case it is recommended we be permissive and
+            // let them proceed anyways, otherwise we're breaking a core site feature until
+            // the outage is resolved.
+            //
+            // See https://docs.friendlycaptcha.com/#/verification_api
+
+            // TODO: log big bad error thing
+        }
+
         return $response->success;
     }
 }

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -16,6 +16,12 @@ class FriendlyCaptchaHandler
         // TODO(aismallard): verify result with FriendlyCaptcha
         // see https://docs.friendlycaptcha.com/#/installation?id=_3-verifying-the-captcha-solution-on-the-server
 
+        // TODO have this actually POST lol
+        $response = doPostSomehow(
+            'https://friendlycaptcha.com/api/v1/siteverify',
+            $request,
+        );
+
         $response = array(
             'success' => true,
             'errorCodes' => ['invalid_solution'],

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wikidot\Utils;
+
+use Wikidot\Utils\GlobalProperties;
+
+class FriendlyCaptchaHandler
+{
+    public static function verifySolution($solution) {
+        $request = array(
+            'solution' => $solution,
+            'secret' => GlobalProperties::$FR_CAPTCHA_API_KEY,
+            'sitekey' => GlobalProperties::$FR_CAPTCHA_SITE_KEY,
+        );
+
+        // TODO(aismallard): verify result with FriendlyCaptcha
+    }
+}

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -14,7 +14,7 @@ class FriendlyCaptchaHandler
             'POST',
             'https://friendlycaptcha.com/api/v1/siteverify',
             [
-                'form_params' => [
+                'json' => [
                     'solution' => $solution,
                     'secret' => GlobalProperties::$FR_CAPTCHA_API_KEY,
                     'sitekey' => GlobalProperties::$FR_CAPTCHA_SITE_KEY,

--- a/web/php/Utils/FriendlyCaptchaHandler.php
+++ b/web/php/Utils/FriendlyCaptchaHandler.php
@@ -25,7 +25,7 @@ class FriendlyCaptchaHandler
 
         if ($response->getStatusCode() != 200) {
             // FriendlyCaptcha will always send 200 OK if the request was properly formed,
-            // regardless of whether
+            // regardless of whether the CAPTCHA was considered valid or not.
             //
             // If another code (e.g. 401) is received, it indicates an error on our end or
             // FriendlyCaptcha's end. In such a case it is recommended we be permissive and

--- a/web/php/Utils/GlobalProperties.php
+++ b/web/php/Utils/GlobalProperties.php
@@ -97,6 +97,8 @@ class GlobalProperties
 
     // third-party keys
     public static $FLICKR_API_KEY;
+    public static $FR_CAPTCHA_SITE_KEY;
+    public static $FR_CAPTCHA_API_KEY;
 
     // non-configurable properties
     public static $DATABASE_TYPE;
@@ -245,6 +247,8 @@ class GlobalProperties
         self::$XSENDFILE_HEADER         = $_ENV["WIKIJUMP_XSENDFILE_HEADER"] ?? self::fromIni("misc", "xsendfile_header", "X-LIGHTTPD-send-file");
 
         self::$FLICKR_API_KEY           = $_ENV["WIKIJUMP_FLICKR_API_KEY"] ?? self::fromIni("keys", "flickr", "");
+        self::$FR_CAPTCHA_SITE_KEY      = $_ENV["WIKIJUMP_FR_CAPTCHA_SITE_KEY"] ?? self::fromIni("keys", "friendlycaptcha-site-key", "");
+        self::$FR_CAPTCHA_API_KEY       = $_ENV["WIKIJUMP_FR_CAPTCHA_API_KEY"] ?? self::fromIni("keys", "friendlycaptcha-api-key", "");
 
         // non-configurable properties
         self::$DATABASE_TYPE            = "pgsql";

--- a/web/templates/modules/CreateAccount/CreateAccount0Module.tpl
+++ b/web/templates/modules/CreateAccount/CreateAccount0Module.tpl
@@ -72,13 +72,10 @@
 						{t}Are you a human?{/t}
 					</td>
 					<td>
-						<img src="/default--flow/Misc__Captcha/rand/{$rand}" alt="turing code"/>
-						<br/>
-						<input class="text" type="text" name="captcha" size="10" />
-						<div class="sub">
-							{t}Please write the code you can see above. Upper/lowercase does not matter.{/t}
-							<br/>{t}This is to prevent automated bots.{/t}
-						</div>
+						<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.module.min.js" async defer></script>
+						<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.min.js" async defer></script>
+						<div class="frc-captcha" data-sitekey="{$captchaSiteKey}"></div>
+						<!-- former home of Misc__Captcha -->
 					</td>
 				</tr>
 				<tr>

--- a/web/templates/modules/CreateAccount2/CreateAccountModule.tpl
+++ b/web/templates/modules/CreateAccount2/CreateAccountModule.tpl
@@ -62,13 +62,10 @@
 						{t}Are you a human?{/t}
 					</td>
 					<td>
-						<img src="/default--flow/Misc__Captcha/rand/{$rand}" alt="turing code"/>
-						<br/>
-						<input class="text" type="text" name="captcha" size="10" />
-						<div class="sub">
-							{t}Please write the code you can see above. Upper/lowercase does not matter.{/t}
-							<br/>{t}This is to prevent automated bots.{/t}
-						</div>
+						<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.module.min.js" async defer></script>
+						<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.min.js" async defer></script>
+						<div class="frc-captcha" data-sitekey="{$captchaSiteKey}"></div>
+						<!-- former home of Misc__Captcha -->
 					</td>
 				</tr>
 				<tr>

--- a/web/templates/modules/NewSite/NewSiteModule.tpl
+++ b/web/templates/modules/NewSite/NewSiteModule.tpl
@@ -108,12 +108,10 @@
 						{t}Are you a human?{/t}
 					</td>
 					<td>
-						<img src="/default--flow/Misc__Captcha/rand/{$rand}" alt="turing code"/>
-						<br/>
-						<input  class="text" type="text" name="captcha" size="10" />
-						<div class="sub">
-							{t}Enter the above code.{/t}
-						</div>
+						<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.module.min.js" async defer></script>
+						<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.8.3/widget.min.js" async defer></script>
+						<div class="frc-captcha" data-sitekey="{$captchaSiteKey}"></div>
+						<!-- former home of Misc__Captcha -->
 					</td>
 				</tr> *}
 				<tr>


### PR DESCRIPTION
This is the initial working implementation of FriendlyCaptcha as our replacement CAPTCHA provider over whatever the fuck Wikidot was doing before.

Running this locally, attempting to create an account successfully results in a backend `POST` to their API, which returns success and allows the registration process to proceed to the next step (in this case email):
![screenshot of JSON response](https://media.discordapp.net/attachments/779439023989981215/825970387472351242/unknown.png)

This is what the account creation screen looks like now:
![screenshot of local wikijump](https://user-images.githubusercontent.com/8848022/112792772-129d5f00-9032-11eb-8530-fc157d1d3dda.png)

----

If you want to run this locally, modify your version of `install/local/dev/php-fpm/wikijump.ini` to set `friendlycaptcha-api-key` to the private API key, as available in the secrets repository. (Or set the `WIKIJUMP_FR_CAPTCHA_API_KEY` environment variable).  
If you do not have access, you can create your own FriendlyCaptcha account and use the provided site and API keys.

Note that the "site key" is public, which is why it is included in this PR. The API key is private.  
For Wikijump, there are separate site and API keys for local/dev and prod.

----

For [WJ-388](https://scuttle.atlassian.net/browse/WJ-388) there are still a few things that need doing:
* Move `<script>` declarations to the HTML header
* Implementing captcha integration for other modules
* Deleting Wikidot's shitty captcha implementation

I will handle these in separate PRs.