### PR TITLE
Remove wikijump_token7

### DIFF
--- a/web/php/Utils/AjaxModuleWikiFlowController.php
+++ b/web/php/Utils/AjaxModuleWikiFlowController.php
@@ -49,13 +49,6 @@ class AjaxModuleWikiFlowController extends WebFlowController
         $logger->debug("RunData object created and initialized");
 
         try {
-            // check security token
-            if ($_COOKIE['wikijump_token7'] == null || $_COOKIE['wikijump_token7'] !== $runData->getParameterList()->getParameterValue('wikijump_token7', 'AMODULE')) {
-                throw new ProcessException("no", "wrong_token7");
-            }
-            //remove token from parameter list!!!
-            $runData->getParameterList()->delParameter('wikijump_token7');
-
             $callbackIndex = $runData->getParameterList()->getParameterValue('callbackIndex');
             $runData->getParameterList()->delParameter('callbackIndex');
 

--- a/web/web/default_flow.php
+++ b/web/web/default_flow.php
@@ -9,9 +9,6 @@ require ('../php/setup.php');
 header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); // Date in the past
 
-
-setsecurecookie("wikijump_token7", md5(rand(0, 10000)), 0, '/', GlobalProperties::$SESSION_COOKIE_DOMAIN);
-
 try {
     $controller = new WDDefaultFlowController();
     $controller->process();

--- a/web/web/files--common/javascript/OZONE/ajax.ts
+++ b/web/web/files--common/javascript/OZONE/ajax.ts
@@ -59,15 +59,6 @@ export const ajax = {
 
     parameters.callbackIndex = callbackIndex;
 
-    // add token information
-    const token = OZONE.utils.getCookie('wikijump_token7');
-    if (token === null) {
-      alert('Error processing the request.\n\nYou have no valid security token which is required to prevent identity theft.\nPlease enable cookies in your browser if you have this option disabled and reload the page.');
-      OZONE.visuals.cursorClear();
-      return;
-    }
-    parameters.wikijump_token7 = token;
-
     YAHOO.util.Connect.asyncRequest(
       'POST',
       '/ajax-module-connector.php',
@@ -82,13 +73,6 @@ export const ajax = {
       // TODO What is the type of the returned JSON?
       // XXX This is an implicit any - why no error?
       const response = JSON.parse(responseObject.responseText);
-
-      if (response.status === 'wrong_token7') {
-        // TODO: De-Wikijump.com-ize - change
-        alert("Wikijump security error:\n\nYour authentication token in the request is not valid. Please enable cookies in your browser and try to repeat the action.\n\nIf you see this message on the page not associated with the Wikijump wiki hosting it probably means an identity theft attempt or improper use of Wikijump service.");
-        OZONE.visuals.cursorClear();
-        return;
-      }
 
       const callbackIndex = response.callbackIndex;
       if (callbackIndex === null) {

--- a/web/web/index.php
+++ b/web/web/index.php
@@ -12,12 +12,6 @@ header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT"); // Date in the past
 
 try {
-    // set anti-session-riding token
-    setsecurecookie("wikijump_token7", md5(rand(0, 10000)), 0, '/', GlobalProperties::$SESSION_COOKIE_DOMAIN);
-    // If this is coming from a custom domain, set a token7 so they can work with the admin panel if needed.
-    if($_SERVER['HTTP_HOST'] != GlobalProperties::$URL_HOST) {
-        setsecurecookie("wikijump_token7", md5(rand(0, 10000)), 0, '/', '.'.$_SERVER['HTTP_HOST']);
-    }
     $controller = new WikiFlowController();
     $out = $controller->process();
 } catch (OzoneDatabaseException $e) {


### PR DESCRIPTION
This PR removes the `wikijump_token7` cookie and POST field from the AJAX Module Flow Controller and cookie setters. As far as we can determine, it was sort of a primitive anti-CSRF token, but totally ineffective.

We will implement proper CSRF tokens where it's sensible to do so, down the road.