### PR TITLE
Bump ftml version to v0.6.0

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "built",
  "cfg-if 1.0.0",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 


### PR DESCRIPTION
We've launched a number of significant changes since we last bumped the version number, such as webasm support.