### PR TITLE
Use nginx and php-fpm containers in local dev

### DIFF
--- a/install/local/dev/docker-compose.yaml.example
+++ b/install/local/dev/docker-compose.yaml.example
@@ -9,7 +9,24 @@ services:
       context: ./postgres
       args:
         FILES_DOMAIN: 'wjfiles.test'
+    ports:
+      - "5432:5432"
     restart: always
+  nginx:
+    build:
+      context: ./nginx
+    links:
+      - php-fpm
+    depends_on:
+      - php-fpm
+#    volumes:
+#      #      - C:\wikijump:/var/www/wikijump
+#      - ~/wikijump:/var/www/wikijump
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.php-fpm.tls=true
+      - traefik.http.routers.php-fpm.rule=Method(`GET`,`POST`,`HEAD`,`PUT`,`PATCH`,`DELETE`)  # Poor man's default route
+      # If you wish to map the web files to a local working copy uncomment whichever makes sense below.
   php-fpm:
     build:
       context: ./php-fpm
@@ -23,16 +40,11 @@ services:
     depends_on:
       - cache
       - database
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.php-fpm.tls=true
-      - traefik.http.routers.php-fpm.rule=Method(`GET`,`POST`,`HEAD`,`PUT`,`PATCH`,`DELETE`) # Poor man's default route
-    # If you wish to map the web files to a local working copy uncomment whichever makes sense below.
-    # volumes:
-    #   - C:\wikijump:/var/www/wikijump
-    #   - /var/www/wikijump:/var/www
+    volumes:
+      #      - C:\wikijump:/var/www/wikijump
+      - ~/wikijump:/var/www/wikijump
   reverse-proxy:
-    image: traefik:v2.3
+    image: traefik:v2.4
     command:
       - --providers.docker
       - --entrypoints.web.address=:80
@@ -45,9 +57,9 @@ services:
       - "80:80"
       - "443:443"
     links:
-      - php-fpm
+      - nginx
     depends_on:
-      - php-fpm
+      - nginx
     volumes:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/install/local/dev/docker-compose.yaml.example
+++ b/install/local/dev/docker-compose.yaml.example
@@ -19,14 +19,14 @@ services:
       - php-fpm
     depends_on:
       - php-fpm
+# If you wish to map the web files to a local working copy uncomment whichever makes sense below.
 #    volumes:
-#      #      - C:\wikijump:/var/www/wikijump
+#      - C:\wikijump:/var/www/wikijump
 #      - ~/wikijump:/var/www/wikijump
     labels:
       - traefik.enable=true
       - traefik.http.routers.php-fpm.tls=true
       - traefik.http.routers.php-fpm.rule=Method(`GET`,`POST`,`HEAD`,`PUT`,`PATCH`,`DELETE`)  # Poor man's default route
-      # If you wish to map the web files to a local working copy uncomment whichever makes sense below.
   php-fpm:
     build:
       context: ./php-fpm
@@ -40,9 +40,10 @@ services:
     depends_on:
       - cache
       - database
-    volumes:
-      #      - C:\wikijump:/var/www/wikijump
-      - ~/wikijump:/var/www/wikijump
+# If you wish to map the web files to a local working copy uncomment whichever makes sense below.
+#    volumes:
+#      - C:\wikijump:/var/www/wikijump
+#      - ~/wikijump:/var/www/wikijump
   reverse-proxy:
     image: traefik:v2.4
     command:

--- a/install/local/dev/nginx/Dockerfile
+++ b/install/local/dev/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+EXPOSE 80
+RUN apk add shadow && usermod -u 1000 nginx && groupmod -g 1000 nginx
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/install/local/dev/nginx/Dockerfile
+++ b/install/local/dev/nginx/Dockerfile
@@ -1,4 +1,28 @@
+FROM node:alpine as npm
+
+# Please note this arg is also defined in the nginx layer further down.
+ARG WIKIJUMP_REPO_DIR="wikijump"
+
+ARG WIKIJUMP_REPO_BRANCH="develop"
+ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
+WORKDIR /src
+
+RUN apk add --no-cache git
+
+RUN git clone \
+            --depth 10 \
+            --branch "${WIKIJUMP_REPO_BRANCH}" \
+            "${WIKIJUMP_REPO}"
+
+WORKDIR /src/${WIKIJUMP_REPO_DIR}/web
+
+RUN npm install
+RUN npm run build
+
 FROM nginx:alpine
+ARG WIKIJUMP_REPO_DIR="wikijump"
 EXPOSE 80
-RUN apk add shadow && usermod -u 1000 nginx && groupmod -g 1000 nginx
+
+COPY --from=npm /src/${WIKIJUMP_REPO_DIR}/web/web /var/www/wikijump/web/web
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/install/local/dev/nginx/nginx.conf
+++ b/install/local/dev/nginx/nginx.conf
@@ -1,146 +1,145 @@
-                     # user www-data;
-                     worker_processes auto;
-                     pid /run/nginx.pid;
+ worker_processes auto;
+ pid /run/nginx.pid;
 
-                     events {
-                             worker_connections 768;
-                             # multi_accept on;
+ events {
+         worker_connections 768;
+         # multi_accept on;
+ }
+
+ http {
+
+         log_format main '$http_x_real_ip - $remote_user [$time_local] '
+         '"$request" $status $body_bytes_sent "$http_referer" '
+         '"$http_user_agent"' ;
+
+         ##
+         # Basic Settings
+         ##
+
+         sendfile on;
+         tcp_nopush on;
+         tcp_nodelay on;
+         keepalive_timeout 65;
+         types_hash_max_size 2048;
+         # server_tokens off;
+
+         # server_names_hash_bucket_size 64;
+         # server_name_in_redirect off;
+
+         include /etc/nginx/mime.types;
+         default_type application/octet-stream;
+
+         ##
+         # SSL Settings
+         ##
+
+         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+         ssl_prefer_server_ciphers on;
+
+         ##
+         # Logging Settings
+         ##
+
+         access_log /var/log/nginx/access.log main;
+         error_log /var/log/nginx/error.log;
+
+         ##
+         # Gzip Settings
+         ##
+
+         gzip on;
+
+         # gzip_vary on;
+         # gzip_proxied any;
+         # gzip_comp_level 6;
+         # gzip_buffers 16 8k;
+         # gzip_http_version 1.1;
+         # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+         ##
+         # Virtual Host Configs
+         ##
+
+         # include /etc/nginx/conf.d/*.conf;
+         server {
+                 server_name wikijump;
+                 listen 80;
+                 listen [::]:80;
+
+                 root /var/www/wikijump/web/web;
+
+                 # Add index.php to the list if you are using PHP
+                 index index.php;
+
+                 location /wikijump--next {
+                     # Assets
+                     location /wikijump--next/assets {
+                         alias /var/www/wikijump/web/storage/app/public;
                      }
 
-                     http {
+                     # Fallback
+                     try_files $uri /laravel.php?$args;
+                 }
 
-                             log_format main '$http_x_real_ip - $remote_user [$time_local] '
-                             '"$request" $status $body_bytes_sent "$http_referer" '
-                             '"$http_user_agent"' ;
+                 location / {
+                     # First attempt to serve request as file, then
+                     # as directory, then fall back to displaying a 404.
+                     # As this is the most vague block, stuff in here gets examined last.
+                     try_files $uri $uri/ /index.php?$args;
+                     # Fallback Route
+                 }
 
-                             ##
-                             # Basic Settings
-                             ##
+                 location ~ \.php$ {
+                             set_real_ip_from reverse-proxy;
+                             # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+                             fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 
-                             sendfile on;
-                             tcp_nopush on;
-                             tcp_nodelay on;
-                             keepalive_timeout 65;
-                             types_hash_max_size 2048;
-                             # server_tokens off;
+                             # Check that the PHP script exists before passing it
+                             try_files $fastcgi_script_name =404;
 
-                             # server_names_hash_bucket_size 64;
-                             # server_name_in_redirect off;
+                             # Set buffer size large enough for Laravel debug stack traces to come through
+                             # LOCAL AND AWS DEV ONLY - There shouldn't be any reason to set this for prod.
+                             fastcgi_buffers 16 256k;
 
-                             include /etc/nginx/mime.types;
-                             default_type application/octet-stream;
+                             # Bypass the fact that try_files resets $fastcgi_path_info
+                             # see: http://trac.nginx.org/nginx/ticket/321
+                             set $path_info $fastcgi_path_info;
+                             fastcgi_param PATH_INFO $path_info;
+                             # fastcgi_param REMOTE_ADDR $http_x_real_ip;
 
-                             ##
-                             # SSL Settings
-                             ##
+                             fastcgi_index index.php;
+                             include fastcgi.conf;
 
-                             ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
-                             ssl_prefer_server_ciphers on;
+                             fastcgi_pass php-fpm:9000;
+                 }
 
-                             ##
-                             # Logging Settings
-                             ##
+                 rewrite ^/common--(.+)$ /files--common/$1 break;
+                 rewrite ^/a16.png /files--common/images/avatars/default/a16.png break;
+                 rewrite ^/a48.png /files--common/images/avatars/default/a48.png break;
+                 rewrite ^/forum/start(.*)$ /index.php?Wiki__WikiScreen/wiki_page/forum:start$1 break;
+                 rewrite ^/forum/t-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:thread/t/$1$2 break;
+                 rewrite ^/forum/c-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:category/c/$1$2 break;
+                 rewrite ^/feed/forum/t\-([0-9]+)\.xml$ /feed.php?Feed__ForumThreadPostsFeed/t/$1 break;
+                 rewrite ^/feed/forum/ct\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryThreadsFeed/c/$1$2 break;
+                 rewrite ^/feed/forum/cp\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryPostsFeed/c/$1$2 break;
+                 rewrite ^/feed/forum/posts\.xml$ /feed.php?Feed__ForumPostsFeed break;
+                 rewrite ^/feed/forum/threads\.xml$ /feed.php?Feed__ForumThreadsFeed break;
+                 rewrite ^/feed/page/comments\-([0-9]+)\.xml$ /feed.php?Feed__PageCommentsFeed/p/$1 break;
+                 rewrite ^/feed/front/([a-z\-:]+)/([0-9a-zA-Z\-]+)\.xml$ /feed.php?Feed__FrontForumFeed/page/$1/label/$2 break;
+                 rewrite ^/feed/site\-changes\.xml$ /feed.php?Feed__SiteChangesFeed break;
+                 rewrite ^/feed/admin\.xml$ /feed.php?Feed__AdminNotificationsFeed break;
+                 rewrite ^/printer--friendly/+forum/start(.*)$ /index.php?PrinterFriendly/wiki_page/forum:start$1 break;
+                 rewrite ^/printer--friendly/+forum/t-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:thread/t/$1$2 break;
+                 rewrite ^/printer--friendly/+forum/c-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:category/c/$1$2 break;
+                 rewrite ^/printer--friendly/(.*)$ /index.php?PrinterFriendly/wiki_page/$1 break;
+                 rewrite ^/default--screen/(.*)$ /index.php?$1 break;
+                 rewrite ^/local--([^/]+/.*)$ /local.php?$1 break;
+                 rewrite ^/([a-z0-9\-]+)/code(?:(/[0-9]+))?$ /local.php?code/$1$2 break;
 
-                             access_log /var/log/nginx/access.log main;
-                             error_log /var/log/nginx/error.log;
+                 # pass PHP scripts to FastCGI server
+                 rewrite ^/(.*)\.php$ /$1.php break;
 
-                             ##
-                             # Gzip Settings
-                             ##
-
-                             gzip on;
-
-                             # gzip_vary on;
-                             # gzip_proxied any;
-                             # gzip_comp_level 6;
-                             # gzip_buffers 16 8k;
-                             # gzip_http_version 1.1;
-                             # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-
-                             ##
-                             # Virtual Host Configs
-                             ##
-
-                             # include /etc/nginx/conf.d/*.conf;
-                             server {
-                                     server_name wikijump;
-                                     listen 80;
-                                     listen [::]:80;
-
-                                     root /var/www/wikijump/web/web;
-
-                                     # Add index.php to the list if you are using PHP
-                                     index index.php;
-
-                                     location /wikijump--next {
-                                         # Assets
-                                         location /wikijump--next/assets {
-                                             alias /var/www/wikijump/web/storage/app/public;
-                                         }
-
-                                         # Fallback
-                                         try_files $uri /laravel.php?$args;
-                                     }
-
-                                     location / {
-                                         # First attempt to serve request as file, then
-                                         # as directory, then fall back to displaying a 404.
-                                         # As this is the most vague block, stuff in here gets examined last.
-                                         try_files $uri $uri/ /index.php?$args;
-                                         # Fallback Route
-                                     }
-
-                                     location ~ \.php$ {
-                                                 set_real_ip_from reverse-proxy;
-                                                 # regex to split $uri to $fastcgi_script_name and $fastcgi_path
-                                                 fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-
-                                                 # Check that the PHP script exists before passing it
-                                                 try_files $fastcgi_script_name =404;
-
-                                                 # Set buffer size large enough for Laravel debug stack traces to come through
-                                                 # LOCAL AND AWS DEV ONLY - There shouldn't be any reason to set this for prod.
-                                                 fastcgi_buffers 16 256k;
-
-                                                 # Bypass the fact that try_files resets $fastcgi_path_info
-                                                 # see: http://trac.nginx.org/nginx/ticket/321
-                                                 set $path_info $fastcgi_path_info;
-                                                 fastcgi_param PATH_INFO $path_info;
-                                                 # fastcgi_param REMOTE_ADDR $http_x_real_ip;
-
-                                                 fastcgi_index index.php;
-                                                 include fastcgi.conf;
-
-                                                 fastcgi_pass php-fpm:9000;
-                                     }
-
-                                     rewrite ^/common--(.+)$ /files--common/$1 break;
-                                     rewrite ^/a16.png /files--common/images/avatars/default/a16.png break;
-                                     rewrite ^/a48.png /files--common/images/avatars/default/a48.png break;
-                                     rewrite ^/forum/start(.*)$ /index.php?Wiki__WikiScreen/wiki_page/forum:start$1 break;
-                                     rewrite ^/forum/t-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:thread/t/$1$2 break;
-                                     rewrite ^/forum/c-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:category/c/$1$2 break;
-                                     rewrite ^/feed/forum/t\-([0-9]+)\.xml$ /feed.php?Feed__ForumThreadPostsFeed/t/$1 break;
-                                     rewrite ^/feed/forum/ct\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryThreadsFeed/c/$1$2 break;
-                                     rewrite ^/feed/forum/cp\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryPostsFeed/c/$1$2 break;
-                                     rewrite ^/feed/forum/posts\.xml$ /feed.php?Feed__ForumPostsFeed break;
-                                     rewrite ^/feed/forum/threads\.xml$ /feed.php?Feed__ForumThreadsFeed break;
-                                     rewrite ^/feed/page/comments\-([0-9]+)\.xml$ /feed.php?Feed__PageCommentsFeed/p/$1 break;
-                                     rewrite ^/feed/front/([a-z\-:]+)/([0-9a-zA-Z\-]+)\.xml$ /feed.php?Feed__FrontForumFeed/page/$1/label/$2 break;
-                                     rewrite ^/feed/site\-changes\.xml$ /feed.php?Feed__SiteChangesFeed break;
-                                     rewrite ^/feed/admin\.xml$ /feed.php?Feed__AdminNotificationsFeed break;
-                                     rewrite ^/printer--friendly/+forum/start(.*)$ /index.php?PrinterFriendly/wiki_page/forum:start$1 break;
-                                     rewrite ^/printer--friendly/+forum/t-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:thread/t/$1$2 break;
-                                     rewrite ^/printer--friendly/+forum/c-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:category/c/$1$2 break;
-                                     rewrite ^/printer--friendly/(.*)$ /index.php?PrinterFriendly/wiki_page/$1 break;
-                                     rewrite ^/default--screen/(.*)$ /index.php?$1 break;
-                                     rewrite ^/local--([^/]+/.*)$ /local.php?$1 break;
-                                     rewrite ^/([a-z0-9\-]+)/code(?:(/[0-9]+))?$ /local.php?code/$1$2 break;
-
-                                     # pass PHP scripts to FastCGI server
-                                     rewrite ^/(.*)\.php$ /$1.php break;
-
-                                     # Fallback route
-                                     rewrite ^\/(?!wikijump--next\/)(.*)$ /index.php?Wiki__WikiScreen/wiki_page/$1? break;
-                             }
-                     }
+                 # Fallback route
+                 rewrite ^\/(?!wikijump--next\/)(.*)$ /index.php?Wiki__WikiScreen/wiki_page/$1? break;
+         }
+ }

--- a/install/local/dev/nginx/nginx.conf
+++ b/install/local/dev/nginx/nginx.conf
@@ -1,0 +1,146 @@
+                     # user www-data;
+                     worker_processes auto;
+                     pid /run/nginx.pid;
+
+                     events {
+                             worker_connections 768;
+                             # multi_accept on;
+                     }
+
+                     http {
+
+                             log_format main '$http_x_real_ip - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent "$http_referer" '
+                             '"$http_user_agent"' ;
+
+                             ##
+                             # Basic Settings
+                             ##
+
+                             sendfile on;
+                             tcp_nopush on;
+                             tcp_nodelay on;
+                             keepalive_timeout 65;
+                             types_hash_max_size 2048;
+                             # server_tokens off;
+
+                             # server_names_hash_bucket_size 64;
+                             # server_name_in_redirect off;
+
+                             include /etc/nginx/mime.types;
+                             default_type application/octet-stream;
+
+                             ##
+                             # SSL Settings
+                             ##
+
+                             ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+                             ssl_prefer_server_ciphers on;
+
+                             ##
+                             # Logging Settings
+                             ##
+
+                             access_log /var/log/nginx/access.log main;
+                             error_log /var/log/nginx/error.log;
+
+                             ##
+                             # Gzip Settings
+                             ##
+
+                             gzip on;
+
+                             # gzip_vary on;
+                             # gzip_proxied any;
+                             # gzip_comp_level 6;
+                             # gzip_buffers 16 8k;
+                             # gzip_http_version 1.1;
+                             # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+                             ##
+                             # Virtual Host Configs
+                             ##
+
+                             # include /etc/nginx/conf.d/*.conf;
+                             server {
+                                     server_name wikijump;
+                                     listen 80;
+                                     listen [::]:80;
+
+                                     root /var/www/wikijump/web/web;
+
+                                     # Add index.php to the list if you are using PHP
+                                     index index.php;
+
+                                     location /wikijump--next {
+                                         # Assets
+                                         location /wikijump--next/assets {
+                                             alias /var/www/wikijump/web/storage/app/public;
+                                         }
+
+                                         # Fallback
+                                         try_files $uri /laravel.php?$args;
+                                     }
+
+                                     location / {
+                                         # First attempt to serve request as file, then
+                                         # as directory, then fall back to displaying a 404.
+                                         # As this is the most vague block, stuff in here gets examined last.
+                                         try_files $uri $uri/ /index.php?$args;
+                                         # Fallback Route
+                                     }
+
+                                     location ~ \.php$ {
+                                                 set_real_ip_from reverse-proxy;
+                                                 # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+                                                 fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+
+                                                 # Check that the PHP script exists before passing it
+                                                 try_files $fastcgi_script_name =404;
+
+                                                 # Set buffer size large enough for Laravel debug stack traces to come through
+                                                 # LOCAL AND AWS DEV ONLY - There shouldn't be any reason to set this for prod.
+                                                 fastcgi_buffers 16 256k;
+
+                                                 # Bypass the fact that try_files resets $fastcgi_path_info
+                                                 # see: http://trac.nginx.org/nginx/ticket/321
+                                                 set $path_info $fastcgi_path_info;
+                                                 fastcgi_param PATH_INFO $path_info;
+                                                 # fastcgi_param REMOTE_ADDR $http_x_real_ip;
+
+                                                 fastcgi_index index.php;
+                                                 include fastcgi.conf;
+
+                                                 fastcgi_pass php-fpm:9000;
+                                     }
+
+                                     rewrite ^/common--(.+)$ /files--common/$1 break;
+                                     rewrite ^/a16.png /files--common/images/avatars/default/a16.png break;
+                                     rewrite ^/a48.png /files--common/images/avatars/default/a48.png break;
+                                     rewrite ^/forum/start(.*)$ /index.php?Wiki__WikiScreen/wiki_page/forum:start$1 break;
+                                     rewrite ^/forum/t-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:thread/t/$1$2 break;
+                                     rewrite ^/forum/c-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:category/c/$1$2 break;
+                                     rewrite ^/feed/forum/t\-([0-9]+)\.xml$ /feed.php?Feed__ForumThreadPostsFeed/t/$1 break;
+                                     rewrite ^/feed/forum/ct\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryThreadsFeed/c/$1$2 break;
+                                     rewrite ^/feed/forum/cp\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryPostsFeed/c/$1$2 break;
+                                     rewrite ^/feed/forum/posts\.xml$ /feed.php?Feed__ForumPostsFeed break;
+                                     rewrite ^/feed/forum/threads\.xml$ /feed.php?Feed__ForumThreadsFeed break;
+                                     rewrite ^/feed/page/comments\-([0-9]+)\.xml$ /feed.php?Feed__PageCommentsFeed/p/$1 break;
+                                     rewrite ^/feed/front/([a-z\-:]+)/([0-9a-zA-Z\-]+)\.xml$ /feed.php?Feed__FrontForumFeed/page/$1/label/$2 break;
+                                     rewrite ^/feed/site\-changes\.xml$ /feed.php?Feed__SiteChangesFeed break;
+                                     rewrite ^/feed/admin\.xml$ /feed.php?Feed__AdminNotificationsFeed break;
+                                     rewrite ^/printer--friendly/+forum/start(.*)$ /index.php?PrinterFriendly/wiki_page/forum:start$1 break;
+                                     rewrite ^/printer--friendly/+forum/t-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:thread/t/$1$2 break;
+                                     rewrite ^/printer--friendly/+forum/c-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:category/c/$1$2 break;
+                                     rewrite ^/printer--friendly/(.*)$ /index.php?PrinterFriendly/wiki_page/$1 break;
+                                     rewrite ^/default--screen/(.*)$ /index.php?$1 break;
+                                     rewrite ^/local--([^/]+/.*)$ /local.php?$1 break;
+                                     rewrite ^/([a-z0-9\-]+)/code(?:(/[0-9]+))?$ /local.php?code/$1$2 break;
+
+                                     # pass PHP scripts to FastCGI server
+                                     rewrite ^/(.*)\.php$ /$1.php break;
+
+                                     # Fallback route
+                                     rewrite ^\/(?!wikijump--next\/)(.*)$ /index.php?Wiki__WikiScreen/wiki_page/$1? break;
+                             }
+                     }

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -18,8 +18,7 @@ ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 
 # Configure timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    mkdir /src
+RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
 WORKDIR /src
 
@@ -36,8 +35,6 @@ RUN apk add --update --no-cache \
     libjpeg-turbo-dev \
     freetype-dev \
     imagemagick \
-    nodejs \
-    npm \
     git \
     html2text \
     libmemcached-libs \
@@ -85,12 +82,9 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
         --no-progress \
         --prefer-dist && \
 
-    # Run NPM
-    npm install && \
-        npm run build && \
-
     # Cleanup
     rm -rf /src && \
+    rm -f /usr/bin/composer && \
 
     # Create tmp folders
     mkdir -p \
@@ -111,11 +105,6 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
     php artisan key:generate && \
     chown -R www-data:www-data .
 
-RUN apk add shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data
-
 COPY etc/php/ /usr/local/etc/php/conf.d/
-# Main process
-# Let the upstream ENTRYPOINT handle running php-fpm
-#ADD ./entrypoint.sh /usr/local/bin/
 
 CMD ["php-fpm"]

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4-fpm-alpine
 
-EXPOSE 80
+EXPOSE 9000
 
 # TODO: copy from bluesoul's container Dockerfile
 
@@ -8,6 +8,7 @@ EXPOSE 80
 ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_DIR="wikijump"
 ARG WIKIJUMP_REPO_BRANCH="develop"
+ARG DEBUG_IP="192.168.42.128"
 
 ARG MAIN_DOMAIN="wikijump.test"
 ARG FILES_DOMAIN="wjfiles.test"
@@ -17,10 +18,9 @@ ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 
 # Configure timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    mkdir /src
 
-# Preparation
-RUN mkdir /src
 WORKDIR /src
 
 # Copy scripts
@@ -40,21 +40,20 @@ RUN apk add --update --no-cache \
     npm \
     git \
     html2text \
-    nginx \
     libmemcached-libs \
     zlib \
     postgresql-dev \
     tidyhtml-dev \
-    gettext-dev
+    gettext-dev && \
 
-# Memcached PHP lib
-RUN /src/setup-memcached.sh
+    # Memcached PHP lib
+    /src/setup-memcached.sh
 
 ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # !! Put your IP for debugging here.
 RUN echo "xdebug.mode = debug" >> ${XDEBUG_INI} \
- && echo "xdebug.client_host = 192.168.42.128" >> ${XDEBUG_INI}
+ && echo "xdebug.client_host = ${DEBUG_IP}" >> ${XDEBUG_INI}
 
 # TODO - let's see if we actually need xdiff and if so can we include it as an artifact or docker layer
 
@@ -62,64 +61,61 @@ RUN echo "xdebug.mode = debug" >> ${XDEBUG_INI} \
 WORKDIR /var/www
 
 # !! Workaround for WSL2-enabled development with exposed host volumes, comment out if not needed.
-RUN apk add shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data
+RUN apk add shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data && \
 
-RUN git clone \
-    --depth 10 \
-    --branch "${WIKIJUMP_REPO_BRANCH}" \
-    "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+    git clone \
+        --depth 10 \
+        --branch "${WIKIJUMP_REPO_BRANCH}" \
+        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
 
 WORKDIR "${WIKIJUMP_DIR}/web"
-RUN mkdir -p \
-    tmp/smarty_templates_c \
-    tmp/lucene_index \
-    tmp/math \
-    tmp/sitebackups \
-    tmp/smarty_cache \
-    tmp/smarty_macro_templates \
-    tmp/htmlpurifier
 
 # Inject values in the wikijump.ini configuration file
 COPY wikijump.ini conf/wikijump.ini
 
-RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini
-RUN sed -i "s/MAINWIKI/${WWW_DOMAIN}/g" conf/wikijump.ini
-RUN sed -i "s/FILEDOMAIN/${FILES_DOMAIN}/g" conf/wikijump.ini
+RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
+    sed -i "s/MAINWIKI/${WWW_DOMAIN}/g" conf/wikijump.ini && \
+    sed -i "s/FILEDOMAIN/${FILES_DOMAIN}/g" conf/wikijump.ini && \
 
-# Run composer install to install the dependencies
-RUN composer install \
-    --no-ansi \
-    --no-interaction \
-    --no-scripts \
-    --no-progress \
-    --prefer-dist
+    # Run composer install to install the dependencies
+    composer install \
+        --no-ansi \
+        --no-interaction \
+        --no-scripts \
+        --no-progress \
+        --prefer-dist && \
 
-# Run NPM
-RUN npm install && \
-    npm run build
+    # Run NPM
+    npm install && \
+        npm run build && \
 
-# Cleanup
-RUN rm -rf /src
+    # Cleanup
+    rm -rf /src && \
 
-# !! Enable this line if you're getting access denied-type errors.
-#RUN chown -R www-data:www-data .
-
-# Install nginx config files
-COPY etc/nginx/ /etc/nginx/
-COPY etc/php/ /usr/local/etc/php/conf.d/
+    # Create tmp folders
+    mkdir -p \
+        tmp/smarty_templates_c \
+        tmp/lucene_index \
+        tmp/math \
+        tmp/sitebackups \
+        tmp/smarty_cache \
+        tmp/smarty_macro_templates \
+        tmp/htmlpurifier && \
 
 # Enable wikijump site in nginx
-RUN mkdir /etc/nginx/sites-enabled && \
-    cp /etc/nginx/sites-available/wikijump /etc/nginx/sites-enabled/wikijump && \
-    rm -f /etc/nginx/sites-enabled/default && \
     mkdir -p /var/log/php && \
     touch /var/log/php/fpm-error.log && \
-    echo "access.format = \"[%t] %m %{REQUEST_SCHEME}e://%{HTTP_HOST}e%{REQUEST_URI}e %f pid:%p took:%ds mem:%{mega}Mmb cpu:%C%% status:%s {%{HTTP_X_REAL_IP}e|%{HTTP_USER_AGENT}e}\"" >> /usr/local/etc/php-fpm.d/docker.conf
+    echo "access.format = \"[%t] %m %{REQUEST_SCHEME}e://%{HTTP_HOST}e%{REQUEST_URI}e %f pid:%p took:%ds mem:%{mega}Mmb cpu:%C%% status:%s {%{HTTP_X_REAL_IP}e|%{HTTP_USER_AGENT}e}\"" >> /usr/local/etc/php-fpm.d/docker.conf && \
 
-RUN install -m 400 -o www-data -g www-data .env.example .env && php artisan key:generate
+    install -m 400 -o www-data -g www-data .env.example .env && \
+    php artisan key:generate && \
+    chown -R www-data:www-data .
 
+RUN apk add shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data
+
+COPY etc/php/ /usr/local/etc/php/conf.d/
 # Main process
 # Let the upstream ENTRYPOINT handle running php-fpm
-ADD ./entrypoint.sh /usr/local/bin/
-CMD ["nginx", "-g", "daemon off;"]
-ENTRYPOINT ["sh", "/usr/local/bin/entrypoint.sh"]
+#ADD ./entrypoint.sh /usr/local/bin/
+
+CMD ["php-fpm"]

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,8 +2,8 @@ APP_NAME=Wikijump
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=https://www.wikijump.dev/wikijump
-ASSET_URL=https://www.wikijump.dev/wikijump/assets
+APP_URL=https://www.wikijump.dev/wikijump--next
+ASSET_URL=https://www.wikijump.dev/wikijump--next/assets
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::prefix('wikijump')->group(function () {
+Route::prefix('wikijump--next')->group(function () {
     Route::get('/', function () {
         return view('welcome');
     });


### PR DESCRIPTION
This PR will break the fairly monolithic `php-fpm` container into two, with nginx set up separately and handling the static asset serving and reverse proxying of php requests to the `php-fpm` container, which is still fairly large as its functions require certain packages to be installed on it. The net reduction in footprint is about 250MB out of 800 and positions the environment for better scalability in ECS.