### PR TITLE
Add getters to ftml-wasm PageInfo

### DIFF
--- a/ftml/src/preproc/mod.rs
+++ b/ftml/src/preproc/mod.rs
@@ -27,7 +27,6 @@ mod test;
 /// Run the preprocessor on the given wikitext, which is modified in-place.
 ///
 /// The following modifications are performed:
-/// * Expand instances of `[[include]]`
 /// * Replacing DOS and legacy Mac newlines
 /// * Trimming whitespace lines
 /// * Concatenating lines that end with backslashes

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -24,6 +24,7 @@ use super::prelude::*;
 use crate::data::PageInfo as RustPageInfo;
 use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use crate::render::Render;
+use ref_map::OptionRefMap;
 use std::sync::Arc;
 
 // Typescript declarations
@@ -93,6 +94,43 @@ impl PageInfo {
         Ok(PageInfo {
             inner: Arc::new(rust_page_info),
         })
+    }
+
+    // Getters
+
+    #[wasm_bindgen(method, getter)]
+    pub fn slug(&self) -> String {
+        self.inner.slug.to_string()
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn category(&self) -> Option<String> {
+        self.inner.category.ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn title(&self) -> String {
+        self.inner.title.to_string()
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn alt_title(&self) -> Option<String> {
+        self.inner.alt_title.ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn rating(&self) -> f32 {
+        self.inner.rating
+    }
+
+    #[wasm_bindgen]
+    pub fn get_tag(&self, index: usize) -> Option<String> {
+        self.inner.tags.get(index).ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn locale(&self) -> String {
+        self.inner.locale.to_string()
     }
 }
 

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -63,6 +63,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "IPageInfo")]
     pub type IPageInfo;
+
+    #[wasm_bindgen(typescript_type = "string[]")]
+    pub type ITags;
 }
 
 // Wrapper structures
@@ -123,15 +126,9 @@ impl PageInfo {
         self.inner.rating
     }
 
-    // Psuedo-getter, since we can't pass back Vec<String> :/
-    #[wasm_bindgen]
-    pub fn tag(&self, index: usize) -> Option<String> {
-        self.inner.tags.get(index).ref_map(ToString::to_string)
-    }
-
-    #[wasm_bindgen]
-    pub fn tag_length(&self) -> usize {
-        self.inner.tags.len()
+    #[wasm_bindgen(method, getter, typescript_type = "ITags")]
+    pub fn tags(&self) -> Result<ITags, JsValue> {
+        rust_to_js!(self.inner.tags)
     }
 
     #[wasm_bindgen(method, getter)]

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -123,9 +123,15 @@ impl PageInfo {
         self.inner.rating
     }
 
+    // Psuedo-getter, since we can't pass back Vec<String> :/
     #[wasm_bindgen]
-    pub fn get_tag(&self, index: usize) -> Option<String> {
+    pub fn tag(&self, index: usize) -> Option<String> {
         self.inner.tags.get(index).ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen]
+    pub fn tag_length(&self) -> usize {
+        self.inner.tags.len()
     }
 
     #[wasm_bindgen(method, getter)]


### PR DESCRIPTION
Adds getters so `PageInfo` in wasm is less opaque.

Generated `ftml.d.ts`:
```typescript
export class PageInfo {
  free(): void;
/**
* @returns {PageInfo}
*/
  copy(): PageInfo;
/**
* @param {IPageInfo} object
*/
  constructor(object: IPageInfo);
/**
* @returns {string | undefined}
*/
  readonly alt_title: string | undefined;
/**
* @returns {string | undefined}
*/
  readonly category: string | undefined;
/**
* @returns {string}
*/
  readonly locale: string;
/**
* @returns {number}
*/
  readonly rating: number;
/**
* @returns {string}
*/
  readonly slug: string;
/**
* @returns {string[]}
*/
  readonly tags: string[];
/**
* @returns {string}
*/
  readonly title: string;
}

```