### PR TITLE
[WJ-3] Change password length limits to min 8, max 1024.

### DIFF
--- a/web/php/Actions/CreateAccountAction.php
+++ b/web/php/Actions/CreateAccountAction.php
@@ -143,8 +143,8 @@ class CreateAccountAction extends SmartyAction
         // check password
         if (strlen8($password)<8) {
             $errors['password'] = _("Please provide a password at least 8 characters long.");
-        } elseif (strlen8($password)>20) {
-            $errors['password'] = _("Password should not be longer than 20 characters.");
+        } elseif (strlen8($password)>1024) {
+            $errors['password'] = _("Password should not be longer than 1024 characters.");
         } elseif ($password2 != $password) {
             $errors['password2'] = _("Passwords are not identical.");
         }

--- a/web/php/Actions/CreateAccountAction.php
+++ b/web/php/Actions/CreateAccountAction.php
@@ -141,8 +141,8 @@ class CreateAccountAction extends SmartyAction
         }
 
         // check password
-        if (strlen8($password)<6) {
-            $errors['password'] = _("Please provide a password min. 6 characters long.");
+        if (strlen8($password)<8) {
+            $errors['password'] = _("Please provide a password at least 8 characters long.");
         } elseif (strlen8($password)>20) {
             $errors['password'] = _("Password should not be longer than 20 characters.");
         } elseif ($password2 != $password) {

--- a/web/templates/modules/Account/Settings/ASPasswordModule.tpl
+++ b/web/templates/modules/Account/Settings/ASPasswordModule.tpl
@@ -11,21 +11,21 @@
 	<table class="form">
 		<tr>
 			<td>Your current password:</td>
-			<td><input class="text" type="password" name="old_password" size="20" maxlength="40"/></td>
+			<td><input class="text" type="password" name="old_password" size="20" maxlength="1024"/></td>
 		</tr>
 		<tr>
 			<td>New password:</td>
 			<td>
-				<input class="text" type="password" name="new_password1" size="20" maxlength="40"/>
+				<input class="text" type="password" name="new_password1" size="20" maxlength="1024"/>
 				<div class="sub">
-					Min. 8 characters, max. 20.
+					Min. 8 characters, max. 1024.
 				</div>
 			</td>
 		</tr>
 		<tr>
 			<td>New password (repeat):</td>
 			<td>
-				<input class="text" type="password" name="new_password2" size="20" maxlength="40"/>
+				<input class="text" type="password" name="new_password2" size="20" maxlength="1024"/>
 				<div class="sub">
 					Please repeat to prevent typos.
 				</div>

--- a/web/templates/modules/Account/Settings/ASPasswordModule.tpl
+++ b/web/templates/modules/Account/Settings/ASPasswordModule.tpl
@@ -18,7 +18,7 @@
 			<td>
 				<input class="text" type="password" name="new_password1" size="20" maxlength="40"/>
 				<div class="sub">
-					Min. 6 characters, max. 20.
+					Min. 8 characters, max. 20.
 				</div>
 			</td>
 		</tr>

--- a/web/templates/modules/CreateAccount/CreateAccount0Module.tpl
+++ b/web/templates/modules/CreateAccount/CreateAccount0Module.tpl
@@ -53,9 +53,9 @@
 						{t}Password{/t}:
 					</td>
 					<td>
-						 <input class="text" type="password" name="password" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password" maxlength="1024" size="15"/>
 						 <div class="sub">
-						 	{t}Between 6 and 20 characters{/t}.
+						 	{t}Between 8 and 1024 characters{/t}.
 						 </div>
 					</td>
 				</tr>
@@ -64,7 +64,7 @@
 						{t}Password (repeat){/t}:
 					</td>
 					<td>
-						 <input class="text" type="password" name="password2" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password2" maxlength="1024" size="15"/>
 					</td>
 				</tr>
 				<tr>

--- a/web/templates/modules/CreateAccount2/CreateAccountModule.tpl
+++ b/web/templates/modules/CreateAccount2/CreateAccountModule.tpl
@@ -20,7 +20,7 @@
 						{t}Your email address{/t}:
 					</td>
 					<td>
-						<input class="text" type="text"  maxlength="50" size="25" name="email"/>
+						<input class="text" type="text" maxlength="50" size="25" name="email"/>
 					</td>
 				</tr>
 				<tr>
@@ -43,9 +43,9 @@
 						{t}Password{/t}:
 					</td>
 					<td>
-						 <input class="text" type="password" name="password" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password" maxlength="1024" size="15"/>
 						 <div class="sub">
-						 	{t}Between 6 and 20 characters{/t}.
+						 	{t}Between 8 and 1024 characters{/t}.
 						 </div>
 					</td>
 				</tr>
@@ -54,7 +54,7 @@
 						{t}Password (repeat){/t}:
 					</td>
 					<td>
-						 <input class="text" type="password" name="password2" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password2" maxlength="1024" size="15"/>
 					</td>
 				</tr>
 				<tr>

--- a/web/templates/modules/Membership/MembershipByPasswordModule.tpl
+++ b/web/templates/modules/Membership/MembershipByPasswordModule.tpl
@@ -13,7 +13,7 @@
 				{t}Password{/t}:
 			</td>
 			<td>
-				<input class="text" type="password" name="password" size="40" maxlength="50"/><br/>
+				<input class="text" type="password" name="password" size="40" maxlength="1024"/><br/>
 			</td>
 		</tr>
 	</table>

--- a/web/templates/modules/PasswordRecovery/PasswordRecovery2Module.tpl
+++ b/web/templates/modules/PasswordRecovery/PasswordRecovery2Module.tpl
@@ -27,9 +27,9 @@
 						Password:
 					</td>
 					<td>
-						 <input class="text" type="password" name="password" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password" maxlength="1024" size="15"/>
 						 <div class="sub">
-						 	Between 6 and 20 characters.
+						 	Between 8 and 1024 characters.
 						 </div>
 					</td>
 				</tr>
@@ -38,7 +38,7 @@
 						Password (repeat):
 					</td>
 					<td>
-						 <input class="text" type="password" name="password2" maxlength="30" size="15"/>
+						 <input class="text" type="password" name="password2" maxlength="1024" size="15"/>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
As detailed in [WJ-3](https://scuttle.atlassian.net/browse/WJ-3), a maximum of 20 is arbitrarily short and limits password effectiveness. This PR raises the upper bound to 1024 (not so large as to enable denial-of-service attacks, but more than long enough for very secure passwords), and raises the lower bound to 8. This will bring Wikijump in line with FIPS recommendations regarding password lengths.

This PR also fixes the various inconsistent password input field maximum lengths set throughout the codebase, standardizing on the maximum length of 1024.