### PR TITLE
Forbid api domains from registration

### DIFF
--- a/web/conf/forbidden_site_names.conf
+++ b/web/conf/forbidden_site_names.conf
@@ -44,3 +44,4 @@
 /^wdupload$/
 /^wjupload$/
 /^file[s]?$/
+/^api[0-9]*/


### PR DESCRIPTION
We may or may not use the e.g., `api` or `api01` subdomain but there's very little legitimate reason to allow it to be registered by a user.