### PR TITLE
Add method for converting SyntaxTree into an owned form

### DIFF
--- a/ftml/src/tree/attribute/mod.rs
+++ b/ftml/src/tree/attribute/mod.rs
@@ -20,6 +20,7 @@
 
 mod safe;
 
+use super::clone::string_to_owned;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
@@ -56,6 +57,19 @@ impl<'t> AttributeMap<'t> {
         }
 
         will_insert
+    }
+
+    pub fn to_owned(&self) -> AttributeMap<'static> {
+        let mut inner = HashMap::new();
+
+        for (key, value) in self.inner.iter() {
+            let key = string_to_owned(key);
+            let value = string_to_owned(value);
+
+            inner.insert(key, value);
+        }
+
+        AttributeMap { inner }
     }
 }
 

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -1,0 +1,66 @@
+/*
+ * tree/clone.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Utilities to help convert tree structures into owned versions.
+//!
+//! `SyntaxTree` and its child structures use `Cow` to enable both
+//! serialization and deserialization.
+//!
+//! However if you need to convert a referenced version into an owned
+//! version, that requires traversing all the child structures and
+//! using `to_owned()`.
+//!
+//! This module has helpers to make this process easier.
+
+use super::element::Element;
+use super::list::ListItem;
+use std::borrow::Cow;
+
+pub fn option_string_to_owned(
+    option_string: &Option<Cow<'_, str>>,
+) -> Option<Cow<'static, str>> {
+    match option_string {
+        Some(string) => Some(string_to_owned(string)),
+        None => None,
+    }
+}
+
+#[inline]
+pub fn string_to_owned(string: &Cow<'_, str>) -> Cow<'static, str> {
+    Cow::Owned(string.clone().into_owned())
+}
+
+pub fn strings_to_owned(strings: &[Cow<'_, str>]) -> Vec<Cow<'static, str>> {
+    strings
+        .iter()
+        .map(|string| string_to_owned(string))
+        .collect()
+}
+
+pub fn elements_to_owned(elements: &[Element<'_>]) -> Vec<Element<'static>> {
+    elements.iter().map(|element| element.to_owned()).collect()
+}
+
+pub fn list_items_to_owned(list_items: &[ListItem<'_>]) -> Vec<ListItem<'static>> {
+    list_items
+        .iter()
+        .map(|list_item| list_item.to_owned())
+        .collect()
+}

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -43,7 +43,12 @@ pub fn option_string_to_owned(
 }
 
 #[inline]
+#[allow(clippy::ptr_arg)]
 pub fn string_to_owned(string: &Cow<'_, str>) -> Cow<'static, str> {
+    // Clippy complains about us using &Cow<str>, which is normally valid,
+    // but here we specifically want to convert the Cow into an owned form,
+    // and we get a reference to Cow that we want to turn into an owned Cow.
+
     Cow::Owned(string.clone().into_owned())
 }
 

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -31,15 +31,14 @@
 
 use super::element::Element;
 use super::list::ListItem;
+use ref_map::OptionRefMap;
 use std::borrow::Cow;
 
+#[inline]
 pub fn option_string_to_owned(
     option_string: &Option<Cow<'_, str>>,
 ) -> Option<Cow<'static, str>> {
-    match option_string {
-        Some(string) => Some(string_to_owned(string)),
-        None => None,
-    }
+    option_string.ref_map(|s| string_to_owned(s))
 }
 
 #[inline]

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -43,13 +43,8 @@ pub fn option_string_to_owned(
 }
 
 #[inline]
-#[allow(clippy::ptr_arg)]
-pub fn string_to_owned(string: &Cow<'_, str>) -> Cow<'static, str> {
-    // Clippy complains about us using &Cow<str>, which is normally valid,
-    // but here we specifically want to convert the Cow into an owned form,
-    // and we get a reference to Cow that we want to turn into an owned Cow.
-
-    Cow::Owned(string.clone().into_owned())
+pub fn string_to_owned(string: &str) -> Cow<'static, str> {
+    Cow::Owned(str!(string))
 }
 
 pub fn strings_to_owned(strings: &[Cow<'_, str>]) -> Vec<Cow<'static, str>> {

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -20,6 +20,7 @@
 
 //! Representation of generic syntax elements which wrap other elements.
 
+use super::clone::elements_to_owned;
 use super::{AttributeMap, Element, HeadingLevel, HtmlTag};
 use strum_macros::IntoStaticStr;
 
@@ -59,6 +60,14 @@ impl<'t> Container<'t> {
     #[inline]
     pub fn attributes(&self) -> &AttributeMap<'t> {
         &self.attributes
+    }
+
+    pub fn to_owned(&self) -> Container<'static> {
+        Container {
+            ctype: self.ctype,
+            elements: elements_to_owned(&self.elements),
+            attributes: self.attributes.to_owned(),
+        }
     }
 }
 

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -18,6 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::clone::{
+    elements_to_owned, list_items_to_owned, option_string_to_owned, string_to_owned,
+};
 use super::{
     AnchorTarget, AttributeMap, Container, LinkLabel, ListItem, ListType, Module,
 };
@@ -176,6 +179,90 @@ impl Element<'_> {
             Element::LineBreak => "LineBreak",
             Element::LineBreaks { .. } => "LineBreaks",
             Element::HorizontalRule => "HorizontalRule",
+        }
+    }
+
+    /// Deep-clones the object, making it an owned version.
+    ///
+    /// Note that `.to_owned()` on `Cow` just copies the pointer,
+    /// it doesn't make an `Cow::Owned(_)` version like its name
+    /// suggests.
+    pub fn to_owned(&self) -> Element<'static> {
+        match self {
+            &Element::Container(container) => Element::Container(container.to_owned()),
+            &Element::Module(module) => Element::Module(module.to_owned()),
+            &Element::Text(text) => Element::Text(string_to_owned(&text)),
+            &Element::Raw(text) => Element::Raw(string_to_owned(&text)),
+            &Element::Email(email) => Element::Email(string_to_owned(&email)),
+            &Element::Anchor {
+                elements,
+                attributes,
+                target,
+            } => Element::Anchor {
+                elements: elements_to_owned(&elements),
+                attributes: attributes.to_owned(),
+                target,
+            },
+            &Element::Link { url, label, target } => Element::Link {
+                url: string_to_owned(&url),
+                label: label.to_owned(),
+                target,
+            },
+            &Element::List { ltype, items } => Element::List {
+                ltype,
+                items: list_items_to_owned(&items),
+            },
+            &Element::RadioButton {
+                name,
+                checked,
+                attributes,
+            } => Element::RadioButton {
+                name: name.to_owned(),
+                checked,
+                attributes: attributes.to_owned(),
+            },
+            &Element::CheckBox {
+                checked,
+                attributes,
+            } => Element::CheckBox {
+                checked,
+                attributes: attributes.to_owned(),
+            },
+            &Element::Collapsible {
+                elements,
+                attributes,
+                start_open,
+                show_text,
+                hide_text,
+                show_top,
+                show_bottom,
+            } => Element::Collapsible {
+                elements: elements_to_owned(&elements),
+                attributes: attributes.to_owned(),
+                start_open,
+                show_text: option_string_to_owned(&show_text),
+                hide_text: option_string_to_owned(&hide_text),
+                show_top,
+                show_bottom,
+            },
+            &Element::Color { color, elements } => Element::Color {
+                color: string_to_owned(&color),
+                elements: elements_to_owned(&elements),
+            },
+            &Element::Code { contents, language } => Element::Code {
+                contents: string_to_owned(&contents),
+                language: option_string_to_owned(&language),
+            },
+            &Element::Html { contents } => Element::Html {
+                contents: string_to_owned(&contents),
+            },
+            &Element::Iframe { url, attributes } => Element::Iframe {
+                url: string_to_owned(&url),
+                attributes: attributes.to_owned(),
+            },
+            &Element::LineBreak => Element::LineBreak,
+            &Element::LineBreaks(amount) => Element::LineBreaks(amount),
+            &Element::HorizontalRule => Element::HorizontalRule,
         }
     }
 }

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -189,46 +189,46 @@ impl Element<'_> {
     /// suggests.
     pub fn to_owned(&self) -> Element<'static> {
         match self {
-            &Element::Container(container) => Element::Container(container.to_owned()),
-            &Element::Module(module) => Element::Module(module.to_owned()),
-            &Element::Text(text) => Element::Text(string_to_owned(&text)),
-            &Element::Raw(text) => Element::Raw(string_to_owned(&text)),
-            &Element::Email(email) => Element::Email(string_to_owned(&email)),
-            &Element::Anchor {
+            Element::Container(container) => Element::Container(container.to_owned()),
+            Element::Module(module) => Element::Module(module.to_owned()),
+            Element::Text(text) => Element::Text(string_to_owned(text)),
+            Element::Raw(text) => Element::Raw(string_to_owned(text)),
+            Element::Email(email) => Element::Email(string_to_owned(email)),
+            Element::Anchor {
                 elements,
                 attributes,
                 target,
             } => Element::Anchor {
                 elements: elements_to_owned(&elements),
                 attributes: attributes.to_owned(),
-                target,
+                target: *target,
             },
-            &Element::Link { url, label, target } => Element::Link {
+            Element::Link { url, label, target } => Element::Link {
                 url: string_to_owned(&url),
                 label: label.to_owned(),
-                target,
+                target: *target,
             },
-            &Element::List { ltype, items } => Element::List {
-                ltype,
+            Element::List { ltype, items } => Element::List {
+                ltype: *ltype,
                 items: list_items_to_owned(&items),
             },
-            &Element::RadioButton {
+            Element::RadioButton {
                 name,
                 checked,
                 attributes,
             } => Element::RadioButton {
-                name: name.to_owned(),
-                checked,
+                name: string_to_owned(&name),
+                checked: *checked,
                 attributes: attributes.to_owned(),
             },
-            &Element::CheckBox {
+            Element::CheckBox {
                 checked,
                 attributes,
             } => Element::CheckBox {
-                checked,
+                checked: *checked,
                 attributes: attributes.to_owned(),
             },
-            &Element::Collapsible {
+            Element::Collapsible {
                 elements,
                 attributes,
                 start_open,
@@ -239,30 +239,30 @@ impl Element<'_> {
             } => Element::Collapsible {
                 elements: elements_to_owned(&elements),
                 attributes: attributes.to_owned(),
-                start_open,
+                start_open: *start_open,
                 show_text: option_string_to_owned(&show_text),
                 hide_text: option_string_to_owned(&hide_text),
-                show_top,
-                show_bottom,
+                show_top: *show_top,
+                show_bottom: *show_bottom,
             },
-            &Element::Color { color, elements } => Element::Color {
+            Element::Color { color, elements } => Element::Color {
                 color: string_to_owned(&color),
                 elements: elements_to_owned(&elements),
             },
-            &Element::Code { contents, language } => Element::Code {
+            Element::Code { contents, language } => Element::Code {
                 contents: string_to_owned(&contents),
                 language: option_string_to_owned(&language),
             },
-            &Element::Html { contents } => Element::Html {
+            Element::Html { contents } => Element::Html {
                 contents: string_to_owned(&contents),
             },
-            &Element::Iframe { url, attributes } => Element::Iframe {
+            Element::Iframe { url, attributes } => Element::Iframe {
                 url: string_to_owned(&url),
                 attributes: attributes.to_owned(),
             },
-            &Element::LineBreak => Element::LineBreak,
-            &Element::LineBreaks(amount) => Element::LineBreaks(amount),
-            &Element::HorizontalRule => Element::HorizontalRule,
+            Element::LineBreak => Element::LineBreak,
+            Element::LineBreaks(amount) => Element::LineBreaks(*amount),
+            Element::HorizontalRule => Element::HorizontalRule,
         }
     }
 }

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -18,9 +18,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::clone::{option_string_to_owned, string_to_owned};
 use std::borrow::Cow;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Hash, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum LinkLabel<'a> {
     /// Custom text link label.
@@ -38,4 +39,14 @@ pub enum LinkLabel<'a> {
     ///
     /// The label for this link is whatever the page's title is.
     Page,
+}
+
+impl LinkLabel<'_> {
+    pub fn to_owned(&self) -> LinkLabel<'static> {
+        match self {
+            LinkLabel::Text(text) => LinkLabel::Text(string_to_owned(text)),
+            LinkLabel::Url(url) => LinkLabel::Url(option_string_to_owned(url)),
+            LinkLabel::Page => LinkLabel::Page,
+        }
+    }
 }

--- a/ftml/src/tree/list.rs
+++ b/ftml/src/tree/list.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::clone::elements_to_owned;
 use super::Element;
 use strum_macros::IntoStaticStr;
 
@@ -34,6 +35,17 @@ pub enum ListItem<'t> {
     ///
     /// That is, it's another, or deeper list within the list.
     SubList(Element<'t>),
+}
+
+impl ListItem<'_> {
+    pub fn to_owned(&self) -> ListItem<'static> {
+        match self {
+            ListItem::Elements(elements) => {
+                ListItem::Elements(elements_to_owned(&elements))
+            }
+            ListItem::SubList(element) => ListItem::SubList(element.to_owned()),
+        }
+    }
 }
 
 #[derive(

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -87,5 +87,8 @@ fn borrowed_to_owned<'a>() {
     let tree_2: SyntaxTree<'static> = tree_1.to_owned();
 
     mem::drop(tree_1);
-    mem::drop(tree_2);
+
+    let tree_3: SyntaxTree<'static> = tree_2.clone();
+
+    mem::drop(tree_3);
 }

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -95,8 +95,7 @@ impl<'t> ToOwned for SyntaxTreeOwned {
 
     fn to_owned(&self) -> SyntaxTreeOwned {
         let inner = SyntaxTree {
-            //elements: self.0.elements.iter().map(ToOwned::to_owned).collect(),
-            elements: vec![],
+            elements: self.0.elements.iter().map(ToOwned::to_owned).collect(),
             styles: self.0.styles.iter().map(ToOwned::to_owned).collect(),
         };
 

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -78,3 +78,14 @@ impl<'t> SyntaxTree<'t> {
         }
     }
 }
+
+#[test]
+fn borrowed_to_owned<'a>() {
+    use std::mem;
+
+    let tree_1: SyntaxTree<'a> = SyntaxTree::default();
+    let tree_2: SyntaxTree<'static> = tree_1.to_owned();
+
+    mem::drop(tree_1);
+    mem::drop(tree_2);
+}

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -95,10 +95,9 @@ impl<'t> ToOwned for SyntaxTreeOwned {
 
     fn to_owned(&self) -> SyntaxTreeOwned {
         let inner = SyntaxTree {
-            //elements: self.elements.iter().map(ToOwned::to_owned).collect(),
+            //elements: self.0.elements.iter().map(ToOwned::to_owned).collect(),
             elements: vec![],
-            //styles: self.styles.iter().map(ToOwned::to_owned).collect(),
-            styles: vec![],
+            styles: self.0.styles.iter().map(ToOwned::to_owned).collect(),
         };
 
         SyntaxTreeOwned(inner)

--- a/ftml/src/tree/module.rs
+++ b/ftml/src/tree/module.rs
@@ -20,6 +20,7 @@
 
 //! Representation of Wikidot modules, along with their context.
 
+use super::clone::option_string_to_owned;
 use super::AttributeMap;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
@@ -63,5 +64,33 @@ impl Module<'_> {
     #[inline]
     pub fn name(&self) -> &'static str {
         self.into()
+    }
+
+    pub fn to_owned(&self) -> Module<'static> {
+        match self {
+            Module::Backlinks { page } => Module::Backlinks {
+                page: option_string_to_owned(page),
+            },
+            Module::Categories { include_hidden } => Module::Categories {
+                include_hidden: *include_hidden,
+            },
+            Module::Join {
+                button_text,
+                attributes,
+            } => Module::Join {
+                button_text: option_string_to_owned(button_text),
+                attributes: attributes.to_owned(),
+            },
+            Module::PageTree {
+                root,
+                show_root,
+                depth,
+            } => Module::PageTree {
+                root: option_string_to_owned(root),
+                show_root: *show_root,
+                depth: *depth,
+            },
+            Module::Rate => Module::Rate,
+        }
     }
 }


### PR DESCRIPTION
This adds a method `.to_owned()` (different from the trait [`ToOwned`](https://doc.rust-lang.org/std/borrow/trait.ToOwned.html)) which clones all the `Cow`s and owned fields within the structure to ensure the lifetime is `'static` (because it's not borrowing anything, so the object can live indefinitely).

This is necessary for ftml-wasm, to clone the whole structure to make it suitable for passing into JS. Presently it uses a hack: it serializes and deserializes the structure, which is extremely inefficient, even if it uses less lines of code.