### PR TITLE
Remove old-style constructors everywhere

### DIFF
--- a/web/lib/date/Date.php
+++ b/web/lib/date/Date.php
@@ -196,7 +196,7 @@ class Date
      * @param mixed $date optional - date/time to initialize
      * @return object Date the new Date object
      */
-    function Date($date = null)
+    function __construct($date = null)
     {
         $this->tz = Date_TimeZone::getDefault();
         if (is_null($date)) {

--- a/web/lib/date/Date/Span.php
+++ b/web/lib/date/Date/Span.php
@@ -150,7 +150,7 @@ class Date_Span
      * @see    set()
      * @access public
      */
-    function Date_Span($time = 0, $format = null)
+    function __construct($time = 0, $format = null)
     {
         $this->set($time, $format);
     }

--- a/web/lib/date/Date/TimeZone.php
+++ b/web/lib/date/Date/TimeZone.php
@@ -133,7 +133,7 @@ class Date_TimeZone
      * @param string $id the time zone id
      * @return object Date_TimeZone the new Date_TimeZone object
      */
-    function Date_TimeZone($id)
+    function __construct($id)
     {
         $_DATE_TIMEZONE_DATA =& $GLOBALS['_DATE_TIMEZONE_DATA'];
         if(Date_TimeZone::isValidID($id)) {

--- a/web/lib/magpierss/rss_cache.inc
+++ b/web/lib/magpierss/rss_cache.inc
@@ -21,7 +21,7 @@ class RSSCache {
     public $MAX_AGE    = 3600;         // when are files stale, default one hour
     public $ERROR      = "";           // accumulate error messages
     
-    function RSSCache ($base='', $age='') {
+    function __construct($base='', $age='') {
         if ( $base ) {
             $this->BASE_CACHE = $base;
         }

--- a/web/lib/magpierss/rss_parse.inc
+++ b/web/lib/magpierss/rss_parse.inc
@@ -91,8 +91,8 @@ class MagpieRSS {
      *                                  source encoding. (caveat emptor)
      *
      */
-    function MagpieRSS ($source, $output_encoding='ISO-8859-1', 
-                        $input_encoding=null, $detect_encoding=true) 
+    function __construct($source, $output_encoding='ISO-8859-1',
+                         $input_encoding=null, $detect_encoding=true)
     {   
         # if PHP xml isn't compiled in, die
         #

--- a/web/lib/phpflickr/phpFlickr.php
+++ b/web/lib/phpflickr/phpFlickr.php
@@ -58,7 +58,7 @@ if ( !class_exists('phpFlickr') ) {
          */
         var $max_cache_rows = 1000;
 
-        function phpFlickr ($api_key, $secret = NULL, $die_on_error = false) {
+        function __construct($api_key, $secret = NULL, $die_on_error = false) {
             //The API Key must be set before any calls can be made.  You can
             //get your own at https://www.flickr.com/services/api/misc.api_keys.html
             $this->api_key = $api_key;

--- a/web/lib/phpmailer/class.pop3.php
+++ b/web/lib/phpmailer/class.pop3.php
@@ -113,7 +113,7 @@ class POP3
    *
    * @return POP3
    */
-  function POP3 ()
+  function __construct()
     {
       $this->pop_conn = 0;
       $this->connected = false;

--- a/web/lib/phpmailer/class.smtp.php
+++ b/web/lib/phpmailer/class.smtp.php
@@ -72,7 +72,7 @@ class SMTP
    * @access public
    * @return void
    */
-  function SMTP() {
+  function __construct() {
     $this->smtp_conn = 0;
     $this->error = null;
     $this->helo_rply = null;

--- a/web/lib/text_wiki/Text/Wiki.php
+++ b/web/lib/text_wiki/Text/Wiki.php
@@ -371,7 +371,7 @@ class Text_Wiki {
     *
     */
 
-    function Text_Wiki($rules = null)
+    function __construct($rules = null)
     {
         if (is_array($rules)) {
             $this->rules = $rules;

--- a/web/lib/text_wiki/Text/Wiki/Parse/Default/Delimiter.php
+++ b/web/lib/text_wiki/Text/Wiki/Parse/Default/Delimiter.php
@@ -47,7 +47,7 @@ class Text_Wiki_Parse_Delimiter extends Text_Wiki_Parse {
     *
     */
 
-    function Text_Wiki_Parse_delimiter(&$obj)
+    function __construct(&$obj)
     {
         parent::__construct($obj);
         $this->regex = '/' . $this->wiki->delim . '/';

--- a/web/lib/text_wiki/Text/Wiki/Parse/Default/Url.php
+++ b/web/lib/text_wiki/Text/Wiki/Parse/Default/Url.php
@@ -95,7 +95,7 @@ class Text_Wiki_Parse_Url extends Text_Wiki_Parse {
     *
     */
 
-    function Text_Wiki_Parse_Url(&$obj)
+    function __construct(&$obj)
     {
         parent::__construct($obj);
 

--- a/web/lib/text_wiki/Text/Wiki/Parse/Default/Wikilink.php
+++ b/web/lib/text_wiki/Text/Wiki/Parse/Default/Wikilink.php
@@ -61,7 +61,7 @@ class Text_Wiki_Parse_Wikilink extends Text_Wiki_Parse {
     *
     */
 
-    function Text_Wiki_Parse_Wikilink(&$obj)
+    function __construct(&$obj)
     {
         parent::__construct($obj);
 

--- a/web/lib/text_wiki/Text/Wiki/Render.php
+++ b/web/lib/text_wiki/Text/Wiki/Render.php
@@ -85,7 +85,7 @@ class Text_Wiki_Render {
     *
     */
 
-    function Text_Wiki_Render(&$obj)
+    function __construct(&$obj)
     {
         // keep a reference to the calling Text_Wiki object
         $this->wiki =& $obj;

--- a/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Embed.php
+++ b/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Embed.php
@@ -39,10 +39,10 @@ class Text_Wiki_Render_Xhtml_Embed extends Text_Wiki_Render {
 
     public $patterns = array();
 
-    public function Text_Wiki_Render_Xhtml_Embed($obj) {
-        parent::Text_Wiki_Render($obj);
+    public function __construct($obj) {
+        parent::__construct($obj);
 
-        $patternDir = WIKIDOT_ROOT . '/conf/wikiparser/embed';
+        $patternDir = WIKIJUMP_ROOT . '/conf/wikiparser/embed';
         $files = glob($patternDir . '/*.php');
         foreach ($files as $f) {
             require $f;

--- a/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Math.php
+++ b/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Math.php
@@ -49,7 +49,7 @@ class Text_Wiki_Render_Xhtml_Math extends Text_Wiki_Render {
             mkdirfull($dir);
         }
 
-        $tmpDir = WIKIDOT_ROOT . '/tmp/math';
+        $tmpDir = WIKIJUMP_ROOT . '/tmp/math';
         if (!file_exists($tmpDir)) {
             mkdirfull($tmpDir);
         }

--- a/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Mathinline.php
+++ b/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Mathinline.php
@@ -48,7 +48,7 @@ class Text_Wiki_Render_Xhtml_Mathinline extends Text_Wiki_Render {
             mkdirfull($dir);
         }
 
-        $tmpDir = WIKIDOT_ROOT . '/tmp/math';
+        $tmpDir = WIKIJUMP_ROOT . '/tmp/math';
         if (!file_exists($tmpDir)) {
             mkdirfull($tmpDir);
         }


### PR DESCRIPTION
This is the result of a simple PHPStorm inspection to remove old-style constructors where a function with the same name as a class works as a constructor. The preferred way is the `__construct()` magic method.

I have also removed a few incorrect constant usages of `WIKIDOT_ROOT` that should be `WIKIJUMP_ROOT` which were throwing errors via the ajax module connector.