### PR TITLE
Finalize mandatory HTTPS for Wikijump installations.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,6 +12,8 @@ If the address is for a `wjfiles.com` subdomain, it will instead hit a CloudFron
 
 Deployment was designed to need a minimum of work done outside the scope of this package. All that should be required is storing some AWS credentials to the CI/CD provider of your choosing.
 
+*Note: Deploying the software via the docker and terraform packages is the only supported configuration. You can certainly deploy another way if you're able, but we likely won't be able to help you troubleshoot it. In particular, modifying the deployment around SSL configuration is highly discouraged, and we cannot offer support on insecure deployments.*
+
 1. You will need [Terraform](https://www.terraform.io) as well as a place to store Terraform state files. We use Terraform Cloud which is free for teams of up to 5 users, but you can also do things like storing the state files in S3.
 2. You will need to make an IAM user for Terraform to use to create and update everything. A JSON file for the IAM Policy is forthcoming.
 3. You will need to make an IAM user for your CI/CD (GitHub Actions for us) to use to push Docker images. A JSON file for the IAM policy is forthcoming.

--- a/web/conf/wikijump.ini.example
+++ b/web/conf/wikijump.ini.example
@@ -72,11 +72,13 @@ ssl = false
 schema = https
 
 ; [allow_http]
-; Purpose: Choose whether or not to allow ANY insecure traffic anywhere on your wiki farm. This is only recommended for
-;   local development where using SSL is tricky. The expectation in production is SSL is enabled everywhere.
+; Purpose: Choose whether or not to allow ANY insecure traffic anywhere on your Wiki farm. You will need this set to
+; true if another service (Traefik, ELB, etc.) is handling SSL termination in front of Wikijump to avoid redirect loops.
+; If you are running a simpler (unsupported) deployment or doing your own thing, setting this to false will basically
+; redirect any requests from http to https.
 ; GlobalProperties Reference: $ALLOW_ANY_HTTP
-; Default: false
-allow_http = false
+; Default: true
+allow_http = true
 
 ; [upload_separate_domain]
 ; Purpose: Determine whether uploaded files should be served off the same domain as your trusted content. It is STRONGLY

--- a/web/php/Utils/GlobalProperties.php
+++ b/web/php/Utils/GlobalProperties.php
@@ -176,7 +176,7 @@ class GlobalProperties
 
         // security settings
         self::$SECRET                   = $_ENV["WIKIJUMP_SECRET"] ?? self::fromIni("security", "secret", md5('secret'));
-        self::$ALLOW_ANY_HTTP           = $_ENV["WIKIJUMP_ALLOW_ANY_HTTP"] ?? self::fromIni("security", "allow_http", false);
+        self::$ALLOW_ANY_HTTP           = $_ENV["WIKIJUMP_ALLOW_ANY_HTTP"] ?? self::fromIni("security", "allow_http", true);
         self::$USE_SSL                  = $_ENV["WIKIJUMP_USE_SSL"] ?? self::fromIni("security", "ssl", false);
         self::$HTTP_SCHEMA              = $_ENV["WIKIJUMP_HTTP_SCHEMA"] ?? self::fromIni("security", "schema", "https");
         self::$SECRET_DOMAIN_LOGIN      = $_ENV["WIKIJUMP_SECRET_DOMAIN_LOGIN"] ?? self::fromIni("security", "secret_login", self::$SECRET . "_custom_domain_login");


### PR DESCRIPTION
This PR updates the behavior in the example `web/conf/wikijump.ini.example` file to flip `allow_http` to true. Since Traefik fronts the backend containers and they're listening on 80, the user will end up in a redirect loop if `allow_http` is false.

It also updates the documentation to spell out that deployments other than via docker and terraform are unsupported, and calls out messing with HTTPS in particular.