### PR TITLE
Add Nginx and Datadog containers to dev

### DIFF
--- a/.github/workflows/docker-build-push-nginx.dev.yaml
+++ b/.github/workflows/docker-build-push-nginx.dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - aws-dev-refactor
     paths:
       - 'web/web/**'
       - 'web/package.json'

--- a/.github/workflows/docker-build-push-nginx.dev.yaml
+++ b/.github/workflows/docker-build-push-nginx.dev.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - aws-dev-refactor
     paths:
       - 'web/web/**'
       - 'web/package.json'

--- a/.github/workflows/docker-build-push-nginx.dev.yaml
+++ b/.github/workflows/docker-build-push-nginx.dev.yaml
@@ -1,0 +1,57 @@
+name: '[backend] Docker build Nginx'
+
+on:
+  push:
+    branches:
+      - develop
+      - aws-dev-refactor
+    paths:
+      - 'web/web/**'
+      - 'web/package.json'
+      - 'web/tsconfig.json'
+      - 'install/aws/dev/docker/nginx/**'
+      - '.github/workflows/docker-build-push-nginx.dev.yaml'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DOCKER_PUSH_KEY }}
+          aws-secret-access-key: ${{ secrets.DOCKER_PUSH_SECRET }}
+          aws-region: us-east-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        working-directory: ./install/aws/dev/docker/nginx
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: wikijump-dev/nginx
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          set -ex
+          docker build --build-arg WIKIJUMP_REPO_BRANCH=${GITHUB_REF##*/} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition wikijump-dev-ec2 --query taskDefinition > task-definition.json
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: nginx
+          image: ${{ steps.build-image.outputs.image }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: wikijump-dev-svc
+          cluster: wikijump-dev
+          wait-for-service-stability: true

--- a/.github/workflows/docker-build-push-php.dev.yaml
+++ b/.github/workflows/docker-build-push-php.dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - aws-dev-refactor
     paths:
       - 'web/**'
       - 'install/aws/dev/docker/php-fpm/**'

--- a/.github/workflows/docker-build-push-php.dev.yaml
+++ b/.github/workflows/docker-build-push-php.dev.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - aws-dev-refactor
     paths:
       - 'web/**'
       - 'install/aws/dev/docker/php-fpm/**'

--- a/install/aws/dev/docker/nginx/Dockerfile
+++ b/install/aws/dev/docker/nginx/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:alpine as npm
+
+# Please note this arg is also defined in the nginx layer further down.
+ARG WIKIJUMP_REPO_DIR="wikijump"
+
+ARG WIKIJUMP_REPO_BRANCH="develop"
+ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
+WORKDIR /src
+
+RUN apk add --no-cache git
+
+RUN git clone \
+            --depth 10 \
+            --branch "${WIKIJUMP_REPO_BRANCH}" \
+            "${WIKIJUMP_REPO}"
+
+WORKDIR /src/${WIKIJUMP_REPO_DIR}/web
+
+RUN npm install
+RUN npm run build
+
+FROM nginx:alpine
+ARG WIKIJUMP_REPO_DIR="wikijump"
+EXPOSE 80
+
+COPY --from=npm /src/${WIKIJUMP_REPO_DIR}/web/web /var/www/wikijump/web/web
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/install/aws/dev/docker/nginx/nginx.conf
+++ b/install/aws/dev/docker/nginx/nginx.conf
@@ -90,7 +90,7 @@
                  }
 
                  location ~ \.php$ {
-                             set_real_ip_from reverse-proxy;
+                             # set_real_ip_from reverse-proxy;
                              # regex to split $uri to $fastcgi_script_name and $fastcgi_path
                              fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 

--- a/install/aws/dev/docker/nginx/nginx.conf
+++ b/install/aws/dev/docker/nginx/nginx.conf
@@ -1,0 +1,145 @@
+ worker_processes auto;
+ pid /run/nginx.pid;
+
+ events {
+         worker_connections 768;
+         # multi_accept on;
+ }
+
+ http {
+
+         log_format main '$http_x_real_ip - $remote_user [$time_local] '
+         '"$request" $status $body_bytes_sent "$http_referer" '
+         '"$http_user_agent"' ;
+
+         ##
+         # Basic Settings
+         ##
+
+         sendfile on;
+         tcp_nopush on;
+         tcp_nodelay on;
+         keepalive_timeout 65;
+         types_hash_max_size 2048;
+         # server_tokens off;
+
+         # server_names_hash_bucket_size 64;
+         # server_name_in_redirect off;
+
+         include /etc/nginx/mime.types;
+         default_type application/octet-stream;
+
+         ##
+         # SSL Settings
+         ##
+
+         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+         ssl_prefer_server_ciphers on;
+
+         ##
+         # Logging Settings
+         ##
+
+         access_log /var/log/nginx/access.log main;
+         error_log /var/log/nginx/error.log;
+
+         ##
+         # Gzip Settings
+         ##
+
+         gzip on;
+
+         # gzip_vary on;
+         # gzip_proxied any;
+         # gzip_comp_level 6;
+         # gzip_buffers 16 8k;
+         # gzip_http_version 1.1;
+         # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+         ##
+         # Virtual Host Configs
+         ##
+
+         # include /etc/nginx/conf.d/*.conf;
+         server {
+                 server_name wikijump;
+                 listen 80;
+                 listen [::]:80;
+
+                 root /var/www/wikijump/web/web;
+
+                 # Add index.php to the list if you are using PHP
+                 index index.php;
+
+                 location /wikijump--next {
+                     # Assets
+                     location /wikijump--next/assets {
+                         alias /var/www/wikijump/web/storage/app/public;
+                     }
+
+                     # Fallback
+                     try_files $uri /laravel.php?$args;
+                 }
+
+                 location / {
+                     # First attempt to serve request as file, then
+                     # as directory, then fall back to displaying a 404.
+                     # As this is the most vague block, stuff in here gets examined last.
+                     try_files $uri $uri/ /index.php?$args;
+                     # Fallback Route
+                 }
+
+                 location ~ \.php$ {
+                             set_real_ip_from reverse-proxy;
+                             # regex to split $uri to $fastcgi_script_name and $fastcgi_path
+                             fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+
+                             # Check that the PHP script exists before passing it
+                             try_files $fastcgi_script_name =404;
+
+                             # Set buffer size large enough for Laravel debug stack traces to come through
+                             # LOCAL AND AWS DEV ONLY - There shouldn't be any reason to set this for prod.
+                             fastcgi_buffers 16 256k;
+
+                             # Bypass the fact that try_files resets $fastcgi_path_info
+                             # see: http://trac.nginx.org/nginx/ticket/321
+                             set $path_info $fastcgi_path_info;
+                             fastcgi_param PATH_INFO $path_info;
+                             # fastcgi_param REMOTE_ADDR $http_x_real_ip;
+
+                             fastcgi_index index.php;
+                             include fastcgi.conf;
+
+                             fastcgi_pass php-fpm:9000;
+                 }
+
+                 rewrite ^/common--(.+)$ /files--common/$1 break;
+                 rewrite ^/a16.png /files--common/images/avatars/default/a16.png break;
+                 rewrite ^/a48.png /files--common/images/avatars/default/a48.png break;
+                 rewrite ^/forum/start(.*)$ /index.php?Wiki__WikiScreen/wiki_page/forum:start$1 break;
+                 rewrite ^/forum/t-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:thread/t/$1$2 break;
+                 rewrite ^/forum/c-([0-9]+)(/.*)?$ /index.php?Wiki__WikiScreen/wiki_page/forum:category/c/$1$2 break;
+                 rewrite ^/feed/forum/t\-([0-9]+)\.xml$ /feed.php?Feed__ForumThreadPostsFeed/t/$1 break;
+                 rewrite ^/feed/forum/ct\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryThreadsFeed/c/$1$2 break;
+                 rewrite ^/feed/forum/cp\-([0-9]+)\.xml$ /feed.php?Feed__ForumCategoryPostsFeed/c/$1$2 break;
+                 rewrite ^/feed/forum/posts\.xml$ /feed.php?Feed__ForumPostsFeed break;
+                 rewrite ^/feed/forum/threads\.xml$ /feed.php?Feed__ForumThreadsFeed break;
+                 rewrite ^/feed/page/comments\-([0-9]+)\.xml$ /feed.php?Feed__PageCommentsFeed/p/$1 break;
+                 rewrite ^/feed/front/([a-z\-:]+)/([0-9a-zA-Z\-]+)\.xml$ /feed.php?Feed__FrontForumFeed/page/$1/label/$2 break;
+                 rewrite ^/feed/site\-changes\.xml$ /feed.php?Feed__SiteChangesFeed break;
+                 rewrite ^/feed/admin\.xml$ /feed.php?Feed__AdminNotificationsFeed break;
+                 rewrite ^/printer--friendly/+forum/start(.*)$ /index.php?PrinterFriendly/wiki_page/forum:start$1 break;
+                 rewrite ^/printer--friendly/+forum/t-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:thread/t/$1$2 break;
+                 rewrite ^/printer--friendly/+forum/c-([0-9]+)(/.*)?$ /index.php?PrinterFriendly/wiki_page/forum:category/c/$1$2 break;
+                 rewrite ^/printer--friendly/(.*)$ /index.php?PrinterFriendly/wiki_page/$1 break;
+                 rewrite ^/default--screen/(.*)$ /index.php?$1 break;
+                 rewrite ^/local--([^/]+/.*)$ /local.php?$1 break;
+                 rewrite ^/([a-z0-9\-]+)/code(?:(/[0-9]+))?$ /local.php?code/$1$2 break;
+
+                 # pass PHP scripts to FastCGI server
+                 rewrite ^/(.*)\.php$ /$1.php break;
+
+                 # Fallback route
+                 rewrite ^\/(?!wikijump--next\/)(.*)$ /index.php?Wiki__WikiScreen/wiki_page/$1? break;
+         }
+ }

--- a/install/aws/dev/terraform/deploy/cloudfront.tf
+++ b/install/aws/dev/terraform/deploy/cloudfront.tf
@@ -93,7 +93,7 @@ resource "aws_cloudfront_distribution" "wikijump_cf_distro" {
 
     forwarded_values {
       query_string = true
-      headers = ["Host"]
+      headers      = ["Host"]
 
       cookies {
         forward = "all"

--- a/install/aws/dev/terraform/deploy/cloudwatch.tf
+++ b/install/aws/dev/terraform/deploy/cloudwatch.tf
@@ -22,3 +22,8 @@ resource "aws_cloudwatch_log_group" "traefik" {
   name              = "ecs/traefik-${var.environment}"
   retention_in_days = "7"
 }
+
+resource "aws_cloudwatch_log_group" "datadog" {
+  name              = "ecs/datadog-${var.environment}"
+  retention_in_days = "7"
+}

--- a/install/aws/dev/terraform/deploy/cloudwatch.tf
+++ b/install/aws/dev/terraform/deploy/cloudwatch.tf
@@ -13,6 +13,11 @@ resource "aws_cloudwatch_log_group" "php-fpm" {
   retention_in_days = "7"
 }
 
+resource "aws_cloudwatch_log_group" "nginx" {
+  name              = "ecs/nginx-${var.environment}"
+  retention_in_days = "7"
+}
+
 resource "aws_cloudwatch_log_group" "traefik" {
   name              = "ecs/traefik-${var.environment}"
   retention_in_days = "7"

--- a/install/aws/dev/terraform/deploy/ecs.tf
+++ b/install/aws/dev/terraform/deploy/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_capacity_provider" "asg" {
 
 resource "aws_ecs_task_definition" "wikijump_task" {
   family                   = "wikijump-${var.environment}-ec2"
-  container_definitions    = "[${module.cache.sensitive_json_map_encoded},${module.database.sensitive_json_map_encoded},${module.php-fpm.sensitive_json_map_encoded},${module.nginx.sensitive_json_map_encoded},${module.reverse-proxy.sensitive_json_map_encoded}]"
+  container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.nginx.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   execution_role_arn       = aws_iam_role.execution.arn

--- a/install/aws/dev/terraform/deploy/ecs.tf
+++ b/install/aws/dev/terraform/deploy/ecs.tf
@@ -68,6 +68,14 @@ resource "aws_ecs_task_definition" "wikijump_task" {
     host_path = "/var/run/docker.sock"
   }
   volume {
+    name = "proc"
+    host_path = "/proc"
+  }
+  volume {
+    name = "cgroup"
+    host_path = "/cgroup"
+  }
+  volume {
     name = "letsencrypt"
 
     efs_volume_configuration {

--- a/install/aws/dev/terraform/deploy/ecs.tf
+++ b/install/aws/dev/terraform/deploy/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_capacity_provider" "asg" {
 
 resource "aws_ecs_task_definition" "wikijump_task" {
   family                   = "wikijump-${var.environment}-ec2"
-  container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.nginx.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
+  container_definitions    = "[${module.cache.sensitive_json_map_encoded},${module.database.sensitive_json_map_encoded},${module.php-fpm.sensitive_json_map_encoded},${module.nginx.sensitive_json_map_encoded},${module.reverse-proxy.sensitive_json_map_encoded}]"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   execution_role_arn       = aws_iam_role.execution.arn

--- a/install/aws/dev/terraform/deploy/ecs.tf
+++ b/install/aws/dev/terraform/deploy/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_capacity_provider" "asg" {
 
 resource "aws_ecs_task_definition" "wikijump_task" {
   family                   = "wikijump-${var.environment}-ec2"
-  container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.nginx.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
+  container_definitions    = "[${module.cache.json_map_encoded},${module.database.sensitive_json_map_encoded},${module.php-fpm.sensitive_json_map_encoded},${module.nginx.sensitive_json_map_encoded},${module.reverse-proxy.sensitive_json_map_encoded},${module.datadog.sensitive_json_map_encoded}]"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   execution_role_arn       = aws_iam_role.execution.arn

--- a/install/aws/dev/terraform/deploy/ecs.tf
+++ b/install/aws/dev/terraform/deploy/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_capacity_provider" "asg" {
 
 resource "aws_ecs_task_definition" "wikijump_task" {
   family                   = "wikijump-${var.environment}-ec2"
-  container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
+  container_definitions    = "[${module.cache.json_map_encoded},${module.database.json_map_encoded},${module.php-fpm.json_map_encoded},${module.nginx.json_map_encoded},${module.reverse-proxy.json_map_encoded}]"
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
   execution_role_arn       = aws_iam_role.execution.arn

--- a/install/aws/dev/terraform/deploy/elb.tf
+++ b/install/aws/dev/terraform/deploy/elb.tf
@@ -20,11 +20,11 @@ resource "aws_lb" "wikijump_elb" {
 }
 
 resource "aws_lb_target_group" "elb_target_group_80" {
-  name        = "wikijump-tg-80-${var.environment}"
-  port        = 80
-  protocol    = "TCP"
-  vpc_id      = aws_vpc.wikijump_vpc.id
-  target_type = "instance"
+  name                 = "wikijump-tg-80-${var.environment}"
+  port                 = 80
+  protocol             = "TCP"
+  vpc_id               = aws_vpc.wikijump_vpc.id
+  target_type          = "instance"
   deregistration_delay = 3
   health_check {
     enabled = true
@@ -34,11 +34,11 @@ resource "aws_lb_target_group" "elb_target_group_80" {
 }
 
 resource "aws_lb_target_group" "elb_target_group_443" {
-  name        = "wikijump-tg-443-${var.environment}"
-  port        = 443
-  protocol    = "TCP"
-  vpc_id      = aws_vpc.wikijump_vpc.id
-  target_type = "instance"
+  name                 = "wikijump-tg-443-${var.environment}"
+  port                 = 443
+  protocol             = "TCP"
+  vpc_id               = aws_vpc.wikijump_vpc.id
+  target_type          = "instance"
   deregistration_delay = 3
   health_check {
     enabled = true

--- a/install/aws/dev/terraform/deploy/ssm.tf
+++ b/install/aws/dev/terraform/deploy/ssm.tf
@@ -16,8 +16,12 @@ resource "aws_ssm_parameter" "URL_UPLOAD_DOMAIN" {
   value = var.files_domain
 }
 
-data "aws_ssm_parameter" "WEB_ECR_URL" {
-  name = "wikijump-${var.environment}-WEB_ECR_URL"
+data "aws_ssm_parameter" "PHP_ECR_URL" {
+  name = "wikijump-${var.environment}-PHP_ECR_URL"
+}
+
+data "aws_ssm_parameter" "NGINX_ECR_URL" {
+  name = "wikijump-${var.environment}-NGINX_ECR_URL"
 }
 
 data "aws_ssm_parameter" "DB_ECR_URL" {

--- a/install/aws/dev/terraform/deploy/ssm.tf
+++ b/install/aws/dev/terraform/deploy/ssm.tf
@@ -1,19 +1,22 @@
 resource "aws_ssm_parameter" "URL_DOMAIN" {
-  name  = "wikijump-${var.environment}-URL_DOMAIN"
-  type  = "String"
-  value = var.web_domain
+  name      = "wikijump-${var.environment}-URL_DOMAIN"
+  type      = "String"
+  value     = var.web_domain
+  sensitive = true
 }
 
 resource "aws_ssm_parameter" "DB_HOST" {
-  name  = "wikijump-${var.environment}-DB_HOST"
-  type  = "String"
-  value = "database"
+  name      = "wikijump-${var.environment}-DB_HOST"
+  type      = "String"
+  value     = "database"
+  sensitive = true
 }
 
 resource "aws_ssm_parameter" "URL_UPLOAD_DOMAIN" {
-  name  = "wikijump-${var.environment}-URL_UPLOAD_DOMAIN"
-  type  = "String"
-  value = var.files_domain
+  name      = "wikijump-${var.environment}-URL_UPLOAD_DOMAIN"
+  type      = "String"
+  value     = var.files_domain
+  sensitive = true
 }
 
 data "aws_ssm_parameter" "PHP_ECR_URL" {

--- a/install/aws/dev/terraform/deploy/ssm.tf
+++ b/install/aws/dev/terraform/deploy/ssm.tf
@@ -1,22 +1,19 @@
 resource "aws_ssm_parameter" "URL_DOMAIN" {
-  name      = "wikijump-${var.environment}-URL_DOMAIN"
-  type      = "String"
-  value     = var.web_domain
-  sensitive = true
+  name  = "wikijump-${var.environment}-URL_DOMAIN"
+  type  = "String"
+  value = var.web_domain
 }
 
 resource "aws_ssm_parameter" "DB_HOST" {
-  name      = "wikijump-${var.environment}-DB_HOST"
-  type      = "String"
-  value     = "database"
-  sensitive = true
+  name  = "wikijump-${var.environment}-DB_HOST"
+  type  = "String"
+  value = "database"
 }
 
 resource "aws_ssm_parameter" "URL_UPLOAD_DOMAIN" {
-  name      = "wikijump-${var.environment}-URL_UPLOAD_DOMAIN"
-  type      = "String"
-  value     = var.files_domain
-  sensitive = true
+  name  = "wikijump-${var.environment}-URL_UPLOAD_DOMAIN"
+  type  = "String"
+  value = var.files_domain
 }
 
 data "aws_ssm_parameter" "PHP_ECR_URL" {

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -194,24 +194,29 @@ module "reverse-proxy" {
 output "cache_json" {
   description = "Container definition in JSON format"
   value       = module.cache.json_map_encoded_list
+  sensitive   = true
 }
 
 output "database_json" {
   description = "Container definition in JSON format"
   value       = module.database.json_map_encoded_list
+  sensitive   = true
 }
 
 output "php-fpm_json" {
   description = "Container definition in JSON format"
   value       = module.php-fpm.json_map_encoded_list
+  sensitive   = true
 }
 
 output "nginx_json" {
   description = "Container definition in JSON format"
   value       = module.nginx.json_map_encoded_list
+  sensitive   = true
 }
 
 output "reverse-proxy_json" {
   description = "Container definition in JSON format"
   value       = module.reverse-proxy.json_map_encoded_list
+  sensitive   = true
 }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -115,7 +115,15 @@ module "datadog" {
   container_image              = "gcr.io/datadoghq/agent:7"
   container_memory_reservation = var.ecs_datadog_memory / 8
   essential                    = false
-  environment                  = []
+  environment                  = [
+    {
+      name      = "DD_API_KEY"
+      value = var.datadog_api_key
+    },
+    {
+      name      = "DD_SITE"
+      value = var.datadog_site
+    }]
 
   log_configuration = {
     logDriver = "awslogs"
@@ -126,16 +134,7 @@ module "datadog" {
     }
   }
 
-  secrets = [
-    {
-      name      = "DD_API_KEY"
-      valueFrom = var.datadog_api_key
-    },
-    {
-      name      = "DD_SITE"
-      valueFrom = var.datadog_site
-    }
-  ]
+  secrets = []
 
   mount_points = [
     {

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -145,12 +145,12 @@ module "datadog" {
 
     },
     {
-      sourceVolume  = "/proc"
+      sourceVolume  = "proc"
       containerPath = "/host/proc"
       readOnly      = true
     },
     {
-      sourceVolume  = "/cgroup"
+      sourceVolume  = "cgroup"
       containerPath = "/host/sys/fs/cgroup"
       readOnly      = true
     }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -95,15 +95,15 @@ module "php-fpm" {
   secrets = [
     {
       name      = "WIKIJUMP_URL_DOMAIN"
-      valueFrom = "wikijump-dev-URL_DOMAIN"
+      valueFrom = aws_ssm_parameter.URL_DOMAIN.name
     },
     {
       name      = "WIKIJUMP_URL_UPLOAD_DOMAIN"
-      valueFrom = "wikijump-dev-URL_UPLOAD_DOMAIN"
+      valueFrom = aws_ssm_parameter.URL_UPLOAD_DOMAIN.name
     },
     {
       name      = "WIKIJUMP_DB_HOST"
-      valueFrom = "wikijump-dev-DB_HOST"
+      valueFrom = aws_ssm_parameter.DB_HOST.name
     }
   ]
 }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -193,30 +193,30 @@ module "reverse-proxy" {
 
 output "cache_json" {
   description = "Container definition in JSON format"
-  value       = module.cache.json_map_encoded_list
+  value       = module.cache.sensitive_json_map_encoded_list
   sensitive   = true
 }
 
 output "database_json" {
   description = "Container definition in JSON format"
-  value       = module.database.json_map_encoded_list
+  value       = module.database.sensitive_json_map_encoded_list
   sensitive   = true
 }
 
 output "php-fpm_json" {
   description = "Container definition in JSON format"
-  value       = module.php-fpm.json_map_encoded_list
+  value       = module.php-fpm.sensitive_json_map_encoded_list
   sensitive   = true
 }
 
 output "nginx_json" {
   description = "Container definition in JSON format"
-  value       = module.nginx.json_map_encoded_list
+  value       = module.nginx.sensitive_json_map_encoded_list
   sensitive   = true
 }
 
 output "reverse-proxy_json" {
   description = "Container definition in JSON format"
-  value       = module.reverse-proxy.json_map_encoded_list
+  value       = module.reverse-proxy.sensitive_json_map_encoded_list
   sensitive   = true
 }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -193,30 +193,25 @@ module "reverse-proxy" {
 
 output "cache_json" {
   description = "Container definition in JSON format"
-  value       = module.cache.sensitive_json_map_encoded_list
-  sensitive   = true
+  value       = module.cache.json_map_encoded_list
 }
 
 output "database_json" {
   description = "Container definition in JSON format"
-  value       = module.database.sensitive_json_map_encoded_list
-  sensitive   = true
+  value       = module.database.json_map_encoded_list
 }
 
 output "php-fpm_json" {
   description = "Container definition in JSON format"
-  value       = module.php-fpm.sensitive_json_map_encoded_list
-  sensitive   = true
+  value       = module.php-fpm.json_map_encoded_list
 }
 
 output "nginx_json" {
   description = "Container definition in JSON format"
-  value       = module.nginx.sensitive_json_map_encoded_list
-  sensitive   = true
+  value       = module.nginx.json_map_encoded_list
 }
 
 output "reverse-proxy_json" {
   description = "Container definition in JSON format"
-  value       = module.reverse-proxy.sensitive_json_map_encoded_list
-  sensitive   = true
+  value       = module.reverse-proxy.json_map_encoded_list
 }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -225,7 +225,6 @@ module "reverse-proxy" {
       sourceVolume  = "docker-socket"
       containerPath = "/var/run/docker.sock"
       readOnly      = true
-
     },
     {
       sourceVolume  = "letsencrypt"

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -145,13 +145,13 @@ module "datadog" {
 
     },
     {
-      sourceVolume  = "/proc/"
-      containerPath = "/host/proc/"
+      sourceVolume  = "/proc"
+      containerPath = "/host/proc"
       readOnly      = true
     },
     {
-      sourceVolume  = "/cgroup/"
-      containerPath = "/host/sys/fs/cgroup/"
+      sourceVolume  = "/cgroup"
+      containerPath = "/host/sys/fs/cgroup"
       readOnly      = true
     }
   ]

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -3,7 +3,7 @@ module "cache" {
 
   container_name               = "cache"
   container_image              = var.ecs_cache_image
-  container_memory_reservation = var.ecs_cache_memory
+  container_memory_reservation = var.ecs_cache_memory / 8
   essential                    = true
   environment                  = []
 
@@ -22,7 +22,7 @@ module "database" {
 
   container_name               = "database"
   container_image              = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
-  container_memory_reservation = var.ecs_db_memory
+  container_memory_reservation = var.ecs_db_memory / 8
   essential                    = true
   environment                  = []
 
@@ -41,7 +41,7 @@ module "nginx" {
 
   container_name               = "nginx"
   container_image              = "${data.aws_ssm_parameter.NGINX_ECR_URL.value}:develop"
-  container_memory_reservation = var.ecs_nginx_memory
+  container_memory_reservation = var.ecs_nginx_memory / 8
   essential                    = true
   environment                  = []
 
@@ -77,7 +77,7 @@ module "php-fpm" {
 
   container_name               = "php-fpm"
   container_image              = "${data.aws_ssm_parameter.PHP_ECR_URL.value}:develop"
-  container_memory_reservation = var.ecs_php_memory
+  container_memory_reservation = var.ecs_php_memory / 8
   essential                    = true
   environment                  = []
 
@@ -113,7 +113,7 @@ module "datadog" {
 
   container_name               = "datadog"
   container_image              = "gcr.io/datadoghq/agent:7"
-  container_memory_reservation = var.ecs_datadog_memory
+  container_memory_reservation = var.ecs_datadog_memory / 8
   essential                    = false
   environment                  = []
 
@@ -162,7 +162,7 @@ module "reverse-proxy" {
 
   container_name               = "reverse-proxy"
   container_image              = var.ecs_traefik_image
-  container_memory_reservation = var.ecs_traefik_memory
+  container_memory_reservation = var.ecs_traefik_memory / 8
   essential                    = true
   environment = [
     {

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -1,5 +1,5 @@
 module "cache" {
-  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
+  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.56.0"
 
   container_name               = "cache"
   container_image              = var.ecs_cache_image
@@ -18,7 +18,7 @@ module "cache" {
 }
 
 module "database" {
-  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
+  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.56.0"
 
   container_name               = "database"
   container_image              = "${data.aws_ssm_parameter.DB_ECR_URL.value}:develop"
@@ -37,7 +37,7 @@ module "database" {
 }
 
 module "nginx" {
-  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
+  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.56.0"
 
   container_name               = "nginx"
   container_image              = "${data.aws_ssm_parameter.NGINX_ECR_URL.value}:develop"
@@ -73,7 +73,7 @@ module "nginx" {
 }
 
 module "php-fpm" {
-  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
+  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.56.0"
 
   container_name               = "php-fpm"
   container_image              = "${data.aws_ssm_parameter.PHP_ECR_URL.value}:develop"
@@ -109,7 +109,7 @@ module "php-fpm" {
 }
 
 module "reverse-proxy" {
-  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.46.0"
+  source = "github.com/cloudposse/terraform-aws-ecs-container-definition?ref=0.56.0"
 
   container_name               = "reverse-proxy"
   container_image              = var.ecs_traefik_image

--- a/install/aws/dev/terraform/deploy/variables.tf
+++ b/install/aws/dev/terraform/deploy/variables.tf
@@ -23,7 +23,8 @@ variable "container_subnet" {
 }
 
 variable "cf_auth_token" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "region" {
@@ -112,9 +113,11 @@ variable "redeploy_ecs_on_tf_apply" {
 }
 
 variable "route53_access_key" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "route53_secret_key" {
-  type = string
+  type      = string
+  sensitive = true
 }

--- a/install/aws/dev/terraform/deploy/variables.tf
+++ b/install/aws/dev/terraform/deploy/variables.tf
@@ -74,6 +74,16 @@ variable "ecs_php_memory" {
   default = 768
 }
 
+variable "ecs_nginx_memory" {
+  type    = number
+  default = 512
+}
+
+variable "ecs_nginx_cpu" {
+  type    = number
+  default = 512
+}
+
 variable "ecs_php_cpu" {
   type    = number
   default = 1024

--- a/install/aws/dev/terraform/deploy/variables.tf
+++ b/install/aws/dev/terraform/deploy/variables.tf
@@ -100,12 +100,23 @@ variable "ecs_traefik_cpu" {
   default = 512
 }
 
+variable "ecs_datadog_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "ecs_datadog_memory" {
+  type    = number
+  default = 512
+}
+
 variable "ecs_traefik_image" {
   type = string
 }
 
 variable "letsencrypt_email" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "redeploy_ecs_on_tf_apply" {
@@ -120,4 +131,14 @@ variable "route53_access_key" {
 variable "route53_secret_key" {
   type      = string
   sensitive = true
+}
+
+variable "datadog_api_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "datadog_site" {
+  type    = string
+  default = "datadoghq.com"
 }

--- a/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
+++ b/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
@@ -25,6 +25,9 @@ ecs_php_cpu    = 1024
 ecs_nginx_memory = 512
 ecs_nginx_cpu    = 512
 
+ecs_datadog_memory = 512
+ecs_datadog_cpu    = 512
+
 ecs_traefik_memory = 512
 ecs_traefik_cpu    = 512
 ecs_traefik_image  = "traefik:v2.4"

--- a/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
+++ b/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
@@ -28,6 +28,9 @@ ecs_db_cpu    = 256
 ecs_php_memory = 768
 ecs_php_cpu    = 1024
 
+ecs_nginx_memory = 512
+ecs_nginx_cpu    = 512
+
 ecs_traefik_memory = 512
 ecs_traefik_cpu    = 512
 ecs_traefik_image  = "traefik:v2.3"

--- a/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
+++ b/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
@@ -10,12 +10,6 @@ vpc_cidr_block   = "10.106.0.0/16"
 elb_subnet       = "10.106.0.0/24"
 container_subnet = "10.106.10.0/24"
 
-# Cloudfront/ELB
-# The cf_auth_token var isn't *sensitive* as such, but an attacker could add this header value to bypass Cloudfront and hit our load balancer directly.
-# So, you may as well store this as a secret, perhaps in Terraform Cloud's vars as a sensitive value so it doesn't show up in tf plans.
-# It can be anything, something vaguely random like a GUID will work fine.
-# cf_auth_token       = "e421b736-aa0f-4fbf-9965-b6fce423c826"
-
 # Container Specs
 instance_type    = "t3.medium"
 ecs_cache_memory = 512
@@ -33,10 +27,22 @@ ecs_nginx_cpu    = 512
 
 ecs_traefik_memory = 512
 ecs_traefik_cpu    = 512
-ecs_traefik_image  = "traefik:v2.3"
+ecs_traefik_image  = "traefik:v2.4"
 
 # Misc
 letsencrypt_email = "info@wikijump.com"
-# If true, ECS will generate a new service with every tf apply, allowing it to perhaps pull in a new version of an image.
-# Otherwise, will only generate a new service when the service or a related piece is modified.
+
+# If true, ECS will generate a new service with every tf apply, allowing it to
+# perhaps pull in a new version of an image. Otherwise, will only generate a new
+# service when the service or a related piece is modified.
 redeploy_ecs_on_tf_apply = true
+
+# Regarding storing secrets for deployment:
+# As we share this repo to the public, but stand up our own installation with
+# unique credentials, we store some vars in terraform cloud as terraform vars
+# there. Generally speaking some sort of secret store is better than putting
+# sensitive keys in a .tfvars file. You need these vars to plan or deploy.
+# cf_auth_token      = "12345678-abcd-1234-5678-1234567890ab"
+# route53_access_key = "AEXAMPLEAPIKEY1234"
+# route53_secret_key = "example123/abcdefghijklmnopqrstuvwxyzABC"
+# datadog_api_key    = "1234567890abcdef1234567890abcdef"

--- a/install/aws/dev/terraform/init/init.tf
+++ b/install/aws/dev/terraform/init/init.tf
@@ -16,10 +16,16 @@ provider "aws" {
   region = local.region
 }
 
-resource "aws_ssm_parameter" "WEB_ECR_URL" {
-  name  = "wikijump-${local.environment}-WEB_ECR_URL"
+resource "aws_ssm_parameter" "PHP_ECR_URL" {
+  name  = "wikijump-${local.environment}-PHP_ECR_URL"
   type  = "String"
-  value = aws_ecr_repository.web_ecr.repository_url
+  value = aws_ecr_repository.php_ecr.repository_url
+}
+
+resource "aws_ssm_parameter" "NGINX_ECR_URL" {
+  name  = "wikijump-${local.environment}-NGINX_ECR_URL"
+  type  = "String"
+  value = aws_ecr_repository.nginx_ecr.repository_url
 }
 
 resource "aws_ssm_parameter" "DB_ECR_URL" {
@@ -28,8 +34,18 @@ resource "aws_ssm_parameter" "DB_ECR_URL" {
   value = aws_ecr_repository.db_ecr.repository_url
 }
 
-resource "aws_ecr_repository" "web_ecr" {
+resource "aws_ecr_repository" "php_ecr" {
   name = "wikijump-${local.environment}/php-fpm"
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_repository" "nginx_ecr" {
+  name = "wikijump-${local.environment}/nginx"
   encryption_configuration {
     encryption_type = "KMS"
   }

--- a/install/aws/dev/terraform/modules/secure-container-definitions/main.tf
+++ b/install/aws/dev/terraform/modules/secure-container-definitions/main.tf
@@ -1,0 +1,108 @@
+locals {
+  # Sort environment variables so terraform will not try to recreate on each plan/apply
+  env_vars_keys        = var.map_environment != null ? keys(var.map_environment) : var.environment != null ? [for m in var.environment : lookup(m, "name")] : []
+  env_vars_values      = var.map_environment != null ? values(var.map_environment) : var.environment != null ? [for m in var.environment : lookup(m, "value")] : []
+  env_vars_as_map      = zipmap(local.env_vars_keys, local.env_vars_values)
+  sorted_env_vars_keys = sort(local.env_vars_keys)
+
+  sorted_environment_vars = [
+    for key in local.sorted_env_vars_keys :
+    {
+      name  = key
+      value = lookup(local.env_vars_as_map, key)
+    }
+  ]
+
+  # Sort secrets so terraform will not try to recreate on each plan/apply
+  secrets_keys        = var.map_secrets != null ? keys(var.map_secrets) : var.secrets != null ? [for m in var.secrets : lookup(m, "name")] : []
+  secrets_values      = var.map_secrets != null ? values(var.map_secrets) : var.secrets != null ? [for m in var.secrets : lookup(m, "valueFrom")] : []
+  secrets_as_map      = zipmap(local.secrets_keys, local.secrets_values)
+  sorted_secrets_keys = sort(local.secrets_keys)
+
+  sorted_secrets_vars = [
+    for key in local.sorted_secrets_keys :
+    {
+      name      = key
+      valueFrom = lookup(local.secrets_as_map, key)
+    }
+  ]
+
+  mount_points = length(var.mount_points) > 0 ? [
+    for mount_point in var.mount_points : {
+      containerPath = lookup(mount_point, "containerPath")
+      sourceVolume  = lookup(mount_point, "sourceVolume")
+      readOnly      = tobool(lookup(mount_point, "readOnly", false))
+    }
+  ] : var.mount_points
+
+  # https://www.terraform.io/docs/configuration/expressions.html#null
+  final_environment_vars = length(local.sorted_environment_vars) > 0 ? local.sorted_environment_vars : null
+  final_secrets_vars     = length(local.sorted_secrets_vars) > 0 ? local.sorted_secrets_vars : null
+
+  log_configuration_secret_options = var.log_configuration != null ? lookup(var.log_configuration, "secretOptions", null) : null
+  log_configuration_with_null = var.log_configuration == null ? null : {
+    logDriver = tostring(lookup(var.log_configuration, "logDriver"))
+    options   = tomap(lookup(var.log_configuration, "options"))
+    secretOptions = local.log_configuration_secret_options == null ? null : [
+      for secret_option in tolist(local.log_configuration_secret_options) : {
+        name      = tostring(lookup(secret_option, "name"))
+        valueFrom = tostring(lookup(secret_option, "valueFrom"))
+      }
+    ]
+  }
+  log_configuration_without_null = local.log_configuration_with_null == null ? null : {
+    for k, v in local.log_configuration_with_null :
+    k => v
+    if v != null
+  }
+  user = var.firelens_configuration != null ? "0" : var.user
+
+  container_definition = {
+    name                   = var.container_name
+    image                  = var.container_image
+    essential              = var.essential
+    entryPoint             = var.entrypoint
+    command                = var.command
+    workingDirectory       = var.working_directory
+    readonlyRootFilesystem = var.readonly_root_filesystem
+    mountPoints            = local.mount_points
+    dnsServers             = var.dns_servers
+    dnsSearchDomains       = var.dns_search_domains
+    ulimits                = var.ulimits
+    repositoryCredentials  = var.repository_credentials
+    links                  = var.links
+    volumesFrom            = var.volumes_from
+    user                   = local.user
+    dependsOn              = var.container_depends_on
+    privileged             = var.privileged
+    portMappings           = var.port_mappings
+    healthCheck            = var.healthcheck
+    firelensConfiguration  = var.firelens_configuration
+    linuxParameters        = var.linux_parameters
+    logConfiguration       = local.log_configuration_without_null
+    memory                 = var.container_memory
+    memoryReservation      = var.container_memory_reservation
+    cpu                    = var.container_cpu
+    environment            = local.final_environment_vars
+    environmentFiles       = var.environment_files
+    secrets                = local.final_secrets_vars
+    dockerLabels           = var.docker_labels
+    startTimeout           = var.start_timeout
+    stopTimeout            = var.stop_timeout
+    systemControls         = var.system_controls
+    extraHosts             = var.extra_hosts
+    hostname               = var.hostname
+    disableNetworking      = var.disable_networking
+    interactive            = var.interactive
+    pseudoTerminal         = var.pseudo_terminal
+    dockerSecurityOptions  = var.docker_security_options
+    resourceRequirements   = var.resource_requirements
+  }
+
+  container_definition_without_null = {
+    for k, v in local.container_definition :
+    k => v
+    if v != null
+  }
+  json_map = jsonencode(merge(local.container_definition_without_null, var.container_definition))
+}

--- a/install/aws/dev/terraform/modules/secure-container-definitions/outputs.tf
+++ b/install/aws/dev/terraform/modules/secure-container-definitions/outputs.tf
@@ -1,0 +1,17 @@
+output "sensitive_json_map_encoded_list" {
+  description = "JSON string encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition (sensitive)"
+  value       = "[${local.json_map}]"
+  sensitive   = true
+}
+
+output "sensitive_json_map_encoded" {
+  description = "JSON string encoded container definitions for use with other terraform resources such as aws_ecs_task_definition (sensitive)"
+  value       = local.json_map
+  sensitive   = true
+}
+
+output "sensitive_json_map_object" {
+  description = "JSON map encoded container definition (sensitive)"
+  value       = jsondecode(local.json_map)
+  sensitive   = true
+}

--- a/install/aws/dev/terraform/modules/secure-container-definitions/variables.tf
+++ b/install/aws/dev/terraform/modules/secure-container-definitions/variables.tf
@@ -1,0 +1,315 @@
+variable "container_name" {
+  type        = string
+  description = "The name of the container. Up to 255 characters ([a-z], [A-Z], [0-9], -, _ allowed)"
+}
+
+variable "container_image" {
+  type        = string
+  description = "The image used to start the container. Images in the Docker Hub registry available by default"
+}
+
+variable "container_memory" {
+  type        = number
+  description = "The amount of memory (in MiB) to allow the container to use. This is a hard limit, if the container attempts to exceed the container_memory, the container is killed. This field is optional for Fargate launch type and the total amount of container_memory of all containers in a task will need to be lower than the task memory value"
+  default     = null
+}
+
+variable "container_memory_reservation" {
+  type        = number
+  description = "The amount of memory (in MiB) to reserve for the container. If container needs to exceed this threshold, it can do so up to the set container_memory hard limit"
+  default     = null
+}
+
+variable "container_definition" {
+  type        = map(any)
+  description = "Container definition overrides which allows for extra keys or overriding existing keys."
+  default     = {}
+}
+
+variable "port_mappings" {
+  type = list(object({
+    containerPort = number
+    hostPort      = number
+    protocol      = string
+  }))
+
+  description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"containerPort\", \"hostPort\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort"
+
+  default = []
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html
+variable "healthcheck" {
+  type = object({
+    command     = list(string)
+    retries     = number
+    timeout     = number
+    interval    = number
+    startPeriod = number
+  })
+  description = "A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries)"
+  default     = null
+}
+
+variable "container_cpu" {
+  type        = number
+  description = "The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of container_cpu of all containers in a task will need to be lower than the task-level cpu value"
+  default     = 0
+}
+
+variable "essential" {
+  type        = bool
+  description = "Determines whether all other containers in a task are stopped, if this container fails or stops for any reason. Due to how Terraform type casts booleans in json it is required to double quote this value"
+  default     = true
+}
+
+variable "entrypoint" {
+  type        = list(string)
+  description = "The entry point that is passed to the container"
+  default     = null
+}
+
+variable "command" {
+  type        = list(string)
+  description = "The command that is passed to the container"
+  default     = null
+}
+
+variable "working_directory" {
+  type        = string
+  description = "The working directory to run commands inside the container"
+  default     = null
+}
+
+variable "environment" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "The environment variables to pass to the container. This is a list of maps. map_environment overrides environment"
+  default     = []
+}
+
+variable "extra_hosts" {
+  type = list(object({
+    ipAddress = string
+    hostname  = string
+  }))
+  description = "A list of hostnames and IP address mappings to append to the /etc/hosts file on the container. This is a list of maps"
+  default     = null
+}
+
+variable "map_environment" {
+  type        = map(string)
+  description = "The environment variables to pass to the container. This is a map of string: {key: value}. map_environment overrides environment"
+  default     = null
+}
+
+variable "map_secrets" {
+  type        = map(string)
+  description = "The secrets variables to pass to the container. This is a map of string: {key: value}. map_secrets overrides secrets"
+  default     = null
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EnvironmentFile.html
+variable "environment_files" {
+  type = list(object({
+    value = string
+    type  = string
+  }))
+  description = "One or more files containing the environment variables to pass to the container. This maps to the --env-file option to docker run. The file must be hosted in Amazon S3. This option is only available to tasks using the EC2 launch type. This is a list of maps"
+  default     = null
+}
+
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "The secrets to pass to the container. This is a list of maps"
+  default     = []
+}
+
+variable "readonly_root_filesystem" {
+  type        = bool
+  description = "Determines whether a container is given read-only access to its root filesystem. Due to how Terraform type casts booleans in json it is required to double quote this value"
+  default     = false
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html
+variable "linux_parameters" {
+  type = object({
+    capabilities = object({
+      add  = list(string)
+      drop = list(string)
+    })
+    devices = list(object({
+      containerPath = string
+      hostPath      = string
+      permissions   = list(string)
+    }))
+    initProcessEnabled = bool
+    maxSwap            = number
+    sharedMemorySize   = number
+    swappiness         = number
+    tmpfs = list(object({
+      containerPath = string
+      mountOptions  = list(string)
+      size          = number
+    }))
+  })
+  description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html"
+  default     = null
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html
+variable "log_configuration" {
+  type        = any
+  description = "Log configuration options to send to a custom log driver for the container. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html"
+  default     = null
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html
+variable "firelens_configuration" {
+  type = object({
+    type    = string
+    options = map(string)
+  })
+  description = "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html"
+  default     = null
+}
+
+variable "mount_points" {
+  type = list(any)
+
+  description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`. The `readOnly` key is optional."
+  default     = []
+}
+
+variable "dns_servers" {
+  type        = list(string)
+  description = "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
+  default     = null
+}
+
+variable "dns_search_domains" {
+  type        = list(string)
+  description = "Container DNS search domains. A list of DNS search domains that are presented to the container"
+  default     = null
+}
+
+variable "ulimits" {
+  type = list(object({
+    name      = string
+    hardLimit = number
+    softLimit = number
+  }))
+  description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
+  default     = null
+}
+
+variable "repository_credentials" {
+  type        = map(string)
+  description = "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
+  default     = null
+}
+
+variable "volumes_from" {
+  type = list(object({
+    sourceContainer = string
+    readOnly        = bool
+  }))
+  description = "A list of VolumesFrom maps which contain \"sourceContainer\" (name of the container that has the volumes to mount) and \"readOnly\" (whether the container can write to the volume)"
+  default     = []
+}
+
+variable "links" {
+  type        = list(string)
+  description = "List of container names this container can communicate with without port mappings"
+  default     = null
+}
+
+variable "user" {
+  type        = string
+  description = "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set."
+  default     = null
+}
+
+variable "container_depends_on" {
+  type = list(object({
+    containerName = string
+    condition     = string
+  }))
+  description = "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY"
+  default     = null
+}
+
+variable "docker_labels" {
+  type        = map(string)
+  description = "The configuration options to send to the `docker_labels`"
+  default     = null
+}
+
+variable "start_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before giving up on resolving dependencies for a container"
+  default     = null
+}
+
+variable "stop_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
+  default     = null
+}
+
+variable "privileged" {
+  type        = bool
+  description = "When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type."
+  default     = null
+}
+
+variable "system_controls" {
+  type        = list(map(string))
+  description = "A list of namespaced kernel parameters to set in the container, mapping to the --sysctl option to docker run. This is a list of maps: { namespace = \"\", value = \"\"}"
+  default     = null
+}
+
+variable "hostname" {
+  type        = string
+  description = "The hostname to use for your container."
+  default     = null
+}
+
+variable "disable_networking" {
+  type        = bool
+  description = "When this parameter is true, networking is disabled within the container."
+  default     = null
+}
+
+variable "interactive" {
+  type        = bool
+  description = "When this parameter is true, this allows you to deploy containerized applications that require stdin or a tty to be allocated."
+  default     = null
+}
+
+variable "pseudo_terminal" {
+  type        = bool
+  description = "When this parameter is true, a TTY is allocated. "
+  default     = null
+}
+
+variable "docker_security_options" {
+  type        = list(string)
+  description = "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems."
+  default     = null
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ResourceRequirement.html
+variable "resource_requirements" {
+  type = list(object({
+    type  = string
+    value = string
+  }))
+  description = "The type and amount of a resource to assign to a container. The only supported resource is a GPU."
+  default     = null
+}

--- a/install/aws/dev/terraform/modules/secure-container-definitions/versions.tf
+++ b/install/aws/dev/terraform/modules/secure-container-definitions/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.2"
+    }
+  }
+}


### PR DESCRIPTION
This provides dev with the same enhancements we've been testing locally around moving nginx to its own container and reducing the php-fpm container workload to just PHP stuff. It adds a GitHub Action to build and push the nginx container to ECR. It also adds the Datadog agent to the ECS task definition so it should be able to collect info from the containers. The Datadog stuff is in early days but it's an important first step.

The pull will be needed to fix dev as it's currently looking for the latest builds of each and can't find them. I think. Kinda learning but I think in the future we'll need to trigger new builds of all the containers when we deploy new terraform changes around containers. This will help prove the likelihood of that.