### PR TITLE
Have OzoneSessionPeer shadow Wikidot class

### DIFF
--- a/web/lib/ozoneframework/php/core/DB/OzoneSessionPeer.php
+++ b/web/lib/ozoneframework/php/core/DB/OzoneSessionPeer.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Ozone\Framework\DB;
+
+
+class OzoneSessionPeer extends \Wikidot\DB\OzoneSessionPeer
+{
+  /**
+   * Stub class used for namespace translation.
+   */
+}


### PR DESCRIPTION
This is a dumb but seemingly necessary change to deal with an `OzoneSessionPeer` instance being dynamically created in the wrong namespace.