### PR TITLE
Small fix and QOL improvement

### DIFF
--- a/install/local/dev/postgres/pg_hba.conf
+++ b/install/local/dev/postgres/pg_hba.conf
@@ -24,6 +24,11 @@ local   all             postgres                                peer
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
+# Docker connections - You are encouraged to tighten this rule up as needed.
+# By default, the username, password, and db name are all `wikijump`.
+host    all             all             172.16.0.0/12           md5
+
+
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
 # IPv4 local connections:

--- a/web/php/DB/OzoneSession.php
+++ b/web/php/DB/OzoneSession.php
@@ -7,7 +7,11 @@ namespace Wikidot\DB;
  * Object Model Class.
  *
  */
-class OzoneSession extends OzoneSessionBase
+class OzoneSession extends \Ozone\Framework\DB\OzoneSession
 {
-
+    /**
+     *  Look man. I know how dumb this looks. You're not telling me anything I don't know.
+     *  But if you remove this class, or rename it, you'll break logon sessions.
+     *  Blame Ozone\Framework\Database\BaseDBPeer.
+     */
 }


### PR DESCRIPTION
This PR has two little things outside the scope of my Laravel work. One is having Wikidot's OzoneSession inherit the Ozone Framework class of the same name to work around some limitations in how namespacing has been introduced to the legacy codebase. Without this, long-lived sessions will cause the user to only see PHP fatal errors rather than the site.

It also changes the local docker-compose environment to allow for connections to the postgres container from your client or IDE of choice.