### PR TITLE
Fix profile website replacer.

### DIFF
--- a/web/templates/modules/UserInfo/UserInfoProfileModule.tpl
+++ b/web/templates/modules/UserInfo/UserInfoProfileModule.tpl
@@ -17,7 +17,7 @@
 		{t}From{/t}: {$profile->getLocation()|escape}<br/>
 	{/if}
 	{if $profile->getWebsite()}
-		{t}Website{/t}: <a href="{$profile->getWebsite()|escape}">{$profile->getWebsite()|replace:{$HTTP_SCHEMA}://:''|escape}</a><br/>
+		{t}Website{/t}: <a href="{$profile->getWebsite()|escape}">{$profile->getWebsite()|replace:'https?://':''|escape}</a><br/>
 	{/if}
 
 	{t}User since{/t}:  <span class="odate">{$user->getRegisteredDate()->getTimestamp()}|%e %b %Y, %H:%M %Z (%O {t}ago{/t})</span><br/>


### PR DESCRIPTION
The `{$HTTP_SCHEMA}` inside the `replace` field wasn't valid, so I added a regex which captures both HTTP and HTTPS links.

This syntax issue was likely originally introduced in the big HTTP search and replace job.

Before:

![image](https://user-images.githubusercontent.com/8848022/114490760-663bab00-9be3-11eb-8b60-0e03c3972c07.png)

After:

![image](https://user-images.githubusercontent.com/8848022/114490736-5ae87f80-9be3-11eb-9362-96a57115b77e.png)
