### PR TITLE
[WJ-243] Add more documentation about development processes

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,3 @@
+# Continuous Integration (CI)
+
+We use [GitHub Actions](https://docs.github.com/en/actions) as our CI system. See the [`.github/workflows`](https://github.com/scpwiki/wikijump/tree/develop/.github/workflows) directory for our current list of jobs. By utilizing [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) we can build, test, and deploy using GitHub Actions.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+This document assumes you have read [Development.md](docs/development.md).
+
+Wikijump has a fairly extensive scope and has lots of areas for people to contribute. Whether it's a small typofix or work on a potential new feature, there's always room for community contributions.
+
+It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it. You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
+
+Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,3 +7,5 @@ Wikijump has a fairly extensive scope and has lots of areas for people to contri
 It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it. You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
 
 Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.
+
+All changes should be merged against `develop`, which automatically deploys to `wikijump.dev`. In longer cycles, we take accrued changes in `develop` and produce a squash commit to `master`, which deploys to `wikijump.com` (the production environment). This way can utilize continuous deployment for development but also keep production stable. (See [CI.md](docs/ci.md) for more information)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ This document assumes you have read [Development.md](development.md).
 
 Wikijump has a fairly extensive scope and has lots of areas for people to contribute. Whether it's a small typofix or work on a potential new feature, there's always room for community contributions. If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it.
 
-It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
+It is important that you join the Wikijump Discord so you can discuss and coordinate with the Wikijump team.  You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
 
 Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](../CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-This document assumes you have read [Development.md](docs/development.md).
+This document assumes you have read [Development.md](development.md).
 
 Wikijump has a fairly extensive scope and has lots of areas for people to contribute. Whether it's a small typofix or work on a potential new feature, there's always room for community contributions.
 
 It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it. You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
 
-Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.
+Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](../CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.
 
-All changes should be merged against `develop`, which automatically deploys to `wikijump.dev`. In longer cycles, we take accrued changes in `develop` and produce a squash commit to `master`, which deploys to `wikijump.com` (the production environment). This way can utilize continuous deployment for development but also keep production stable. (See [CI.md](docs/ci.md) for more information)
+All changes should be merged against `develop`, which automatically deploys to `wikijump.dev`. In longer cycles, we take accrued changes in `develop` and produce a squash commit to `master`, which deploys to `wikijump.com` (the production environment). This way can utilize continuous deployment for development but also keep production stable. (See [CI.md](ci.md) for more information)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,9 +2,9 @@
 
 This document assumes you have read [Development.md](development.md).
 
-Wikijump has a fairly extensive scope and has lots of areas for people to contribute. Whether it's a small typofix or work on a potential new feature, there's always room for community contributions.
+Wikijump has a fairly extensive scope and has lots of areas for people to contribute. Whether it's a small typofix or work on a potential new feature, there's always room for community contributions. If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it.
 
-It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  If appropriate, a team member can make a [JIRA](https://scuttle.atlassian.net/browse/WJ) issue for it. You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
+It is important that you join the Wikijump discord guild so you can discuss and coordinate with the Wikijump team.  You can get an invitation by asking in [#site11](https://scp-wiki.wikidot.com/chat-guide).
 
 Once you've implemented the changes, create a PR and request reviews from 1-3 relevant people. See [CODEOWNERS](../CODEOWNERS) to get an idea of who works on which parts of the repository. It'll be reviewed and merged if ready.
 


### PR DESCRIPTION
This issue has been outstanding for a bit, and is marked as necessary for `1.0.0`. I added a bit more relevant information about our development processes to be helpful to interested potential contributors.