### PR TITLE
Add more editorconfig file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,21 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,ftml}]
 trim_trailing_whitespace = false
+
+[{Makefile,*.mk,*.sh}]
+indent_style = tab
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{js,json}]
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,7 @@ indent_size = 4
 [*.rs]
 indent_style = space
 indent_size = 4
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,10 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+[*.toml]
+indent_style = space
+indent_size = 4
+
 [*.rs]
 indent_style = space
 indent_size = 4

--- a/ftml/.editorconfig
+++ b/ftml/.editorconfig
@@ -1,0 +1,2 @@
+[*.json]
+indent_size = 4


### PR DESCRIPTION
With an upcoming PR for a client / frontend monorepo, I thought we should update `.editorconfig` rules so compatible editors properly format files within each relevant section of the codebase.