### PR TITLE
[FTML-97] Place all slog logging behind default feature

### DIFF
--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -20,7 +20,9 @@ jobs:
         with:
           toolchain: stable
       - run: cd ftml && cargo build --all-features --release
+        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo test --all-features -- --nocapture --test-threads 1
+        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo build --no-default-features --release
         env: RUSTFLAGS: -A unused_variables
   wasm:
@@ -35,7 +37,9 @@ jobs:
         with:
           version: 'latest'
       - run: cd ftml && wasm-pack build
+        env: RUSTFLAGS: -D warnings
       - run: cd ftml && wasm-pack build -- --features wasm-log
+        env: RUSTFLAGS: -D warnings
       - run: cd ftml && wasm-pack build -- --no-default-features
         env: RUSTFLAGS: -A unused_variables
   http_build:
@@ -47,7 +51,9 @@ jobs:
         with:
           toolchain: stable
       - run: cd ftml && cargo build -p ftml-http --all-features --release
+        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo test -p ftml-http -- --nocapture --test-threads 1
+        env: RUSTFLAGS: -D warnings
   clippy_lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -21,6 +21,8 @@ jobs:
           toolchain: stable
       - run: cd ftml && cargo build --all-features --release
       - run: cd ftml && cargo test --all-features -- --nocapture --test-threads 1
+      - run: cd ftml && cargo build --no-default-features --release
+        env: RUSTFLAGS: -A unused_variables
   wasm:
     name: WebASM
     runs-on: ubuntu-latest
@@ -34,6 +36,8 @@ jobs:
           version: 'latest'
       - run: cd ftml && wasm-pack build
       - run: cd ftml && wasm-pack build -- --features wasm-log
+      - run: cd ftml && wasm-pack build -- --no-default-features
+        env: RUSTFLAGS: -A unused_variables
   http_build:
     name: HTTP
     runs-on: ubuntu-latest

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -14,20 +14,23 @@ jobs:
   library_build_and_test:
     name: Library
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - run: cd ftml && cargo build --all-features --release
-        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo test --all-features -- --nocapture --test-threads 1
-        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo build --no-default-features --release
-        env: RUSTFLAGS: -A unused_variables
+        env:
+          RUSTFLAGS: -A unused_variables
   wasm:
     name: WebASM
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,26 +40,27 @@ jobs:
         with:
           version: 'latest'
       - run: cd ftml && wasm-pack build
-        env: RUSTFLAGS: -D warnings
       - run: cd ftml && wasm-pack build -- --features wasm-log
-        env: RUSTFLAGS: -D warnings
       - run: cd ftml && wasm-pack build -- --no-default-features
-        env: RUSTFLAGS: -A unused_variables
+        env:
+          RUSTFLAGS: -A unused_variables
   http_build:
     name: HTTP
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - run: cd ftml && cargo build -p ftml-http --all-features --release
-        env: RUSTFLAGS: -D warnings
       - run: cd ftml && cargo test -p ftml-http -- --nocapture --test-threads 1
-        env: RUSTFLAGS: -D warnings
   clippy_lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -66,4 +70,4 @@ jobs:
           override: true
           components: rustfmt, clippy
       - run: cd ftml && cargo fmt --all -- --check
-      - run: cd ftml && cargo clippy -- -D warnings
+      - run: cd ftml && cargo clippy

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "built",
  "cfg-if 1.0.0",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -25,6 +25,7 @@ has-log  = ["slog"] # If removed, then logging is cut out entirely -- replaces s
 wasm-log = [] # Enables console.log() logging. Spams your browser, caveat emptor!
 
 [dependencies]
+cfg-if = "1"
 entities = "1"
 enum-map = "1"
 lazy_static = "1"
@@ -51,7 +52,6 @@ built = { version = "0.4", features = ["chrono", "git2"] }
 sloggers = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-cfg-if = "1"
 ouroboros = "0.9"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["console"] }

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -20,6 +20,8 @@ name = "ftml"
 crate-type = ["cdylib", "lib"]
 
 [features]
+default  = ["has-log"]
+has-log  = ["slog"] # If removed, then logging is cut out entirely -- replaces slog macros with no-ops.
 wasm-log = [] # Enables console.log() logging. Spams your browser, caveat emptor!
 
 [dependencies]
@@ -33,7 +35,7 @@ ref-map = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-slog = { version = "2.7", features = ["max_level_trace"] }
+slog = { version = "2.7", features = ["max_level_trace"], optional = true }
 str-macro = "1"
 strum = "0.20"
 strum_macros = "0.20"

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -36,15 +36,33 @@ You can use this as a dependency by adding the following to your `Cargo.toml`:
 ftml = "0.4"
 ```
 
+Additionally, if you disable the default feature `has-log`, you can remove all `slog` logging code entirely.
+This can have performance benefits in certain situations:
+
+```
+$ RUSTFLAGS=-Aunused_variables cargo check --no-default-features
+```
+
+The `RUSTFLAGS` argument is added to suppress warnings from now-unused variables as a result of logging.
+Work into having the macros consume the elements of the logging call is not a priority given the complexity
+of the underlying slog macros.
+
+If you wish to build the WebAssembly target for ftml, use `wasm-pack`:
+
+```
+$ wasm-pack build
+```
+
+Or you can build with Cargo by specifying `--target wasm32-unknown-unknown` (usually for development).
+
 ### Testing
 ```sh
 $ cargo test
 ```
 
 Add `-- --nocapture` to the end if you want to see test output.
-If you wish to see the logging output, you can change `crate::build_logger()`
-to use a different logger creation implementation. Or you can modify the test
-you're inspecting to use a different logger.
+If you wish to see the logging output, you can change `crate::build_logger()` to use a different logger 
+creation implementation. Or you can modify the test you're inspecting to use a different logger.
 
 ### Philosophy
 

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -50,10 +50,17 @@ of the underlying slog macros.
 If you wish to build the WebAssembly target for ftml, use `wasm-pack`:
 
 ```
-$ wasm-pack build
+$ RUSTFLAGS=-Aunused_variables wasm-pack build -- --no-default-features
 ```
 
-Or you can build with Cargo by specifying `--target wasm32-unknown-unknown` (usually for development).
+This produces a build with no `slog` logging at all, which is helpful for limiting the binary footprint and improving performance.
+
+However, there is a `wasm-log` feature, which initializes a `console.log()`-based `slog::Logger` for WebASM. Note that this will slam your brower's console hard and is **not** recommended for production, only local testing.
+
+If developing and just want to check that the build passes, use:
+```
+$ cargo check --target wasm32-unknown-unknown
+```
 
 ### Testing
 ```sh
@@ -61,7 +68,7 @@ $ cargo test
 ```
 
 Add `-- --nocapture` to the end if you want to see test output.
-If you wish to see the logging output, you can change `crate::build_logger()` to use a different logger 
+If you wish to see the logging output, you can change `crate::build_logger()` to use a different logger
 creation implementation. Or you can modify the test you're inspecting to use a different logger.
 
 ### Philosophy

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -29,8 +29,8 @@ pub use self::includer::{DebugIncluder, FetchedPage, Includer, NullIncluder};
 pub use self::object::{IncludeRef, IncludeVariables, PageRef};
 
 use self::parse::parse_include_block;
-use regex::{Regex, RegexBuilder};
 use crate::log::prelude::*;
+use regex::{Regex, RegexBuilder};
 
 lazy_static! {
     static ref INCLUDE_REGEX: Regex = {

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -29,8 +29,8 @@ pub use self::includer::{DebugIncluder, FetchedPage, Includer, NullIncluder};
 pub use self::object::{IncludeRef, IncludeVariables, PageRef};
 
 use self::parse::parse_include_block;
-use crate::span_wrap::SpanWrap;
 use regex::{Regex, RegexBuilder};
+use crate::log::prelude::*;
 
 lazy_static! {
     static ref INCLUDE_REGEX: Regex = {
@@ -44,7 +44,7 @@ lazy_static! {
 }
 
 pub fn include<'t, I, E, F>(
-    log: &slog::Logger,
+    log: &Logger,
     input: &'t str,
     mut includer: I,
     invalid_return: F,

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -71,10 +71,7 @@ pub fn parse_include_block<'t>(
     }
 }
 
-fn process_pairs<'t>(
-    log: &Logger,
-    mut pairs: Pairs<'t, Rule>,
-) -> Option<IncludeRef<'t>> {
+fn process_pairs<'t>(log: &Logger, mut pairs: Pairs<'t, Rule>) -> Option<IncludeRef<'t>> {
     let page_raw = match pairs.next() {
         Some(pair) => pair.as_str(),
         None => return None,

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -19,7 +19,7 @@
  */
 
 use super::{IncludeRef, PageRef};
-use crate::span_wrap::SpanWrap;
+use crate::log::prelude::*;
 use pest::iterators::Pairs;
 use pest::Parser;
 use std::borrow::Cow;
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 struct IncludeParser;
 
 pub fn parse_include_block<'t>(
-    log: &slog::Logger,
+    log: &Logger,
     text: &'t str,
     start: usize,
 ) -> Option<(IncludeRef<'t>, usize)> {
@@ -72,7 +72,7 @@ pub fn parse_include_block<'t>(
 }
 
 fn process_pairs<'t>(
-    log: &slog::Logger,
+    log: &Logger,
     mut pairs: Pairs<'t, Rule>,
 ) -> Option<IncludeRef<'t>> {
     let page_raw = match pairs.next() {

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -33,6 +33,9 @@
 // Rest are implicit based on Cargo.toml
 
 #[macro_use]
+extern crate cfg_if;
+
+#[macro_use]
 extern crate enum_map;
 
 #[macro_use]
@@ -59,6 +62,9 @@ extern crate slog;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "has-log")]
+mod span_wrap;
+
 #[macro_use]
 mod log;
 
@@ -67,7 +73,6 @@ mod macros;
 
 mod non_empty_vec;
 mod preproc;
-mod span_wrap;
 mod text;
 mod url;
 
@@ -83,6 +88,7 @@ pub mod tokenizer;
 pub mod tree;
 
 #[cfg(test)]
+#[cfg(feature = "has-log")]
 pub use self::log::{build_logger, build_null_logger, build_terminal_logger};
 
 pub use self::includes::include;

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -48,10 +48,11 @@ extern crate pest_derive;
 extern crate serde;
 
 #[macro_use]
-extern crate slog;
-
-#[macro_use]
 extern crate str_macro;
+
+#[cfg(feature = "has-log")]
+#[macro_use]
+extern crate slog;
 
 // Library top-level modules
 

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -18,49 +18,101 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! Helper module to add filenames and newlines to slog output.
-//!
-//! See https://github.com/slog-rs/slog/issues/123
+cfg_if! {
+    if #[cfg(feature = "has-log")] {
+        // Re-export main slog logger
+        pub mod prelude {
+            pub use slog::Logger;
+            pub use crate::span_wrap::SpanWrap;
+        }
 
-macro_rules! slog_filename {
-    () => {
-        slog::PushFnValue(|r: &slog::Record, ser: slog::PushFnValueSerializer| {
-            ser.emit(r.file())
-        })
-    };
-}
+        // Helper macros to add filenames and newlines to slog output.
+        // See https://github.com/slog-rs/slog/issues/123
+        macro_rules! slog_filename {
+            () => {
+                slog::PushFnValue(|r: &slog::Record, ser: slog::PushFnValueSerializer| {
+                    ser.emit(r.file())
+                })
+            };
+        }
 
-macro_rules! slog_lineno {
-    () => {
-        slog::PushFnValue(|r: &slog::Record, ser: slog::PushFnValueSerializer| {
-            ser.emit(r.line())
-        })
-    };
-}
+        macro_rules! slog_lineno {
+            () => {
+                slog::PushFnValue(|r: &slog::Record, ser: slog::PushFnValueSerializer| {
+                    ser.emit(r.line())
+                })
+            };
+        }
 
-#[cfg(test)]
-#[allow(dead_code)]
-mod loggers {
-    #[inline]
-    pub fn build_logger() -> slog::Logger {
-        build_null_logger()
+        // Pre-built loggers for testing
+        #[cfg(test)]
+        #[allow(dead_code)]
+        mod loggers {
+            #[inline]
+            pub fn build_logger() -> slog::Logger {
+                build_null_logger()
+            }
+
+            pub fn build_null_logger() -> slog::Logger {
+                slog::Logger::root(slog::Discard, o!())
+            }
+
+            pub fn build_terminal_logger() -> slog::Logger {
+                use sloggers::terminal::TerminalLoggerBuilder;
+                use sloggers::types::Severity;
+                use sloggers::Build;
+
+                TerminalLoggerBuilder::new()
+                    .level(Severity::Trace)
+                    .build()
+                    .expect("Unable to initialize logger")
+            }
+        }
+
+        #[cfg(test)]
+        pub use self::loggers::{build_logger, build_null_logger, build_terminal_logger};
+    } else {
+        // Dummy prelude
+        pub mod prelude {
+            pub use super::Logger;
+        }
+
+        // Dummy filename/lineno macros
+        macro_rules! slog_filename {
+            () => ();
+        }
+
+        macro_rules! slog_lineno {
+            () => ();
+        }
+
+        // Dummy logging macros
+        macro_rules! crit {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        macro_rules! error {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        macro_rules! warn {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        macro_rules! info {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        macro_rules! debug {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        macro_rules! trace {
+            ($l:expr, $($args:tt)+) => ();
+        }
+
+        // Dummy logging structures
+        #[derive(Debug)]
+        pub struct Logger;
     }
-
-    pub fn build_null_logger() -> slog::Logger {
-        slog::Logger::root(slog::Discard, o!())
-    }
-
-    pub fn build_terminal_logger() -> slog::Logger {
-        use sloggers::terminal::TerminalLoggerBuilder;
-        use sloggers::types::Severity;
-        use sloggers::Build;
-
-        TerminalLoggerBuilder::new()
-            .level(Severity::Trace)
-            .build()
-            .expect("Unable to initialize logger")
-    }
 }
-
-#[cfg(test)]
-pub use self::loggers::{build_logger, build_null_logger, build_terminal_logger};

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -77,59 +77,6 @@ cfg_if! {
             pub use super::Logger;
         }
 
-        // Dummy filename/lineno macros
-        macro_rules! slog_filename {
-            () => ();
-        }
-
-        macro_rules! slog_lineno {
-            () => ();
-        }
-
-        // Dummy logging macros
-        macro_rules! crit {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        macro_rules! error {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        macro_rules! warn {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        macro_rules! info {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        macro_rules! debug {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        macro_rules! trace {
-            ($l:expr, $($args:tt)+) => {
-                crate::log::unused($l)
-            };
-        }
-
-        // Dummy logging construction macros
-        macro_rules! slog_o {
-            ($($args:tt)+) => {
-                ()
-            };
-        }
-
         // Dummy logging structure
         #[derive(Debug, Copy, Clone)]
         pub struct Logger;
@@ -142,5 +89,62 @@ cfg_if! {
 
         // Helpers
         pub fn unused<T>(_x: T) {}
+
+        #[macro_use]
+        #[allow(unused_macros)]
+        mod macros {
+            // Dummy filename/lineno macros
+            macro_rules! slog_filename {
+                () => ();
+            }
+
+            macro_rules! slog_lineno {
+                () => ();
+            }
+
+            // Dummy logging macros
+            macro_rules! crit {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            macro_rules! error {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            macro_rules! warn {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            macro_rules! info {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            macro_rules! debug {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            macro_rules! trace {
+                ($l:expr, $($args:tt)+) => {
+                    crate::log::unused($l)
+                };
+            }
+
+            // Dummy logging construction macros
+            macro_rules! slog_o {
+                ($($args:tt)+) => {
+                    ()
+                };
+            }
+        }
     }
 }

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -88,31 +88,59 @@ cfg_if! {
 
         // Dummy logging macros
         macro_rules! crit {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
         macro_rules! error {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
         macro_rules! warn {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
         macro_rules! info {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
         macro_rules! debug {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
         macro_rules! trace {
-            ($l:expr, $($args:tt)+) => ();
+            ($l:expr, $($args:tt)+) => {
+                crate::log::unused($l)
+            };
         }
 
-        // Dummy logging structures
-        #[derive(Debug)]
+        // Dummy logging construction macros
+        macro_rules! slog_o {
+            ($($args:tt)+) => {
+                ()
+            };
+        }
+
+        // Dummy logging structure
+        #[derive(Debug, Copy, Clone)]
         pub struct Logger;
+
+        impl Logger {
+            pub fn new(&self, _: ()) -> &Logger {
+                self
+            }
+        }
+
+        // Helpers
+        pub fn unused<T>(_x: T) {}
     }
 }

--- a/ftml/src/parsing/collect/consume.rs
+++ b/ftml/src/parsing/collect/consume.rs
@@ -27,7 +27,7 @@ use super::prelude::*;
 ///
 /// This call always sets `step_on_final` to `true`.
 pub fn collect_consume<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     close_conditions: &[ParseCondition],

--- a/ftml/src/parsing/collect/container.rs
+++ b/ftml/src/parsing/collect/container.rs
@@ -39,7 +39,7 @@ use crate::tree::{AttributeMap, Container, ContainerType, Element};
 /// Must match the parse rule.
 /// * `container_type`
 pub fn collect_container<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     container_type: ContainerType,

--- a/ftml/src/parsing/collect/generic.rs
+++ b/ftml/src/parsing/collect/generic.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::span_wrap::SpanWrap;
 
 /// Generic function to parse upcoming tokens until conditions are met.
 ///
@@ -62,7 +61,7 @@ use crate::span_wrap::SpanWrap;
 /// The final token from the collection, one prior to the now-current token,
 /// is returned.
 pub fn collect<'p, 'r, 't, F>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     close_conditions: &[ParseCondition],
@@ -71,7 +70,7 @@ pub fn collect<'p, 'r, 't, F>(
     mut process: F,
 ) -> ParseResult<'r, 't, &'r ExtractedToken<'t>>
 where
-    F: FnMut(&slog::Logger, &mut Parser<'r, 't>) -> ParseResult<'r, 't, ()>,
+    F: FnMut(&Logger, &mut Parser<'r, 't>) -> ParseResult<'r, 't, ()>,
 {
     // Log collect_until() call
     let log = {

--- a/ftml/src/parsing/collect/mod.rs
+++ b/ftml/src/parsing/collect/mod.rs
@@ -28,6 +28,7 @@
 
 mod prelude {
     pub use super::collect;
+    pub use crate::log::prelude::*;
     pub use crate::parsing::condition::ParseCondition;
     pub use crate::parsing::consume::consume;
     pub use crate::parsing::exception::{ParseWarning, ParseWarningKind};
@@ -36,7 +37,6 @@ mod prelude {
     pub use crate::parsing::rule::Rule;
     pub use crate::parsing::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
-    pub use crate::log::prelude::*;
 }
 
 mod consume;

--- a/ftml/src/parsing/collect/mod.rs
+++ b/ftml/src/parsing/collect/mod.rs
@@ -36,6 +36,7 @@ mod prelude {
     pub use crate::parsing::rule::Rule;
     pub use crate::parsing::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
+    pub use crate::log::prelude::*;
 }
 
 mod consume;

--- a/ftml/src/parsing/collect/text.rs
+++ b/ftml/src/parsing/collect/text.rs
@@ -27,7 +27,7 @@ use super::prelude::*;
 /// rather than considering them as special elements.
 #[inline]
 pub fn collect_text<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     close_conditions: &[ParseCondition],
@@ -53,7 +53,7 @@ where
 /// The last token terminating the collection is kept, and returned
 /// to the caller alongside the string slice.
 pub fn collect_text_keep<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     close_conditions: &[ParseCondition],

--- a/ftml/src/parsing/consume.rs
+++ b/ftml/src/parsing/consume.rs
@@ -29,7 +29,6 @@
 use super::prelude::*;
 use super::rule::{get_rules_for_token, impls::RULE_FALLBACK};
 use super::Parser;
-use crate::span_wrap::SpanWrap;
 use std::mem;
 
 /// Main function that consumes tokens to produce a single element, then returns.
@@ -37,7 +36,7 @@ use std::mem;
 /// It will use the fallback if all rules, fail, so the only failure case is if
 /// the end of the input is reached.
 pub fn consume<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let log = &log.new(slog_o!(

--- a/ftml/src/parsing/exception.rs
+++ b/ftml/src/parsing/exception.rs
@@ -159,6 +159,7 @@ impl ParseWarningKind {
     }
 }
 
+#[cfg(feature = "has-log")]
 impl slog::Value for ParseWarningKind {
     fn serialize(
         &self,

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -37,13 +37,13 @@ mod string;
 mod token;
 
 mod prelude {
+    pub use crate::log::prelude::*;
     pub use crate::parsing::{
         ExtractedToken, ParseException, ParseResult, ParseSuccess, ParseWarning,
         ParseWarningKind, Token,
     };
     pub use crate::text::FullText;
     pub use crate::tree::{Element, Elements, ElementsIterator};
-    pub use crate::log::prelude::*;
 }
 
 use self::boolean::parse_boolean;
@@ -52,10 +52,10 @@ use self::paragraph::{gather_paragraphs, NO_CLOSE_CONDITION};
 use self::parser::Parser;
 use self::rule::impls::RULE_PAGE;
 use self::string::parse_string;
+use crate::log::prelude::*;
 use crate::tokenizer::Tokenization;
 use crate::tree::SyntaxTree;
 use std::borrow::Cow;
-use crate::log::prelude::*;
 
 pub use self::exception::{ParseException, ParseWarning, ParseWarningKind};
 pub use self::outcome::ParseOutcome;

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -43,6 +43,7 @@ mod prelude {
     };
     pub use crate::text::FullText;
     pub use crate::tree::{Element, Elements, ElementsIterator};
+    pub use crate::log::prelude::*;
 }
 
 use self::boolean::parse_boolean;
@@ -54,6 +55,7 @@ use self::string::parse_string;
 use crate::tokenizer::Tokenization;
 use crate::tree::SyntaxTree;
 use std::borrow::Cow;
+use crate::log::prelude::*;
 
 pub use self::exception::{ParseException, ParseWarning, ParseWarningKind};
 pub use self::outcome::ParseOutcome;
@@ -64,7 +66,7 @@ pub use self::token::{ExtractedToken, Token};
 ///
 /// This takes a list of `ExtractedToken` items produced by `tokenize()`.
 pub fn parse<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     tokenization: &'r Tokenization<'t>,
 ) -> ParseOutcome<SyntaxTree<'t>>
 where

--- a/ftml/src/parsing/paragraph/mod.rs
+++ b/ftml/src/parsing/paragraph/mod.rs
@@ -21,6 +21,7 @@
 mod stack;
 
 use self::stack::ParagraphStack;
+use crate::log::prelude::*;
 use super::consume::consume;
 use super::parser::Parser;
 use super::prelude::*;
@@ -44,7 +45,7 @@ type CloseConditionFn = fn(&mut Parser) -> Result<bool, ParseWarning>;
 /// extraction deeper in code, such as in the `try_paragraph`
 /// collection helper.
 pub fn gather_paragraphs<'r, 't, F>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     rule: Rule,
     mut close_condition_fn: Option<F>,

--- a/ftml/src/parsing/paragraph/mod.rs
+++ b/ftml/src/parsing/paragraph/mod.rs
@@ -21,12 +21,12 @@
 mod stack;
 
 use self::stack::ParagraphStack;
-use crate::log::prelude::*;
 use super::consume::consume;
 use super::parser::Parser;
 use super::prelude::*;
 use super::rule::Rule;
 use super::token::Token;
+use crate::log::prelude::*;
 
 /// Wrapper type to satisfy the issue with generic closure types.
 ///

--- a/ftml/src/parsing/paragraph/stack.rs
+++ b/ftml/src/parsing/paragraph/stack.rs
@@ -24,8 +24,8 @@ use std::mem;
 
 #[derive(Debug)]
 pub struct ParagraphStack<'t> {
-    /// The `slog::Logger` instance used for logging stack operations.
-    log: slog::Logger,
+    /// The `Logger` instance used for logging stack operations.
+    log: Logger,
 
     /// Elements being accumulated in the current paragraph.
     current: Vec<Element<'t>>,
@@ -39,9 +39,9 @@ pub struct ParagraphStack<'t> {
 
 impl<'t> ParagraphStack<'t> {
     #[inline]
-    pub fn new(log: &slog::Logger) -> Self {
+    pub fn new(log: &Logger) -> Self {
         ParagraphStack {
-            log: slog::Logger::clone(log),
+            log: Logger::clone(log),
             current: Vec::new(),
             finished: Vec::new(),
             exceptions: Vec::new(),

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -22,15 +22,15 @@ use super::condition::ParseCondition;
 use super::prelude::*;
 use super::rule::Rule;
 use super::RULE_PAGE;
-use crate::span_wrap::SpanWrap;
 use crate::tokenizer::Tokenization;
 use std::ptr;
+use crate::log::prelude::*;
 
 const MAX_RECURSION_DEPTH: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct Parser<'r, 't> {
-    log: slog::Logger,
+    log: Logger,
     current: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
     full_text: FullText<'t>,
@@ -43,8 +43,8 @@ impl<'r, 't> Parser<'r, 't> {
     ///
     /// All other instances should be `.clone()` or `.clone_with_rule()`d from
     /// the main instance used during parsing.
-    pub(crate) fn new(log: &slog::Logger, tokenization: &'r Tokenization<'t>) -> Self {
-        let log = slog::Logger::clone(log);
+    pub(crate) fn new(log: &Logger, tokenization: &'r Tokenization<'t>) -> Self {
+        let log = Logger::clone(log);
         let full_text = tokenization.full_text();
         let (current, remaining) = tokenization
             .tokens()
@@ -63,8 +63,8 @@ impl<'r, 't> Parser<'r, 't> {
 
     // Getters
     #[inline]
-    pub fn log(&self) -> slog::Logger {
-        slog::Logger::clone(&self.log)
+    pub fn log(&self) -> Logger {
+        Logger::clone(&self.log)
     }
 
     #[inline]

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -22,9 +22,9 @@ use super::condition::ParseCondition;
 use super::prelude::*;
 use super::rule::Rule;
 use super::RULE_PAGE;
+use crate::log::prelude::*;
 use crate::tokenizer::Tokenization;
 use std::ptr;
-use crate::log::prelude::*;
 
 const MAX_RECURSION_DEPTH: usize = 100;
 

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -30,7 +30,7 @@ pub const BLOCK_ANCHOR: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -29,7 +29,7 @@ pub const BLOCK_BLOCKQUOTE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -29,7 +29,7 @@ pub const BLOCK_BOLD: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -48,7 +48,7 @@ pub const BLOCK_CHAR: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -29,7 +29,7 @@ pub const BLOCK_CHECKBOX: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -29,7 +29,7 @@ pub const BLOCK_CODE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -30,7 +30,7 @@ pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -29,7 +29,7 @@ pub const BLOCK_CSS: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -29,7 +29,7 @@ pub const BLOCK_DEL: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -29,7 +29,7 @@ pub const BLOCK_DIV: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -29,7 +29,7 @@ pub const BLOCK_HIDDEN: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/html.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/html.rs
@@ -29,7 +29,7 @@ pub const BLOCK_HTML: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -29,7 +29,7 @@ pub const BLOCK_IFRAME: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -38,7 +38,7 @@ pub const BLOCK_INCLUDE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -29,7 +29,7 @@ pub const BLOCK_INS: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -29,7 +29,7 @@ pub const BLOCK_INVISIBLE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -29,7 +29,7 @@ pub const BLOCK_ITALICS: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/later.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/later.rs
@@ -38,7 +38,7 @@ pub const BLOCK_LATER: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     _special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -30,7 +30,7 @@ pub const BLOCK_LINES: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -29,7 +29,7 @@ pub const BLOCK_MARK: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -26,6 +26,7 @@ mod prelude {
     pub use crate::parsing::prelude::*;
     pub use crate::parsing::{ParseWarning, Token};
     pub use crate::tree::{Container, ContainerType, Element};
+    pub use crate::log::prelude::*;
 
     #[cfg(debug)]
     pub fn assert_generic_name(

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -20,13 +20,13 @@
 
 mod prelude {
     pub use super::super::{Arguments, BlockRule};
+    pub use crate::log::prelude::*;
     pub use crate::parsing::collect::*;
     pub use crate::parsing::condition::ParseCondition;
     pub use crate::parsing::parser::Parser;
     pub use crate::parsing::prelude::*;
     pub use crate::parsing::{ParseWarning, Token};
     pub use crate::tree::{Container, ContainerType, Element};
-    pub use crate::log::prelude::*;
 
     #[cfg(debug)]
     pub fn assert_generic_name(

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
@@ -29,6 +29,7 @@ use crate::parsing::rule::Rule;
 use crate::parsing::{ParseResult, Parser};
 use crate::tree::{Elements, Module};
 use std::fmt::{self, Debug};
+use crate::log::prelude::*;
 
 pub use self::rule::BLOCK_MODULE;
 
@@ -59,7 +60,7 @@ impl ModuleRule {
     pub fn rule(&self) -> Rule {
         // Stubbed try_consume_fn implementation for the Rule.
         fn try_consume_fn<'p, 'r, 't>(
-            _: &slog::Logger,
+            _: &Logger,
             _: &'p mut Parser<'r, 't>,
         ) -> ParseResult<'r, 't, Elements<'t>> {
             panic!("Pseudo rule for this module should not be executed directly!");
@@ -85,12 +86,12 @@ impl Debug for ModuleRule {
 /// Function pointer type to implement module parsing.
 ///
 /// The arguments are, in order:
-/// * `log` -- `slog::Logger` instance
+/// * `log` -- `Logger` instance
 /// * `parser` -- `Parser` instance
 /// * `name` -- The name of this module
 /// * `arguments` -- The arguments passed into the module
 pub type ModuleParseFn = for<'r, 't> fn(
-    &slog::Logger,
+    &Logger,
     &mut Parser<'r, 't>,
     &'t str,
     Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
@@ -24,12 +24,12 @@ mod parser;
 mod rule;
 
 use super::prelude;
+use crate::log::prelude::*;
 use crate::parsing::rule::impls::block::Arguments;
 use crate::parsing::rule::Rule;
 use crate::parsing::{ParseResult, Parser};
 use crate::tree::{Elements, Module};
 use std::fmt::{self, Debug};
-use crate::log::prelude::*;
 
 pub use self::rule::BLOCK_MODULE;
 

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -27,7 +27,7 @@ pub const MODULE_BACKLINKS: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
@@ -27,7 +27,7 @@ pub const MODULE_CATEGORIES: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
@@ -27,7 +27,7 @@ pub const MODULE_CSS: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     _arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -27,7 +27,7 @@ pub const MODULE_JOIN: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -27,7 +27,7 @@ pub const MODULE_PAGE_TREE: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
@@ -27,7 +27,7 @@ pub const MODULE_RATE: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &mut Parser<'r, 't>,
     name: &'t str,
     _arguments: Arguments<'t>,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -30,7 +30,7 @@ pub const BLOCK_MODULE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -29,7 +29,7 @@ pub const BLOCK_MONOSPACE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -29,7 +29,7 @@ pub const BLOCK_RADIO: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -31,7 +31,7 @@ pub const BLOCK_SIZE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -29,7 +29,7 @@ pub const BLOCK_SPAN: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -29,7 +29,7 @@ pub const BLOCK_STRIKETHROUGH: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -29,7 +29,7 @@ pub const BLOCK_SUBSCRIPT: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -29,7 +29,7 @@ pub const BLOCK_SUPERSCRIPT: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -29,7 +29,7 @@ pub const BLOCK_UNDERLINE: BlockRule = BlockRule {
 };
 
 fn parse_fn<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -29,6 +29,7 @@ use crate::parsing::rule::Rule;
 use crate::parsing::Parser;
 use crate::tree::Elements;
 use std::fmt::{self, Debug};
+use crate::log::prelude::*;
 
 mod arguments;
 mod mapping;
@@ -90,7 +91,7 @@ impl BlockRule {
     pub fn rule(&self) -> Rule {
         // Stubbed try_consume_fn implementation for the Rule.
         fn try_consume_fn<'p, 'r, 't>(
-            _: &slog::Logger,
+            _: &Logger,
             _: &'p mut Parser<'r, 't>,
         ) -> ParseResult<'r, 't, Elements<'t>> {
             panic!("Pseudo rule for this block should not be executed directly!");
@@ -118,13 +119,13 @@ impl Debug for BlockRule {
 /// Function pointer type to implement block parsing.
 ///
 /// The arguments are, in order:
-/// * `log` -- `slog::Logger` instance
+/// * `log` -- `Logger` instance
 /// * `parser` -- `Parser` instance
 /// * `name` -- The name of the block
 /// * `special` -- Whether this block is `[[*` (special) or `[[` (regular)
 /// * `in_head` -- Whether we're still in the block head, or if it's finished
 pub type BlockParseFn = for<'r, 't> fn(
-    &slog::Logger,
+    &Logger,
     &mut Parser<'r, 't>,
     &'t str,
     bool,

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -24,12 +24,12 @@
 //! against the upcoming tokens in accordance to how the
 //! various blocks define themselves.
 
+use crate::log::prelude::*;
 use crate::parsing::result::ParseResult;
 use crate::parsing::rule::Rule;
 use crate::parsing::Parser;
 use crate::tree::Elements;
 use std::fmt::{self, Debug};
-use crate::log::prelude::*;
 
 mod arguments;
 mod mapping;

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -39,7 +39,7 @@ pub const RULE_BLOCK_SKIP: Rule = Rule {
 // Rule implementations
 
 fn block_regular<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to process a block");
@@ -48,7 +48,7 @@ fn block_regular<'r, 't>(
 }
 
 fn block_special<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to process a block (with special)");
@@ -57,7 +57,7 @@ fn block_special<'r, 't>(
 }
 
 fn block_skip<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(
@@ -100,7 +100,7 @@ fn block_skip<'r, 't>(
 // Block parsing implementation
 
 fn parse_block<'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &mut Parser<'r, 't>,
     special: bool,
 ) -> ParseResult<'r, 't, Elements<'t>>

--- a/ftml/src/parsing/rule/impls/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/blockquote.rs
@@ -20,7 +20,6 @@
 
 use super::prelude::*;
 use crate::parsing::{process_depths, DepthItem, DepthList};
-use crate::span_wrap::SpanWrap;
 use crate::tree::{AttributeMap, Container, ContainerType};
 
 const MAX_BLOCKQUOTE_DEPTH: usize = 30;
@@ -31,7 +30,7 @@ pub const RULE_BLOCKQUOTE: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing nested native blockquotes");

--- a/ftml/src/parsing/rule/impls/bold.rs
+++ b/ftml/src/parsing/rule/impls/bold.rs
@@ -26,7 +26,7 @@ pub const RULE_BOLD: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create bold (strong) container");

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -26,7 +26,7 @@ pub const RULE_COLOR: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create color container");

--- a/ftml/src/parsing/rule/impls/comment.rs
+++ b/ftml/src/parsing/rule/impls/comment.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::span_wrap::SpanWrap;
 
 pub const RULE_COMMENT: Rule = Rule {
     name: "comment",
@@ -27,7 +26,7 @@ pub const RULE_COMMENT: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming tokens until end of comment");

--- a/ftml/src/parsing/rule/impls/dash.rs
+++ b/ftml/src/parsing/rule/impls/dash.rs
@@ -26,7 +26,7 @@ pub const RULE_DASH: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token to create an em dash");

--- a/ftml/src/parsing/rule/impls/double_angle.rs
+++ b/ftml/src/parsing/rule/impls/double_angle.rs
@@ -26,7 +26,7 @@ pub const RULE_DOUBLE_ANGLE: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let current = parser.current();

--- a/ftml/src/parsing/rule/impls/email.rs
+++ b/ftml/src/parsing/rule/impls/email.rs
@@ -26,7 +26,7 @@ pub const RULE_EMAIL: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as an email");

--- a/ftml/src/parsing/rule/impls/fallback.rs
+++ b/ftml/src/parsing/rule/impls/fallback.rs
@@ -34,7 +34,7 @@ pub const RULE_FALLBACK: Rule = Rule {
 /// See the end of the `consume()` function in `parse/consume.rs` for
 /// where the fallback action is performed.
 fn try_consume_fn<'p, 'r, 't>(
-    _: &slog::Logger,
+    _: &Logger,
     _: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     panic!("Manual fallback rule should not be executed directly!")

--- a/ftml/src/parsing/rule/impls/horizontal_rule.rs
+++ b/ftml/src/parsing/rule/impls/horizontal_rule.rs
@@ -26,7 +26,7 @@ pub const RULE_HORIZONTAL_RULE: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token to create a horizontal rule");

--- a/ftml/src/parsing/rule/impls/italics.rs
+++ b/ftml/src/parsing/rule/impls/italics.rs
@@ -26,7 +26,7 @@ pub const RULE_ITALICS: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create italics (emphasis) container");

--- a/ftml/src/parsing/rule/impls/line_break.rs
+++ b/ftml/src/parsing/rule/impls/line_break.rs
@@ -31,7 +31,7 @@ pub const RULE_LINE_BREAK_PARAGRAPH: Rule = Rule {
 };
 
 fn line_break<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming newline token as line break");
@@ -40,7 +40,7 @@ fn line_break<'p, 'r, 't>(
 }
 
 fn line_break_paragraph<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming paragraph break as line break");

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -34,7 +34,7 @@ pub const RULE_LINK_ANCHOR: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create a single-bracket anchor link");

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -39,7 +39,7 @@ pub const RULE_LINK_SINGLE_NEW_TAB: Rule = Rule {
 };
 
 fn link<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to create a single-bracket link (regular)");
@@ -50,7 +50,7 @@ fn link<'p, 'r, 't>(
 }
 
 fn link_new_tab<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to create a single-bracket link (new tab)");
@@ -67,7 +67,7 @@ fn link_new_tab<'p, 'r, 't>(
 
 /// Build a single-bracket link with the given target.
 fn try_consume_link<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     target: Option<AnchorTarget>,

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -43,7 +43,7 @@ pub const RULE_LINK_TRIPLE_NEW_TAB: Rule = Rule {
 };
 
 fn link<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to create a triple-bracket link (regular)");
@@ -54,7 +54,7 @@ fn link<'p, 'r, 't>(
 }
 
 fn link_new_tab<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     trace!(log, "Trying to create a triple-bracket link (new tab)");
@@ -71,7 +71,7 @@ fn link_new_tab<'p, 'r, 't>(
 
 /// Build a triple-bracket link with the given target.
 fn try_consume_link<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     target: Option<AnchorTarget>,
@@ -128,7 +128,7 @@ fn try_consume_link<'p, 'r, 't>(
 /// Helper to build link with the same URL and label.
 /// e.g. `[[[name]]]`
 fn build_same<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
     url: &'t str,
     target: Option<AnchorTarget>,
@@ -155,7 +155,7 @@ fn build_same<'p, 'r, 't>(
 /// Helper to build link with separate URL and label.
 /// e.g. `[[[page|label]]]`, or `[[[page|]]]`
 fn build_separate<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
     rule: Rule,
     url: &'t str,

--- a/ftml/src/parsing/rule/impls/list.rs
+++ b/ftml/src/parsing/rule/impls/list.rs
@@ -20,7 +20,6 @@
 
 use super::prelude::*;
 use crate::parsing::{process_depths, DepthItem, DepthList};
-use crate::span_wrap::SpanWrap;
 use crate::tree::{ListItem, ListType};
 
 const MAX_LIST_DEPTH: usize = 20;
@@ -39,7 +38,7 @@ pub const RULE_LIST: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     // We don't know the list type(s) yet, so just log that we're starting

--- a/ftml/src/parsing/rule/impls/mod.rs
+++ b/ftml/src/parsing/rule/impls/mod.rs
@@ -30,6 +30,7 @@ mod prelude {
     pub use crate::parsing::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
     pub use crate::tree::{AttributeMap, Container, ContainerType, Element, Elements};
+    pub use crate::log::prelude::*;
 }
 
 mod block;

--- a/ftml/src/parsing/rule/impls/mod.rs
+++ b/ftml/src/parsing/rule/impls/mod.rs
@@ -19,6 +19,7 @@
  */
 
 mod prelude {
+    pub use crate::log::prelude::*;
     pub use crate::parsing::check_step::check_step;
     pub use crate::parsing::collect::*;
     pub use crate::parsing::condition::ParseCondition;
@@ -30,7 +31,6 @@ mod prelude {
     pub use crate::parsing::token::{ExtractedToken, Token};
     pub use crate::text::FullText;
     pub use crate::tree::{AttributeMap, Container, ContainerType, Element, Elements};
-    pub use crate::log::prelude::*;
 }
 
 mod block;

--- a/ftml/src/parsing/rule/impls/monospace.rs
+++ b/ftml/src/parsing/rule/impls/monospace.rs
@@ -26,7 +26,7 @@ pub const RULE_MONOSPACE: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create monospace container");

--- a/ftml/src/parsing/rule/impls/null.rs
+++ b/ftml/src/parsing/rule/impls/null.rs
@@ -26,7 +26,7 @@ pub const RULE_NULL: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token and outputting null element");

--- a/ftml/src/parsing/rule/impls/page.rs
+++ b/ftml/src/parsing/rule/impls/page.rs
@@ -35,7 +35,7 @@ pub const RULE_PAGE: Rule = Rule {
 /// See the `parse()` function `parse/mod.rs` for the code inherently
 /// implementing this consumption action.
 fn try_consume_fn<'p, 'r, 't>(
-    _: &slog::Logger,
+    _: &Logger,
     _: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     panic!("Manual page rule should not be executed directly!")

--- a/ftml/src/parsing/rule/impls/raw.rs
+++ b/ftml/src/parsing/rule/impls/raw.rs
@@ -19,7 +19,6 @@
  */
 
 use super::prelude::*;
-use crate::span_wrap::SpanWrap;
 
 macro_rules! raw {
     ($value:expr) => {
@@ -33,7 +32,7 @@ pub const RULE_RAW: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming tokens until end of raw");

--- a/ftml/src/parsing/rule/impls/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/strikethrough.rs
@@ -26,7 +26,7 @@ pub const RULE_STRIKETHROUGH: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create strikethrough container");

--- a/ftml/src/parsing/rule/impls/subscript.rs
+++ b/ftml/src/parsing/rule/impls/subscript.rs
@@ -26,7 +26,7 @@ pub const RULE_SUBSCRIPT: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create subscript container");

--- a/ftml/src/parsing/rule/impls/superscript.rs
+++ b/ftml/src/parsing/rule/impls/superscript.rs
@@ -26,7 +26,7 @@ pub const RULE_SUPERSCRIPT: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create superscript container");

--- a/ftml/src/parsing/rule/impls/text.rs
+++ b/ftml/src/parsing/rule/impls/text.rs
@@ -26,7 +26,7 @@ pub const RULE_TEXT: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as plain text element");

--- a/ftml/src/parsing/rule/impls/todo.rs
+++ b/ftml/src/parsing/rule/impls/todo.rs
@@ -29,7 +29,7 @@ pub const RULE_TODO: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     error!(log, "Encountered unimplemented rule! Returning warning");

--- a/ftml/src/parsing/rule/impls/underline.rs
+++ b/ftml/src/parsing/rule/impls/underline.rs
@@ -26,7 +26,7 @@ pub const RULE_UNDERLINE: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Trying to create underline container");

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -27,7 +27,7 @@ pub const RULE_URL: Rule = Rule {
 };
 
 fn try_consume_fn<'p, 'r, 't>(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as a URL");

--- a/ftml/src/parsing/rule/mod.rs
+++ b/ftml/src/parsing/rule/mod.rs
@@ -49,7 +49,7 @@ impl Rule {
     #[inline]
     pub fn try_consume<'p, 'r, 't>(
         self,
-        log: &slog::Logger,
+        log: &Logger,
         parser: &'p mut Parser<'r, 't>,
     ) -> ParseResult<'r, 't, Elements<'t>> {
         info!(log, "Trying to consume for parse rule"; "name" => self.name);
@@ -76,6 +76,7 @@ impl Debug for Rule {
     }
 }
 
+#[cfg(feature = "has-log")]
 impl slog::Value for Rule {
     fn serialize(
         &self,
@@ -89,6 +90,6 @@ impl slog::Value for Rule {
 
 /// The function type for actually trying to consume tokens
 pub type TryConsumeFn = for<'p, 'r, 't> fn(
-    log: &slog::Logger,
+    log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>>;

--- a/ftml/src/parsing/token/mod.rs
+++ b/ftml/src/parsing/token/mod.rs
@@ -32,7 +32,7 @@ mod lexer {
 }
 
 use self::lexer::*;
-use crate::span_wrap::SpanWrap;
+use crate::log::prelude::*;
 use pest::iterators::Pair;
 use pest::Parser;
 use std::ops::Range;
@@ -152,7 +152,7 @@ pub enum Token {
 
 impl Token {
     pub(crate) fn extract_all<'a>(
-        log: &slog::Logger,
+        log: &Logger,
         text: &'a str,
     ) -> Vec<ExtractedToken<'a>> {
         debug!(log, "Running lexer on input");
@@ -189,7 +189,7 @@ impl Token {
     }
 
     /// Converts a single `Pair` from pest into its corresponding `ExtractedToken`.
-    fn convert_pair<'a>(log: &slog::Logger, pair: Pair<'a, Rule>) -> ExtractedToken<'a> {
+    fn convert_pair<'a>(log: &Logger, pair: Pair<'a, Rule>) -> ExtractedToken<'a> {
         // Extract values from the Pair
         let rule = pair.as_rule();
         let slice = pair.as_str();
@@ -303,6 +303,7 @@ impl Token {
     }
 }
 
+#[cfg(feature = "has-log")]
 impl slog::Value for Token {
     fn serialize(
         &self,

--- a/ftml/src/preproc/mod.rs
+++ b/ftml/src/preproc/mod.rs
@@ -24,6 +24,8 @@ mod whitespace;
 #[cfg(test)]
 mod test;
 
+use crate::log::prelude::*;
+
 /// Run the preprocessor on the given wikitext, which is modified in-place.
 ///
 /// The following modifications are performed:
@@ -35,7 +37,7 @@ mod test;
 ///
 /// This call always succeeds. The return value designates where issues occurred
 /// to allow programmatic determination of where things were not as expected.
-pub fn preprocess(log: &slog::Logger, text: &mut String) {
+pub fn preprocess(log: &Logger, text: &mut String) {
     let log = &log.new(slog_o!(
         "filename" => slog_filename!(),
         "lineno" => slog_lineno!(),
@@ -51,7 +53,7 @@ pub fn preprocess(log: &slog::Logger, text: &mut String) {
 
 #[test]
 fn fn_type() {
-    type SubstituteFn = fn(&slog::Logger, &mut String);
+    type SubstituteFn = fn(&Logger, &mut String);
 
     let _: SubstituteFn = whitespace::substitute;
     let _: SubstituteFn = typography::substitute;

--- a/ftml/src/preproc/test.rs
+++ b/ftml/src/preproc/test.rs
@@ -19,10 +19,11 @@
  */
 
 use super::preprocess;
+use crate::log::prelude::*;
 
 pub fn test_substitution<F>(filter_name: &str, mut substitute: F, tests: &[(&str, &str)])
 where
-    F: FnMut(&slog::Logger, &mut String),
+    F: FnMut(&Logger, &mut String),
 {
     let mut string = String::new();
     let log = crate::build_logger();

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -29,6 +29,7 @@
 //! * ... to an ellipsis
 
 use regex::Regex;
+use crate::log::prelude::*;
 
 lazy_static! {
     // ‘ - LEFT SINGLE QUOTATION MARK
@@ -90,7 +91,7 @@ pub enum Replacer {
 }
 
 impl Replacer {
-    fn replace(&self, log: &slog::Logger, text: &mut String, buffer: &mut String) {
+    fn replace(&self, log: &Logger, text: &mut String, buffer: &mut String) {
         use self::Replacer::*;
 
         match *self {
@@ -157,7 +158,7 @@ impl Replacer {
     }
 }
 
-pub fn substitute(log: &slog::Logger, text: &mut String) {
+pub fn substitute(log: &Logger, text: &mut String) {
     let mut buffer = String::new();
 
     debug!(log, "Performing typography substitutions"; "text" => &*text);

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -28,8 +28,8 @@
 //! * ,, .. '' to fancy lowered double quotes
 //! * ... to an ellipsis
 
-use regex::Regex;
 use crate::log::prelude::*;
+use regex::Regex;
 
 lazy_static! {
     // ‘ - LEFT SINGLE QUOTATION MARK

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -31,8 +31,8 @@
 //! to prevent typography from converting the `--` in `[!--` and `--]` into
 //! em dashes.
 
-use regex::{Regex, RegexBuilder};
 use crate::log::prelude::*;
+use regex::{Regex, RegexBuilder};
 
 lazy_static! {
     static ref WHITESPACE: Regex = {
@@ -81,12 +81,7 @@ fn str_replace(log: &Logger, text: &mut String, pattern: &str, replacement: &str
     }
 }
 
-fn regex_replace(
-    log: &Logger,
-    text: &mut String,
-    regex: &Regex,
-    replacement: &str,
-) {
+fn regex_replace(log: &Logger, text: &mut String, regex: &Regex, replacement: &str) {
     debug!(
         log,
         "Replacing miscellaneous regular expression";

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -32,6 +32,7 @@
 //! em dashes.
 
 use regex::{Regex, RegexBuilder};
+use crate::log::prelude::*;
 
 lazy_static! {
     static ref WHITESPACE: Regex = {
@@ -44,7 +45,7 @@ lazy_static! {
     static ref TRAILING_NEWLINES: Regex = Regex::new(r"\n+$").unwrap();
 }
 
-pub fn substitute(log: &slog::Logger, text: &mut String) {
+pub fn substitute(log: &Logger, text: &mut String) {
     // Replace DOS and Mac newlines
     str_replace(log, text, "\r\n", "\n");
     str_replace(log, text, "\r", "\n");
@@ -64,7 +65,7 @@ pub fn substitute(log: &slog::Logger, text: &mut String) {
     regex_replace(log, text, &*TRAILING_NEWLINES, "");
 }
 
-fn str_replace(log: &slog::Logger, text: &mut String, pattern: &str, replacement: &str) {
+fn str_replace(log: &Logger, text: &mut String, pattern: &str, replacement: &str) {
     debug!(
         log,
         "Replacing miscellaneous static string";
@@ -81,7 +82,7 @@ fn str_replace(log: &slog::Logger, text: &mut String, pattern: &str, replacement
 }
 
 fn regex_replace(
-    log: &slog::Logger,
+    log: &Logger,
     text: &mut String,
     regex: &Regex,
     replacement: &str,

--- a/ftml/src/render/debug.rs
+++ b/ftml/src/render/debug.rs
@@ -31,7 +31,7 @@ impl Render for DebugRender {
     #[inline]
     fn render(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         page_info: &PageInfo,
         tree: &SyntaxTree,
     ) -> String {

--- a/ftml/src/render/debug.rs
+++ b/ftml/src/render/debug.rs
@@ -29,12 +29,7 @@ impl Render for DebugRender {
     type Output = String;
 
     #[inline]
-    fn render(
-        &self,
-        log: &Logger,
-        page_info: &PageInfo,
-        tree: &SyntaxTree,
-    ) -> String {
+    fn render(&self, log: &Logger, page_info: &PageInfo, tree: &SyntaxTree) -> String {
         info!(log, "Running debug logger on syntax tree");
 
         format!("{:#?}\n{:#?}", page_info, tree)

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -19,11 +19,11 @@
  */
 
 use crate::data::PageInfo;
+use crate::log::prelude::*;
 use crate::tree::LinkLabel;
 use crate::tree::Module;
 use std::num::NonZeroUsize;
 use strum_macros::IntoStaticStr;
-use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct Handle;
@@ -71,13 +71,8 @@ impl Handle {
         format!("TODO: actual title ({})", page_slug)
     }
 
-    pub fn get_link_label<F>(
-        &self,
-        log: &Logger,
-        url: &str,
-        label: &LinkLabel,
-        f: F,
-    ) where
+    pub fn get_link_label<F>(&self, log: &Logger, url: &str, label: &LinkLabel, f: F)
+    where
         F: FnOnce(&str),
     {
         let page_title;
@@ -94,12 +89,7 @@ impl Handle {
         f(label_text);
     }
 
-    pub fn get_message(
-        &self,
-        log: &Logger,
-        locale: &str,
-        message: &str,
-    ) -> &'static str {
+    pub fn get_message(&self, log: &Logger, locale: &str, message: &str) -> &'static str {
         debug!(
             log,
             "Fetching message";

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -23,6 +23,7 @@ use crate::tree::LinkLabel;
 use crate::tree::Module;
 use std::num::NonZeroUsize;
 use strum_macros::IntoStaticStr;
+use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct Handle;
@@ -41,7 +42,7 @@ impl Handle {
 
     pub fn render_module(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         buffer: &mut String,
         module: &Module,
         mode: ModuleRenderMode,
@@ -63,7 +64,7 @@ impl Handle {
         }
     }
 
-    pub fn get_page_title(&self, log: &slog::Logger, page_slug: &str) -> String {
+    pub fn get_page_title(&self, log: &Logger, page_slug: &str) -> String {
         debug!(log, "Fetching page title"; "page" => page_slug);
 
         // TODO
@@ -95,7 +96,7 @@ impl Handle {
 
     pub fn get_message(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         locale: &str,
         message: &str,
     ) -> &'static str {
@@ -122,14 +123,14 @@ impl Handle {
         }
     }
 
-    pub fn post_html(&self, log: &slog::Logger, _info: &PageInfo, _html: &str) -> String {
+    pub fn post_html(&self, log: &Logger, _info: &PageInfo, _html: &str) -> String {
         debug!(log, "Submitting HTML to create iframe-able snippet");
 
         // TODO
         str!("https://example.com/")
     }
 
-    pub fn post_code(&self, log: &slog::Logger, index: NonZeroUsize, code: &str) {
+    pub fn post_code(&self, log: &Logger, index: NonZeroUsize, code: &str) {
         debug!(
             log,
             "Submitting code snippet";

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -29,7 +29,7 @@ use crate::log::prelude::*;
 pub struct Handle;
 
 impl Handle {
-    pub fn get_url(&self, log: &slog::Logger, site_slug: &str) -> String {
+    pub fn get_url(&self, log: &Logger, site_slug: &str) -> String {
         debug!(
             log,
             "Getting URL of this Wikijump instance";
@@ -73,7 +73,7 @@ impl Handle {
 
     pub fn get_link_label<F>(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         url: &str,
         label: &LinkLabel,
         f: F,

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -20,6 +20,7 @@
 
 use super::context::HtmlContext;
 use super::escape::escape_char;
+use crate::log::prelude::*;
 use super::render::ItemRender;
 use crate::tree::AttributeMap;
 
@@ -215,7 +216,7 @@ impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
     }
 
     #[inline]
-    pub fn inner(&mut self, log: &slog::Logger, item: &dyn ItemRender) -> &mut Self {
+    pub fn inner(&mut self, log: &Logger, item: &dyn ItemRender) -> &mut Self {
         self.content_start();
         item.render(log, self.ctx);
 

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -20,8 +20,8 @@
 
 use super::context::HtmlContext;
 use super::escape::escape_char;
-use crate::log::prelude::*;
 use super::render::ItemRender;
+use crate::log::prelude::*;
 use crate::tree::AttributeMap;
 
 macro_rules! tag_method {

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -55,11 +55,7 @@ impl<'a> Collapsible<'a> {
     }
 }
 
-pub fn render_collapsible(
-    log: &Logger,
-    ctx: &mut HtmlContext,
-    collapsible: Collapsible,
-) {
+pub fn render_collapsible(log: &Logger, ctx: &mut HtmlContext, collapsible: Collapsible) {
     let Collapsible {
         elements,
         attributes,

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -56,7 +56,7 @@ impl<'a> Collapsible<'a> {
 }
 
 pub fn render_collapsible(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     collapsible: Collapsible,
 ) {

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::Container;
 
 pub fn render_container(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     container: &Container,
 ) {
@@ -45,7 +45,7 @@ pub fn render_container(
 }
 
 pub fn render_color(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     color: &str,
     elements: &[Element],

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -21,11 +21,7 @@
 use super::prelude::*;
 use crate::tree::Container;
 
-pub fn render_container(
-    log: &Logger,
-    ctx: &mut HtmlContext,
-    container: &Container,
-) {
+pub fn render_container(log: &Logger, ctx: &mut HtmlContext, container: &Container) {
     debug!(log, "Rendering container"; "container" => container.ctype().name());
 
     // Get HTML tag type for this type of container

--- a/ftml/src/render/html/element/iframe.rs
+++ b/ftml/src/render/html/element/iframe.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::AttributeMap;
 
 pub fn render_iframe(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     url: &str,
     attributes: &AttributeMap,
@@ -36,7 +36,7 @@ pub fn render_iframe(
     ctx.html().iframe().attr("src", &[url]).attr_map(attributes);
 }
 
-pub fn render_html(log: &slog::Logger, ctx: &mut HtmlContext, contents: &str) {
+pub fn render_html(log: &Logger, ctx: &mut HtmlContext, contents: &str) {
     debug!(
         log,
         "Rendering html block (submitting to remote for iframe)";

--- a/ftml/src/render/html/element/input.rs
+++ b/ftml/src/render/html/element/input.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::AttributeMap;
 
 pub fn render_radio_button(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     name: &str,
     checked: bool,
@@ -50,7 +50,7 @@ pub fn render_radio_button(
 }
 
 pub fn render_checkbox(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     checked: bool,
     attributes: &AttributeMap,

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel};
 
 pub fn render_anchor(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     elements: &[Element],
     attributes: &AttributeMap,
@@ -41,7 +41,7 @@ pub fn render_anchor(
 }
 
 pub fn render_link(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     url: &str,
     label: &LinkLabel,

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::{ListItem, ListType};
 
 pub fn render_list(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     ltype: ListType,
     list_items: &[ListItem],

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -32,11 +32,13 @@ mod prelude {
     pub use super::super::context::HtmlContext;
     pub use super::render_element;
     pub use crate::tree::{Element, SyntaxTree};
+    pub use crate::log::prelude::*;
 }
 
 use self::collapsible::{render_collapsible, Collapsible};
 use self::container::{render_color, render_container};
 use self::iframe::{render_html, render_iframe};
+use crate::log::prelude::*;
 use self::input::{render_checkbox, render_radio_button};
 use self::link::{render_anchor, render_link};
 use self::list::render_list;
@@ -46,7 +48,7 @@ use crate::render::ModuleRenderMode;
 use crate::tree::Element;
 use ref_map::OptionRefMap;
 
-pub fn render_elements(log: &slog::Logger, ctx: &mut HtmlContext, elements: &[Element]) {
+pub fn render_elements(log: &Logger, ctx: &mut HtmlContext, elements: &[Element]) {
     debug!(log, "Rendering elements"; "elements-len" => elements.len());
 
     for element in elements {
@@ -54,7 +56,7 @@ pub fn render_elements(log: &slog::Logger, ctx: &mut HtmlContext, elements: &[El
     }
 }
 
-pub fn render_element(log: &slog::Logger, ctx: &mut HtmlContext, element: &Element) {
+pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
     macro_rules! ref_cow {
         ($input:expr) => {
             $input.ref_map(|s| s.as_ref())

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -31,19 +31,19 @@ mod text;
 mod prelude {
     pub use super::super::context::HtmlContext;
     pub use super::render_element;
-    pub use crate::tree::{Element, SyntaxTree};
     pub use crate::log::prelude::*;
+    pub use crate::tree::{Element, SyntaxTree};
 }
 
 use self::collapsible::{render_collapsible, Collapsible};
 use self::container::{render_color, render_container};
 use self::iframe::{render_html, render_iframe};
-use crate::log::prelude::*;
 use self::input::{render_checkbox, render_radio_button};
 use self::link::{render_anchor, render_link};
 use self::list::render_list;
 use self::text::{render_code, render_email, render_wikitext_raw};
 use super::HtmlContext;
+use crate::log::prelude::*;
 use crate::render::ModuleRenderMode;
 use crate::tree::Element;
 use ref_map::OptionRefMap;

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -20,7 +20,7 @@
 
 use super::prelude::*;
 
-pub fn render_wikitext_raw(log: &slog::Logger, ctx: &mut HtmlContext, text: &str) {
+pub fn render_wikitext_raw(log: &Logger, ctx: &mut HtmlContext, text: &str) {
     debug!(log, "Escaping raw string"; "text" => text);
 
     ctx.html()
@@ -30,7 +30,7 @@ pub fn render_wikitext_raw(log: &slog::Logger, ctx: &mut HtmlContext, text: &str
         .inner(&log, &text);
 }
 
-pub fn render_email(log: &slog::Logger, ctx: &mut HtmlContext, email: &str) {
+pub fn render_email(log: &Logger, ctx: &mut HtmlContext, email: &str) {
     debug!(log, "Rendering email address"; "email" => email);
 
     // Since our usecase doesn't typically have emails as real,
@@ -44,7 +44,7 @@ pub fn render_email(log: &slog::Logger, ctx: &mut HtmlContext, email: &str) {
 }
 
 pub fn render_code(
-    log: &slog::Logger,
+    log: &Logger,
     ctx: &mut HtmlContext,
     language: Option<&str>,
     contents: &str,

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -40,6 +40,7 @@ use self::element::render_elements;
 use crate::data::PageInfo;
 use crate::render::{Handle, Render};
 use crate::tree::SyntaxTree;
+use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct HtmlRender;
@@ -49,7 +50,7 @@ impl Render for HtmlRender {
 
     fn render(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         page_info: &PageInfo,
         tree: &SyntaxTree,
     ) -> HtmlOutput {

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -38,9 +38,9 @@ use super::prelude;
 use self::context::HtmlContext;
 use self::element::render_elements;
 use crate::data::PageInfo;
+use crate::log::prelude::*;
 use crate::render::{Handle, Render};
 use crate::tree::SyntaxTree;
-use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct HtmlRender;

--- a/ftml/src/render/html/render.rs
+++ b/ftml/src/render/html/render.rs
@@ -21,28 +21,29 @@
 use super::context::HtmlContext;
 use super::element::{render_element, render_elements};
 use crate::tree::Element;
+use crate::log::prelude::*;
 
 pub trait ItemRender {
-    fn render(&self, log: &slog::Logger, ctx: &mut HtmlContext);
+    fn render(&self, log: &Logger, ctx: &mut HtmlContext);
 }
 
 impl ItemRender for &'_ str {
     #[inline]
-    fn render(&self, _log: &slog::Logger, ctx: &mut HtmlContext) {
+    fn render(&self, _log: &Logger, ctx: &mut HtmlContext) {
         ctx.push_escaped(self);
     }
 }
 
 impl ItemRender for &'_ Element<'_> {
     #[inline]
-    fn render(&self, log: &slog::Logger, ctx: &mut HtmlContext) {
+    fn render(&self, log: &Logger, ctx: &mut HtmlContext) {
         render_element(log, ctx, self)
     }
 }
 
 impl ItemRender for &'_ [Element<'_>] {
     #[inline]
-    fn render(&self, log: &slog::Logger, ctx: &mut HtmlContext) {
+    fn render(&self, log: &Logger, ctx: &mut HtmlContext) {
         render_elements(log, ctx, self)
     }
 }

--- a/ftml/src/render/html/render.rs
+++ b/ftml/src/render/html/render.rs
@@ -20,8 +20,8 @@
 
 use super::context::HtmlContext;
 use super::element::{render_element, render_elements};
-use crate::tree::Element;
 use crate::log::prelude::*;
+use crate::tree::Element;
 
 pub trait ItemRender {
     fn render(&self, log: &Logger, ctx: &mut HtmlContext);

--- a/ftml/src/render/json.rs
+++ b/ftml/src/render/json.rs
@@ -48,7 +48,7 @@ impl Render for JsonRender {
 
     fn render(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         page_info: &PageInfo,
         syntax_tree: &SyntaxTree,
     ) -> String {

--- a/ftml/src/render/mod.rs
+++ b/ftml/src/render/mod.rs
@@ -22,6 +22,7 @@ mod prelude {
     pub use super::Render;
     pub use crate::data::PageInfo;
     pub use crate::tree::{AttributeMap, Container, ContainerType, Element, SyntaxTree};
+    pub use crate::log::prelude::*;
 }
 
 pub mod debug;
@@ -35,6 +36,7 @@ mod handle;
 use self::handle::{Handle, ModuleRenderMode};
 use crate::data::PageInfo;
 use crate::tree::SyntaxTree;
+use crate::log::prelude::*;
 
 /// Abstract trait for any ftml renderer.
 ///
@@ -57,7 +59,7 @@ pub trait Render {
     /// it requires to produce the output string.
     fn render(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         page_info: &PageInfo,
         tree: &SyntaxTree,
     ) -> Self::Output;

--- a/ftml/src/render/mod.rs
+++ b/ftml/src/render/mod.rs
@@ -21,8 +21,8 @@
 mod prelude {
     pub use super::Render;
     pub use crate::data::PageInfo;
-    pub use crate::tree::{AttributeMap, Container, ContainerType, Element, SyntaxTree};
     pub use crate::log::prelude::*;
+    pub use crate::tree::{AttributeMap, Container, ContainerType, Element, SyntaxTree};
 }
 
 pub mod debug;
@@ -35,8 +35,8 @@ mod handle;
 
 use self::handle::{Handle, ModuleRenderMode};
 use crate::data::PageInfo;
-use crate::tree::SyntaxTree;
 use crate::log::prelude::*;
+use crate::tree::SyntaxTree;
 
 /// Abstract trait for any ftml renderer.
 ///

--- a/ftml/src/render/null.rs
+++ b/ftml/src/render/null.rs
@@ -32,7 +32,7 @@ impl Render for NullRender {
     type Output = ();
 
     #[inline]
-    fn render(&self, _log: &slog::Logger, _page_info: &PageInfo, _tree: &SyntaxTree) {}
+    fn render(&self, _log: &Logger, _page_info: &PageInfo, _tree: &SyntaxTree) {}
 }
 
 #[test]

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -21,10 +21,10 @@
 //! Module that implements text rendering for `Element` and its children.
 
 use super::TextContext;
+use crate::log::prelude::*;
 use crate::render::ModuleRenderMode;
 use crate::tree::{ContainerType, Element, ListItem, ListType};
 use crate::url::is_url;
-use crate::log::prelude::*;
 use std::borrow::Cow;
 
 pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]) {

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -24,9 +24,10 @@ use super::TextContext;
 use crate::render::ModuleRenderMode;
 use crate::tree::{ContainerType, Element, ListItem, ListType};
 use crate::url::is_url;
+use crate::log::prelude::*;
 use std::borrow::Cow;
 
-pub fn render_elements(log: &slog::Logger, ctx: &mut TextContext, elements: &[Element]) {
+pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]) {
     debug!(log, "Rendering elements"; "elements-len" => elements.len());
 
     for element in elements {
@@ -34,7 +35,7 @@ pub fn render_elements(log: &slog::Logger, ctx: &mut TextContext, elements: &[El
     }
 }
 
-pub fn render_element(log: &slog::Logger, ctx: &mut TextContext, element: &Element) {
+pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
     debug!(log, "Rendering element"; "element" => element.name());
 
     match element {
@@ -235,7 +236,9 @@ pub fn render_element(log: &slog::Logger, ctx: &mut TextContext, element: &Eleme
     }
 }
 
-fn get_full_url<'a>(log: &slog::Logger, ctx: &TextContext, url: &'a str) -> Cow<'a, str> {
+fn get_full_url<'a>(log: &Logger, ctx: &TextContext, url: &'a str) -> Cow<'a, str> {
+    debug!(log, "Building full URL"; "url" => url);
+
     // TODO: when we remove inline javascript stuff
     if url == "javascript:;" {
         return Cow::Borrowed("#");

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -24,9 +24,9 @@ mod elements;
 use self::context::TextContext;
 use self::elements::render_elements;
 use crate::data::PageInfo;
+use crate::log::prelude::*;
 use crate::render::{Handle, Render};
 use crate::tree::SyntaxTree;
-use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct TextRender;
@@ -34,12 +34,7 @@ pub struct TextRender;
 impl Render for TextRender {
     type Output = String;
 
-    fn render(
-        &self,
-        log: &Logger,
-        page_info: &PageInfo,
-        tree: &SyntaxTree,
-    ) -> String {
+    fn render(&self, log: &Logger, page_info: &PageInfo, tree: &SyntaxTree) -> String {
         info!(
             log,
             "Rendering syntax tree";

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -26,6 +26,7 @@ use self::elements::render_elements;
 use crate::data::PageInfo;
 use crate::render::{Handle, Render};
 use crate::tree::SyntaxTree;
+use crate::log::prelude::*;
 
 #[derive(Debug)]
 pub struct TextRender;
@@ -35,7 +36,7 @@ impl Render for TextRender {
 
     fn render(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         page_info: &PageInfo,
         tree: &SyntaxTree,
     ) -> String {

--- a/ftml/src/test.rs
+++ b/ftml/src/test.rs
@@ -25,11 +25,11 @@
 
 use crate::data::PageInfo;
 use crate::includes::DebugIncluder;
+use crate::log::prelude::*;
 use crate::parsing::{ParseWarning, ParseWarningKind, Token};
 use crate::render::html::HtmlRender;
 use crate::render::text::TextRender;
 use crate::render::Render;
-use crate::log::prelude::*;
 use crate::tree::{Element, SyntaxTree};
 use std::borrow::Cow;
 use std::fs::{self, File};

--- a/ftml/src/test.rs
+++ b/ftml/src/test.rs
@@ -29,6 +29,7 @@ use crate::parsing::{ParseWarning, ParseWarningKind, Token};
 use crate::render::html::HtmlRender;
 use crate::render::text::TextRender;
 use crate::render::Render;
+use crate::log::prelude::*;
 use crate::tree::{Element, SyntaxTree};
 use std::borrow::Cow;
 use std::fs::{self, File};
@@ -128,7 +129,7 @@ impl Test<'_> {
         test
     }
 
-    pub fn run(&self, log: &slog::Logger) {
+    pub fn run(&self, log: &Logger) {
         info!(
             &log,
             "Running syntax tree test case";

--- a/ftml/src/text.rs
+++ b/ftml/src/text.rs
@@ -18,8 +18,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::parsing::ExtractedToken;
 use crate::log::prelude::*;
+use crate::parsing::ExtractedToken;
 
 /// Wrapper for the input string that was tokenized.
 ///

--- a/ftml/src/text.rs
+++ b/ftml/src/text.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::parsing::ExtractedToken;
+use crate::log::prelude::*;
 
 /// Wrapper for the input string that was tokenized.
 ///
@@ -58,7 +59,7 @@ impl<'t> FullText<'t> {
     /// this function will panic.
     pub fn slice(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         start_token: &ExtractedToken,
         end_token: &ExtractedToken,
     ) -> &'t str {
@@ -83,7 +84,7 @@ impl<'t> FullText<'t> {
     /// this function will panic.
     pub fn slice_partial(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         start_token: &ExtractedToken,
         end_token: &ExtractedToken,
     ) -> &'t str {
@@ -95,7 +96,7 @@ impl<'t> FullText<'t> {
 
     fn slice_impl(
         &self,
-        log: &slog::Logger,
+        log: &Logger,
         slice_kind: &'static str,
         start: usize,
         end: usize,

--- a/ftml/src/tokenizer.rs
+++ b/ftml/src/tokenizer.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::log::prelude::*;
 use crate::parsing::{ExtractedToken, Token};
 use crate::text::FullText;
 
@@ -47,7 +48,7 @@ impl<'t> From<Tokenization<'t>> for Vec<ExtractedToken<'t>> {
 }
 
 /// Take an input string and produce a list of tokens for consumption by the parser.
-pub fn tokenize<'t>(log: &slog::Logger, text: &'t str) -> Tokenization<'t> {
+pub fn tokenize<'t>(log: &Logger, text: &'t str) -> Tokenization<'t> {
     let log = &log.new(slog_o!(
         "filename" => slog_filename!(),
         "lineno" => slog_lineno!(),

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -136,6 +136,7 @@ impl ContainerType {
     }
 }
 
+#[cfg(feature = "has-log")]
 impl slog::Value for ContainerType {
     fn serialize(
         &self,

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -267,6 +267,7 @@ impl Element<'_> {
     }
 }
 
+#[cfg(feature = "has-log")]
 impl slog::Value for Element<'_> {
     fn serialize(
         &self,

--- a/ftml/src/wasm/log/mod.rs
+++ b/ftml/src/wasm/log/mod.rs
@@ -28,16 +28,16 @@ cfg_if! {
         pub use self::console::ConsoleLogger;
 
         lazy_static! {
-            pub static ref LOGGER: slog::Logger = {
+            pub static ref LOGGER: Logger = {
                 use slog::Drain;
 
-                slog::Logger::root(ConsoleLogger.fuse(), o!())
+                Logger::root(ConsoleLogger.fuse(), o!())
             };
         }
     } else {
         lazy_static! {
-            pub static ref LOGGER: slog::Logger = {
-                slog::Logger::root(slog::Discard, o!()) //
+            pub static ref LOGGER: Logger = {
+                Logger::root(slog::Discard, o!()) //
             };
         }
     }

--- a/ftml/src/wasm/log/mod.rs
+++ b/ftml/src/wasm/log/mod.rs
@@ -29,17 +29,17 @@ cfg_if! {
         pub use self::console::ConsoleLogger;
 
         lazy_static! {
-            pub static ref LOGGER: Logger = {
+            pub static ref LOGGER: slog::Logger = {
                 use slog::Drain;
 
-                Logger::root(ConsoleLogger.fuse(), o!())
+                slog::Logger::root(ConsoleLogger.fuse(), o!())
             };
         }
     } else if #[cfg(feature = "has-log")] {
         // Use a null logger
         lazy_static! {
-            pub static ref LOGGER: Logger = {
-                Logger::root(slog::Discard, o!()) //
+            pub static ref LOGGER: slog::Logger = {
+                slog::Logger::root(slog::Discard, o!()) //
             };
         }
     } else {

--- a/ftml/src/wasm/log/mod.rs
+++ b/ftml/src/wasm/log/mod.rs
@@ -22,6 +22,7 @@ use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "wasm-log")] {
+        // Use console.log()
         mod console;
         mod context;
 
@@ -34,11 +35,19 @@ cfg_if! {
                 Logger::root(ConsoleLogger.fuse(), o!())
             };
         }
-    } else {
+    } else if #[cfg(feature = "has-log")] {
+        // Use a null logger
         lazy_static! {
             pub static ref LOGGER: Logger = {
                 Logger::root(slog::Discard, o!()) //
             };
+        }
+    } else {
+        // Use dummy logging
+        use crate::log::Logger;
+
+        lazy_static! {
+            pub static ref LOGGER: Logger = Logger;
         }
     }
 }


### PR DESCRIPTION
This creates a default feature `has-log`, which instantiates `slog::Logger` as expected. However, if you build without default features, then all logging are replaced with no-ops. This has considerable performance improvements for the WebAssembly target, so the documentation has been updated to recommend this.

Due to the complexity of the slog logging macros, this PR does not properly "consume" unused logging variables, so instead it just builds with `RUSTFLAGS=-Aunused_variables` to suppress these warnings. Obviously during normal development, use the default target and take heed to any compiler warnings.

**Edit:** This also updates GitHub actions to build the non-logged form, and while I was at it, I properly added `RUSTFLAGS = -D warnings` for all builds (except where we're suppressing warnings obviously).