### PR TITLE
[FTML-87] Add support for HTML entities

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -411,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "enum-map"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +492,7 @@ version = "0.5.0"
 dependencies = [
  "built",
  "cfg-if 1.0.0",
+ "entities",
  "enum-map",
  "lazy_static",
  "maplit",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["cdylib", "lib"]
 wasm-log = [] # Enables console.log() logging. Spams your browser, caveat emptor!
 
 [dependencies]
+entities = "1"
 enum-map = "0.6"
 lazy_static = "1"
 maplit = "1"

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -81,6 +81,7 @@ Here is a table showing the options each block has with regards to its construct
 | [Anchor](#anchor)               | `a`, `anchor`                    | No       | Yes       | No        | Map           | Elements  |
 | [Blockquote](#blockquote)       | `blockquote`, `quote`            | No       | No        | Yes       | Map           | Elements  |
 | [Bold](#bold)                   | `b`, `bold`, `strong`            | No       | No        | No        | Map           | Elements  |
+| [Char](#char)                   | `char`, `character`              | No       | No        | No        | Value         | None      |
 | [Checkbox](#checkbox)           | `checkbox`                       | Yes      | No        | No        | Map           | None      |
 | [Code](#code)                   | `code`                           | No       | No        | Yes       | Map           | Raw       |
 | [Collapsible](#collapsible)     | `collapsible`                    | No       | No        | Yes       | Map           | Elements  |
@@ -157,6 +158,21 @@ Example:
 
 ```
 Some [[b]]text![[/b]]
+```
+
+### Char
+
+Outputs: `Element::Text`
+
+Body: None
+
+Arguments:
+Value &mdash; (String) The HTML entity to place here.
+
+Example:
+
+```
+This file is [[char copy]] 2021 Team Wikijump.
 ```
 
 ### Checkbox

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -105,6 +105,45 @@ fn find_entity(entity: &str) -> Option<Cow<str>> {
     None
 }
 
+/// Gets the appropriate character from the number specified in the string.
+///
+/// Using the passed radix, it gets the integer value, then finds the appropriate
+/// character, if one exists.
+///
+/// Then converts the character into a string with only that value.
+fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
+    let codepoint = match u32::from_str_radix(value, radix) {
+        Ok(codepoint) => codepoint,
+        Err(_) => return None,
+    };
+
+    let ch = match char::from_u32(codepoint) {
+        Some(ch) => ch,
+        None => return None,
+    };
+
+    Some(Cow::Owned(ch.to_string()))
+}
+
+
+/// If a string starts with `&` and ends with `;`, those are removed.
+/// First trims the string.
+fn strip_entity(s: &str) -> &str {
+    let s = s.trim();
+
+    if s.starts_with('&') && s.ends_with(';') {
+        // Strip first and last characters
+
+        &s[1..s.len() - 1]
+    } else {
+        // Leave unchanged
+
+        s
+    }
+}
+
+/* Tests */
+
 #[test]
 fn test_get_entity() {
     macro_rules! check {
@@ -142,26 +181,6 @@ fn test_get_entity() {
     check!("#x1fffff", None);
 }
 
-/// Gets the appropriate character from the number specified in the string.
-///
-/// Using the passed radix, it gets the integer value, then finds the appropriate
-/// character, if one exists.
-///
-/// Then converts the character into a string with only that value.
-fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
-    let codepoint = match u32::from_str_radix(value, radix) {
-        Ok(codepoint) => codepoint,
-        Err(_) => return None,
-    };
-
-    let ch = match char::from_u32(codepoint) {
-        Some(ch) => ch,
-        None => return None,
-    };
-
-    Some(Cow::Owned(ch.to_string()))
-}
-
 #[test]
 fn test_get_char() {
     macro_rules! check {
@@ -188,22 +207,6 @@ fn test_get_char() {
     check!("ff", 16, Some(Cow::Owned(str!('\u{ff}'))));
     check!("1f4af", 16, Some(Cow::Owned(str!('💯'))));
     check!("1fffff", 16, None);
-}
-
-/// If a string starts with `&` and ends with `;`, those are removed.
-/// First trims the string.
-fn strip_entity(s: &str) -> &str {
-    let s = s.trim();
-
-    if s.starts_with('&') && s.ends_with(';') {
-        // Strip first and last characters
-
-        &s[1..s.len() - 1]
-    } else {
-        // Leave unchanged
-
-        s
-    }
 }
 
 #[test]

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -1,0 +1,123 @@
+/*
+ * parsing/rule/impls/block/blocks/char.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use entities::ENTITIES;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+lazy_static! {
+    static ref ENTITY_MAPPING: HashMap<&str, &str> = {
+        let mut mapping = HashMap::new();
+
+        for entity in &ENTITIES {
+            let key = strip_entity(entity.entity);
+            let value = entity.characters;
+
+            mapping.insert(key, value);
+        }
+
+        mapping
+    };
+}
+
+pub const BLOCK_CHAR: BlockRule = BlockRule {
+    name: "block-char",
+    accepts_names: &["char", "character"],
+    accepts_special: false,
+    accepts_newlines: false,
+    parse_fn,
+};
+
+fn parse_fn<'r, 't>(
+    log: &slog::Logger,
+    parser: &mut Parser<'r, 't>,
+    name: &'t str,
+    special: bool,
+    in_head: bool,
+) -> ParseResult<'r, 't, Elements<'t>> {
+    debug!(log, "Parsing character / HTML entity block"; "in-head" => in_head);
+
+    assert_eq!(special, false, "Char doesn't allow special variant");
+    assert_block_name(&BLOCK_CHAR, name);
+
+    let entity = parser.get_head_value(&BLOCK_CHAR, in_head, parse_count)?;
+    let result = find_entity(strip_entity(entity));
+
+    ok!(Element::Text(result))
+}
+
+/// Find the string corresponding to the passed entity, if any.
+fn find_entity(entity: &str) -> Option<Cow<str>> {
+    // Named entity
+    if let Some(result) = ENTITY_MAPPING.get(entity) {
+        return Some(cow!(result));
+    }
+
+    // Hexadecimal entity
+    if entity.starts_with("#x") {
+        if let Some(result) = get_char(&entity[2..], 16) {
+            return Some(result);
+        }
+    }
+
+    // Decimal entity
+    if entity.starts_with('#') {
+        if let Some(result) = get_char(&entity[1..], 10) {
+            return Some(result);
+        }
+    }
+
+    // Not found
+    None
+}
+
+/// Gets the appropriate character from the number specified in the string.
+///
+/// Using the passed radix, it gets the integer value, then finds the appropriate
+/// character, if one exists.
+///
+/// Then converts the character into a string with only that value.
+fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
+    let codepoint = match u32::from_str_radix(value, radix) {
+        Ok(codepoint) => codepoint,
+        Err(_) => return None,
+    };
+
+    let ch = match char::from_u32(codepoint) {
+        Some(ch) => ch,
+        None => return None,
+    };
+
+    Some(Cow::Borrowed(ch.to_string()))
+}
+
+/// If a string starts with `&` and ends with `;`, those are removed.
+fn strip_entity(s: &str) -> &str {
+    if s.starts_with('&') && s.ends_with(';') {
+        // Strip first and last characters
+
+        &s[1..s.len() - 1]
+    } else {
+        // Leave unchanged
+
+        s
+    }
+}

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -88,15 +88,15 @@ fn find_entity(entity: &str) -> Option<Cow<str>> {
     }
 
     // Hexadecimal entity
-    if entity.starts_with("#x") {
-        if let Some(result) = get_char(&entity[2..], 16) {
+    if let Some(value) = entity.strip_prefix("#x") {
+        if let Some(result) = get_char(value, 16) {
             return Some(result);
         }
     }
 
     // Decimal entity
-    if entity.starts_with('#') {
-        if let Some(result) = get_char(&entity[1..], 10) {
+    if let Some(value) = entity.strip_prefix('#') {
+        if let Some(result) = get_char(value, 10) {
             return Some(result);
         }
     }

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -227,6 +227,11 @@ fn test_strip_entity() {
     check!("&#100;", "#100");
     check!("&xdeadbeef;", "xdeadbeef");
 
+    check!("&amp", "amp");
+    check!("amp;", "amp");
+    check!("&#100", "#100");
+    check!("#100;", "#100");
+
     check!(" ", "");
     check!(" abc", "abc");
     check!(" legumes1", "legumes1");

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -125,20 +125,20 @@ fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
     Some(Cow::Owned(ch.to_string()))
 }
 
-/// If a string starts with `&` and ends with `;`, those are removed.
-/// First trims the string.
-fn strip_entity(s: &str) -> &str {
-    let s = s.trim();
+/// If a string starts with `&` or ends with `;`, those are removed.
+/// First trims the string of whitespace.
+fn strip_entity(mut s: &str) -> &str {
+    s = s.trim();
 
-    if s.starts_with('&') && s.ends_with(';') {
-        // Strip first and last characters
-
-        &s[1..s.len() - 1]
-    } else {
-        // Leave unchanged
-
-        s
+    if let Some(stripped) = s.strip_prefix('&') {
+        s = stripped;
     }
+
+    if let Some(stripped) = s.strip_suffix(';') {
+        s = stripped;
+    }
+
+    s
 }
 
 /* Tests */

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -121,3 +121,26 @@ fn strip_entity(s: &str) -> &str {
         s
     }
 }
+
+#[test]
+fn test_strip_entity() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {{
+            let actual = strip_entity($input);
+            let expected = $expected;
+
+            assert_eq!(
+                actual,
+                expected,
+                "Actual stripped entity value didn't match expected",
+            );
+        }};
+    }
+
+    check!("", "");
+    check!("abc", "abc");
+    check!("legumes1", "legumes1");
+    check!("&amp;", "amp");
+    check!("&#100;", "#100");
+    check!("&xdeadbeef;", "xdeadbeef");
+}

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -105,6 +105,43 @@ fn find_entity(entity: &str) -> Option<Cow<str>> {
     None
 }
 
+#[test]
+fn test_get_entity() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {{
+            let actual = find_entity($input);
+            let expected = $expected;
+
+            assert_eq!(
+                actual,
+                expected,
+                "Actual entity string doesn't match expected",
+            );
+        }};
+    }
+
+    check!("", None);
+
+    // Names
+    check!("amp", Some(cow!("&")));
+    check!("lt", Some(cow!("<")));
+    check!("gt", Some(cow!(">")));
+    check!("copy", Some(cow!("©")));
+    check!("xxxzzz", None);
+
+    // Decimal
+    check!("#32", Some(cow!(" ")));
+    check!("#255", Some(cow!("\u{ff}")));
+    check!("#128175", Some(cow!("💯")));
+    check!("#2097151", None);
+
+    // Hex
+    check!("#x20", Some(cow!(" ")));
+    check!("#xff", Some(cow!("\u{ff}")));
+    check!("#x1f4af", Some(cow!("💯")));
+    check!("#x1fffff", None);
+}
+
 /// Gets the appropriate character from the number specified in the string.
 ///
 /// Using the passed radix, it gets the integer value, then finds the appropriate
@@ -142,13 +179,13 @@ fn test_get_char() {
 
     // Decimal
     check!("32", 10, Some(Cow::Owned(str!(' '))));
-    check!("200", 10, Some(Cow::Owned(str!('\u{c8}'))));
+    check!("255", 10, Some(Cow::Owned(str!('\u{ff}'))));
     check!("128175", 10, Some(Cow::Owned(str!('💯'))));
     check!("2097151", 10, None);
 
     // Hex
     check!("20", 16, Some(Cow::Owned(str!(' '))));
-    check!("c8", 16, Some(Cow::Owned(str!('\u{c8}'))));
+    check!("ff", 16, Some(Cow::Owned(str!('\u{ff}'))));
     check!("1f4af", 16, Some(Cow::Owned(str!('💯'))));
     check!("1fffff", 16, None);
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -21,8 +21,8 @@
 use super::prelude::*;
 use entities::ENTITIES;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::char;
+use std::collections::HashMap;
 
 lazy_static! {
     static ref ENTITY_MAPPING: HashMap<&'static str, &'static str> = {
@@ -125,7 +125,6 @@ fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
     Some(Cow::Owned(ch.to_string()))
 }
 
-
 /// If a string starts with `&` and ends with `;`, those are removed.
 /// First trims the string.
 fn strip_entity(s: &str) -> &str {
@@ -152,8 +151,7 @@ fn test_get_entity() {
             let expected = $expected;
 
             assert_eq!(
-                actual,
-                expected,
+                actual, expected,
                 "Actual entity string doesn't match expected",
             );
         }};
@@ -189,8 +187,7 @@ fn test_get_char() {
             let expected = $expected;
 
             assert_eq!(
-                actual,
-                expected,
+                actual, expected,
                 "Actual character value doesn't match expected",
             );
         }};
@@ -217,8 +214,7 @@ fn test_strip_entity() {
             let expected = $expected;
 
             assert_eq!(
-                actual,
-                expected,
+                actual, expected,
                 "Actual stripped entity value didn't match expected",
             );
         }};

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -125,6 +125,34 @@ fn get_char(value: &str, radix: u32) -> Option<Cow<str>> {
     Some(Cow::Owned(ch.to_string()))
 }
 
+#[test]
+fn test_get_char() {
+    macro_rules! check {
+        ($value:expr, $radix:expr, $expected:expr $(,)?) => {{
+            let actual = get_char($value, $radix);
+            let expected = $expected;
+
+            assert_eq!(
+                actual,
+                expected,
+                "Actual character value doesn't match expected",
+            );
+        }};
+    }
+
+    // Decimal
+    check!("32", 10, Some(Cow::Owned(str!(' '))));
+    check!("200", 10, Some(Cow::Owned(str!('\u{c8}'))));
+    check!("128175", 10, Some(Cow::Owned(str!('💯'))));
+    check!("2097151", 10, None);
+
+    // Hex
+    check!("20", 16, Some(Cow::Owned(str!(' '))));
+    check!("c8", 16, Some(Cow::Owned(str!('\u{c8}'))));
+    check!("1f4af", 16, Some(Cow::Owned(str!('💯'))));
+    check!("1fffff", 16, None);
+}
+
 /// If a string starts with `&` and ends with `;`, those are removed.
 /// First trims the string.
 fn strip_entity(s: &str) -> &str {
@@ -162,4 +190,11 @@ fn test_strip_entity() {
     check!("&amp;", "amp");
     check!("&#100;", "#100");
     check!("&xdeadbeef;", "xdeadbeef");
+
+    check!(" ", "");
+    check!(" abc", "abc");
+    check!(" legumes1", "legumes1");
+    check!(" &amp;", "amp");
+    check!(" &#100;", "#100");
+    check!(" &xdeadbeef;", "xdeadbeef");
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing newlines block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Code doesn't allow special variant");
+    assert_eq!(special, false, "Lines doesn't allow special variant");
     assert_block_name(&BLOCK_LINES, name);
 
     let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -58,6 +58,7 @@ mod prelude {
 mod anchor;
 mod blockquote;
 mod bold;
+mod char;
 mod checkbox;
 mod code;
 mod collapsible;
@@ -87,6 +88,7 @@ mod underline;
 pub use self::anchor::BLOCK_ANCHOR;
 pub use self::blockquote::BLOCK_BLOCKQUOTE;
 pub use self::bold::BLOCK_BOLD;
+pub use self::char::BLOCK_CHAR;
 pub use self::checkbox::BLOCK_CHECKBOX;
 pub use self::code::BLOCK_CODE;
 pub use self::collapsible::BLOCK_COLLAPSIBLE;

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -22,10 +22,11 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 28] = [
+pub const BLOCK_RULES: [BlockRule; 29] = [
     BLOCK_ANCHOR,
     BLOCK_BLOCKQUOTE,
     BLOCK_BOLD,
+    BLOCK_CHAR,
     BLOCK_CHECKBOX,
     BLOCK_CODE,
     BLOCK_COLLAPSIBLE,

--- a/ftml/test/char-alias.json
+++ b/ftml/test/char-alias.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[character gt]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": ">"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char-decimal.json
+++ b/ftml/test/char-decimal.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char #129408]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "🦀"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char-hex.json
+++ b/ftml/test/char-hex.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char #x1f980]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "🦀"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char-name.json
+++ b/ftml/test/char-name.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char copy]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "©"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char.json
+++ b/ftml/test/char.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char amp]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "&"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-alias.json
+++ b/ftml/test/char2-alias.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[character &gt;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": ">"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-decimal.json
+++ b/ftml/test/char2-decimal.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char &#129408;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "🦀"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-hex.json
+++ b/ftml/test/char2-hex.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char &#x1f980;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "🦀"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-leading.json
+++ b/ftml/test/char2-leading.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char &amp]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "&"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-name.json
+++ b/ftml/test/char2-name.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char &copy;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "©"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2-trailing.json
+++ b/ftml/test/char2-trailing.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char amp;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "&"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/char2.json
+++ b/ftml/test/char2.json
@@ -1,0 +1,32 @@
+{
+    "input": "[[char &amp;]] pineapple",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "&"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "pineapple"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}


### PR DESCRIPTION
This PR adds the `[[char]]` block, which allows use of HTML entities. See [FTML-87](https://scuttle.atlassian.net/browse/FTML-87) for more information.

It supports the form both with and without `&..;` (so for instance, `[[char amp]]` and `[[char &amp;]]` are both valid), and the hexadecimal and decimal entities (e.g. `&#100;`, `&#xff;`)

The outputted element is still `Element::Text`. Actual escaping (for instance, forming an HTML entity in the final HTML output) is up to the escaping mechanism.