### PR TITLE
[WJ-456] Add the Tarnation grammar generator/system

### DIFF
--- a/client/modules/cm-tarnation/package.json
+++ b/client/modules/cm-tarnation/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "cm-tarnation",
+  "license": "agpl-3.0-or-later",
+  "description": "An alternative regex based parser for CodeMirror 6.",
+  "version": "0.0.0",
+  "keywords": [
+    "wikijump"
+  ],
+  "scripts": {
+    "clean": "trash dist .ultra.cache.json",
+    "build": "node ../../scripts/build-modules.js -self"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scpwiki/wikijump.git"
+  },
+  "bugs": {
+    "url": "https://scuttle.atlassian.net/servicedesk/customer/portal/2"
+  },
+  "homepage": "https://github.com/scpwiki/wikijump#readme",
+  "eslintConfig": {
+    "extends": "../../.eslintrc.js"
+  },
+  "dependencies": {
+    "@codemirror/highlight": "^0.18.3",
+    "@codemirror/language": "^0.18.1",
+    "@codemirror/state": "^0.18.6",
+    "@codemirror/view": "^0.18.6",
+    "is-what": "^4.0.0",
+    "klona": "^2.0.4",
+    "lezer": "^0.13.4",
+    "lezer-tree": "^0.13.2",
+    "wj-util": "^1.0.0"
+  }
+}

--- a/client/modules/cm-tarnation/package.json
+++ b/client/modules/cm-tarnation/package.json
@@ -28,7 +28,7 @@
     "@codemirror/highlight": "^0.18.3",
     "@codemirror/language": "^0.18.1",
     "@codemirror/state": "^0.18.6",
-    "@codemirror/view": "^0.18.6",
+    "@codemirror/view": "^0.18.7",
     "is-what": "^4.0.0",
     "klona": "^2.0.4",
     "lezer": "^0.13.4",

--- a/client/modules/cm-tarnation/src/buffer.ts
+++ b/client/modules/cm-tarnation/src/buffer.ts
@@ -1,0 +1,355 @@
+import { search, SearchOpts } from "wj-util"
+import { TokenizerStack, SerializedTokenizerStack } from "./tokenizer"
+import { ParserElementStack, ParserStack, SerializedEmbedded } from "./parser"
+import type { Tree } from "lezer-tree"
+
+// ---- CONTEXT
+
+/** State storage class for Tarnation.
+ *  The parser and tokenizer should be able to restart if given
+ *  the information available in this object. */
+export class Context {
+  constructor(
+    public pos: number,
+    public tokenizer: TokenizerStack = new TokenizerStack(),
+    public parser: ParserStack = new ParserStack(),
+    public embed: SerializedEmbedded = { pending: [], parsers: [] }
+  ) {}
+}
+
+// ---- BUFFER
+
+/** Represents a Lezer token.
+ *  The `tree` value is for storing a reusable form of this token and its children. */
+type TokenData = [id: number, from: number, to: number, children: number, tree?: Tree]
+
+/** @see Buffer */
+type BufferElement = BufferToken | Checkpoint
+
+/** Stores the token and checkpoint information about the previous parse.
+ *  New tokens, and context snapshots ({@link Checkpoint}), are stored in this buffer. */
+export class Buffer {
+  /** The latest (by position) checkpoint in the buffer. */
+  declare lastCheckpoint?: Checkpoint
+
+  constructor(
+    /** The raw array storing the buffer's data. */
+    public buffer: BufferElement[] = [],
+    /** The previous `Buffer` linked, if any. */
+    public prev: Buffer | null = null
+  ) {}
+
+  /** Number of elements in the buffer. */
+  get length() {
+    return this.buffer.length
+  }
+
+  /** Fully compiles the buffer's data
+   *  into a {@link Tree `Tree.build`} compatible format. */
+  compile() {
+    // verbose approach to maximize speed
+    const buffer: number[] = []
+    const reused: Tree[] = []
+    for (let i = this.buffer.length - 1; i >= 0; i--) {
+      const node = this.buffer[i]
+      if (node instanceof Checkpoint) continue
+      const token = node.compile()
+      if (!token[4]) {
+        buffer.push(token[3], token[2], token[1], token[0])
+      } else {
+        const [, start, end, size, tree] = token
+        reused.push(tree)
+        const idx = reused.length - 1
+        buffer.push(-1, start + tree.length, start, idx)
+        // skip past cached tree
+        if (size >= 8) {
+          let left = (size - 4) / 4
+          while (left !== 0) {
+            i--
+            if (this.buffer[i] instanceof BufferToken) {
+              left--
+              // add a filler/repeat node using context hash
+              buffer.push(-2, end, start, 0)
+            }
+          }
+        }
+      }
+    }
+    // our buffer is inverted (push+reverse is faster than unshift usually)
+    buffer.reverse()
+    return { buffer, reused }
+  }
+
+  // get tokens() {
+  //   // verbose approach to maximize speed
+  //   const tokens: BufferToken[] = []
+  //   for (let i = this.buffer.length - 1; i >= 0; i--) {
+  //     const node = this.buffer[i]
+  //     if (node instanceof Checkpoint) continue
+  //     tokens.unshift(node)
+  //   }
+  //   return tokens
+  // }
+
+  /** Add a new token or context snapshot to the buffer. */
+  add(node: TokenData | Context) {
+    if (node instanceof Context) {
+      const checkpoint = new Checkpoint(node, this.lastCheckpoint)
+      this.buffer.push(checkpoint)
+      this.lastCheckpoint = checkpoint
+      return checkpoint
+    } else {
+      const token = new BufferToken(node, this.lastCheckpoint)
+      this.buffer.push(token)
+      return token
+    }
+  }
+
+  /** Get an element from the buffer. */
+  get(index: number) {
+    return this.buffer[index]
+  }
+
+  /** {@link search} comparator function.  */
+  private static _searchComparator = ({ pos }: BufferElement, target: number) =>
+    pos === target ? true : pos - target
+
+  /** Searches for the closest element to the given position. */
+  search(pos: number, opts?: SearchOpts) {
+    return search(this.buffer, pos, Buffer._searchComparator, opts)
+  }
+
+  /** Finds the closest {@link Context} behind the given `before` value,
+   *  but after the given `start` value. */
+  findContext(start: number, before: number) {
+    // binary search for closest position to `before`
+    let idx = this.search(before, { precise: false })?.index ?? this.buffer.length
+    for (; idx >= start; idx--) {
+      const node = this.buffer[idx]
+      if (node instanceof Checkpoint && node.pos <= before) {
+        return { context: node.context, index: idx }
+      }
+    }
+    return null
+  }
+
+  /** Cuts the buffer at the given position (or index). All elements after the given position will be removed. */
+  cut(at: number, indexed = false) {
+    let idx: number | undefined
+    if (indexed) idx = at
+    else idx = this.search(at)?.index
+
+    if (idx) {
+      const node = this.buffer[idx]
+      if (node instanceof Checkpoint) this.lastCheckpoint = node
+      else this.lastCheckpoint = node.checkpoint
+      this.buffer = this.buffer.slice(0, idx + (node instanceof BufferToken ? 0 : 1))
+      return this
+    }
+
+    throw new Error(`Failed to cut precisely! (${at})`)
+  }
+
+  /** Counts the number of checkpoints (context snapshots) in the buffer. */
+  countCheckpoints() {
+    if (!this.lastCheckpoint) return 0
+    let count = 0
+    let checkpoint: Checkpoint | undefined = this.lastCheckpoint
+    while (checkpoint) {
+      count++
+      checkpoint = checkpoint.prev
+    }
+    return count
+  }
+
+  /** Returns a copy of this buffer. */
+  clone() {
+    return new Buffer([...this.buffer])
+  }
+
+  // cursor(index?: number) {
+  //   return new BufferCursor(this, index)
+  // }
+}
+
+// export class BufferCursor {
+
+//   declare private buffer: BufferToken[]
+//   declare private index: number
+//   declare private token: TokenData
+
+//   constructor(buffer: Buffer | BufferToken[], index?: number) {
+//     if (buffer instanceof Buffer) this.buffer = buffer.tokens
+//     else this.buffer = buffer
+//     this.index = (index ?? this.buffer.length - 1) + 1
+//     this.next()
+//   }
+
+//   get id()    { return this.token[0] }
+//   get start() { return this.token[1] }
+//   get end()   { return this.token[2] }
+//   get size()  { return this.token[3] }
+//   get pos()   { return this.index * 4 }
+
+//   next() {
+//     this.index -= 1
+//     const node = this.buffer[this.index]
+//     if (node) this.token = node.token
+//   }
+
+//   fork() {
+//     return new BufferCursor(this.buffer, this.index)
+//   }
+// }
+
+/** {@link WeakMap} wrapper for accessing a
+ *  cached {@link Buffer} from a CodeMirror syntax tree. */
+export class BufferCache {
+  private map: WeakMap<Tree, Buffer> = new WeakMap()
+
+  /** Associates the given {@link Buffer} to the given tree. */
+  attach(buffer: Buffer, tree: Tree) {
+    this.map.set(tree, buffer)
+    return buffer
+  }
+
+  /** Checks if a {@link Buffer} is associated with the given tree. */
+  has(tree: Tree) {
+    return this.map.has(tree)
+  }
+
+  /** Gets the {@link Buffer} associated with the tree, if it exists. */
+  get(tree: Tree) {
+    return this.map.get(tree)
+  }
+}
+
+/** `Checkpoint` objects take in a {@link Context} and represent a parsing "snapshot".
+ *
+ *  In a {@link Buffer} all positional data is relative to the previous `Checkpoint`. */
+export class Checkpoint {
+  declare offset: number
+  declare prev?: Checkpoint
+
+  private declare last: number
+  private declare _tokenizer: SerializedTokenizerStack
+  private declare _parser: ParserElementStack
+  private declare _embed: SerializedEmbedded
+
+  constructor(context: Context, prev?: Checkpoint) {
+    this.prev = prev
+    this.last = prev ? prev.pos : 0
+    if (context) {
+      this.pos = context.pos
+      this.tokenizer = context.tokenizer
+      this.parser = context.parser
+      this.embed = context.embed
+    }
+  }
+
+  /** Ensures that all positions in the checkpoint chain are fresh
+   *  by recalculating them. */
+  update() {
+    if (this.prev) {
+      this.prev.update()
+      this.last = this.prev.pos
+    } else this.last = 0
+  }
+
+  get pos() {
+    return this.last + this.offset
+  }
+  set pos(pos: number) {
+    const offset = pos - this.last
+    if (offset < 0) throw new Error(`Bad offset position set (${pos} -> ${offset})`)
+    this.offset = offset
+  }
+
+  get tokenizer() {
+    return new TokenizerStack(this._tokenizer)
+  }
+  set tokenizer(tokenizer: TokenizerStack) {
+    this._tokenizer = tokenizer.serialize()
+  }
+
+  get parser() {
+    const stack = this._parser.map(element => {
+      const clone = [...element]
+      clone[1] = this.last + clone[1]
+      return clone
+    }) as ParserElementStack
+
+    return new ParserStack(stack)
+  }
+  set parser(parser: ParserStack) {
+    const stack = parser.serialize()
+    stack.forEach(element => (element[1] -= this.last))
+    this._parser = stack
+  }
+
+  get embed(): SerializedEmbedded {
+    const { pending, parsers } = this._embed
+    const pos = this.pos
+    return {
+      pending: [...pending],
+      parsers: parsers.map(([token, { lang, start, end }]) => [
+        token,
+        { lang, start: start + pos, end: end + pos }
+      ])
+    }
+  }
+  set embed(embed: SerializedEmbedded) {
+    const { pending, parsers } = embed
+    const last = this.last
+    this._embed = {
+      pending: [...pending],
+      parsers: parsers.map(([token, { lang, start, end }]) => [
+        token,
+        { lang, start: start - last, end: end - last }
+      ])
+    }
+  }
+
+  get context() {
+    return new Context(this.pos, this.tokenizer, this.parser, this.embed)
+  }
+}
+
+/** Represents a parsed token in the {@link Buffer}.
+ *  Tokens are positionally relative to the previous {@link Checkpoint} object. */
+export class BufferToken {
+  declare checkpoint?: Checkpoint
+
+  private declare token: TokenData
+  private declare lastOffset?: number
+  private declare lastCompile?: TokenData
+
+  constructor(token: TokenData, checkpoint?: Checkpoint) {
+    if (checkpoint) this.checkpoint = checkpoint
+    this.token = this.compile(token, -(this.checkpoint?.pos ?? 0))
+  }
+
+  get pos() {
+    return this.token[1] + (this.checkpoint?.pos ?? 0)
+  }
+
+  set tree(tree: Tree | undefined) {
+    this.token[4] = tree
+    this.lastOffset = -1
+  }
+
+  compile(_token = this.token, offset = this.checkpoint?.pos ?? 0) {
+    // verbose, fast, and cached approach. this function is executed _very_ often
+    if (offset === this.lastOffset && this.lastCompile) return this.lastCompile
+    const token: TokenData = [
+      _token[0],
+      _token[1] + offset,
+      _token[2] + offset,
+      _token[3]
+    ]
+    if (_token[4]) token[4] = _token[4]
+    this.lastOffset = offset
+    this.lastCompile = token
+    return token
+  }
+}

--- a/client/modules/cm-tarnation/src/buffer.ts
+++ b/client/modules/cm-tarnation/src/buffer.ts
@@ -250,7 +250,9 @@ export class Checkpoint {
     if (this.prev) {
       this.prev.update()
       this.last = this.prev.pos
-    } else this.last = 0
+    } else {
+      this.last = 0
+    }
   }
 
   get pos() {

--- a/client/modules/cm-tarnation/src/buffer.ts
+++ b/client/modules/cm-tarnation/src/buffer.ts
@@ -80,17 +80,6 @@ export class Buffer {
     return { buffer, reused }
   }
 
-  // get tokens() {
-  //   // verbose approach to maximize speed
-  //   const tokens: BufferToken[] = []
-  //   for (let i = this.buffer.length - 1; i >= 0; i--) {
-  //     const node = this.buffer[i]
-  //     if (node instanceof Checkpoint) continue
-  //     tokens.unshift(node)
-  //   }
-  //   return tokens
-  // }
-
   /** Add a new token or context snapshot to the buffer. */
   add(node: TokenData | Context) {
     if (node instanceof Context) {
@@ -171,6 +160,14 @@ export class Buffer {
   //   return new BufferCursor(this, index)
   // }
 }
+
+/*
+ * This chunk of code currently won't work with the current Buffer implementation, but
+ * it still may prove useful later. Currently, the functionality provided by this class
+ * is provided by Buffer's compile() function, but if it ever proves that it's desirable
+ * for the Lezer tree builder to use a cursor, rather than a precompiled list, this code
+ * can be adapted for that.
+ */
 
 // export class BufferCursor {
 

--- a/client/modules/cm-tarnation/src/grammar/definition.d.ts
+++ b/client/modules/cm-tarnation/src/grammar/definition.d.ts
@@ -1,0 +1,534 @@
+import type { Tag, tags } from "@codemirror/highlight"
+import type { NodePropSource } from "lezer-tree"
+import type { GrammarContext } from "./grammar"
+
+/** A Tarnation grammar definition. */
+export interface Grammar {
+  /** {@link Action} to fallback onto when the grammar can't find a match. */
+  fallback?: Action | ActionObject
+  /** Specifies if the grammar is case sensitive. */
+  ignoreCase?: boolean
+  /** A list of {@link Bracket} definitions.
+   *  To be used with the special `@BR` node type. */
+  brackets?: Bracket[]
+  /** A list of {@link Variable} definitions.
+   *  These can be referenced in a {@link Match}. */
+  variables?: Record<string, Variable>
+  /** The starting {@link State} of the grammar. */
+  start?: string
+  /** A list of {@link Rule} definitions (a {@link State}) that the
+   *  grammar will always try to match last. */
+  global?: State
+  /** The primary list of {@link State} definitions. */
+  states: Record<string, State>
+}
+
+/** The `Bracket` definition is a way of defining opening / closing pair nodes easily.
+ *  A bracket can be referenced in a {@link Type} using a special syntax.
+ *
+ *  `@BR</O|/C><:[hint]>`, where anything in `<>` brackets is optional.
+ *  The `/O` and `/C` symbols specify directly if the node is
+ *  an opening or closing delimiter.
+ *
+ *  Finally, you can choose not to provide the `pair` property. If `pair` isn't provided,
+ *  no actions will be generated for the brackets/delimiters, but the node names will
+ *  still be generated.
+ *  A name of `Emphasis` would be emitted as `EmphasisOpen`, `EmphasisClose`.
+ *
+ *  @example
+ *  rule = [/(\{)(.*?)(\})/, ['@BR', '', '@BR']]
+ *  rule = [/(\{)(.*?)(\})/, ['@BR/O', '', '@BR/C']]
+ *  rule = [/(\{)(.*?)(\})/, ['@BR:curly', '', '@BR:curly']] */
+export interface Bracket {
+  /** The `name` property provides the prefix for the `Open` and `Close`
+   *  nodes of the bracket.
+   *  e.g. providing `Variable` would yield the
+   *  node types `VariableOpen` and `VariableClose`. */
+  name: Type
+  /** The `pair` property is the pair of strings that specify the
+   *  opening and closing delimiters.
+   *  If only a string is provided, the string will be duplicated
+   *  into an array pair automatically. */
+  pair?: [string, string] | string
+  /** The `hint` property effectively "namespaces" a bracket.
+   *  This is so that conflicting bracket characters can be used. */
+  hint?: string
+  /** The `tag` property is a helper utility for assigning a
+   *  highlighting tag to the brackets. */
+  tag?: TagType | ""
+  /** The `parented` property is a flag for making it so that
+   *  bracket highlighting is based off the parent.
+   *  The "parent" in this case is the `name` property.
+   *
+   *  Defaults to `true` if the `pair` property isn't provided. */
+  parented?: boolean
+}
+
+/** A list of {@link Rule} definitions.
+ *  A `State` can be switched to by an {@link Action} or
+ *  simply used as reservoir of rules for other states.
+ *  To include the rules of a state into another state,
+ *  you can use an {@link IncludeDirective}. */
+export type State = (Directive | Rule | RuleState)[]
+
+/** Directives are special rules that don't have direct tokenization behavior. */
+export type Directive =
+  | IncludeDirective
+  | PropsDirective
+  | StyleDirective
+  | BracketsDirective
+  | VariablesDirective
+
+/** @see IncludeDirective#include */
+export interface IncludeDirective {
+  /** A directive that includes the rules of another {@link State}.
+   *  @example
+   *  include = { include: '#foo' } */
+  include: StateRef
+}
+
+/** @see PropsDirective#props */
+export interface PropsDirective {
+  /** A directive that allows for an inline configuration of node types.
+   *
+   *  Directives are simply stringed together as they're found.
+   *  This directive is for convinence, and doesn't have any scoping behavior.
+   *  @example
+   *  props = { props: [
+   *    NodeProp.group.add({ 'FieldDeclaration': ['Declaration'] })
+   *  ] } */
+  props: NodePropSource[]
+}
+
+/** @see StyleDirective#style */
+export interface StyleDirective {
+  /** A directive that allows for an inline configuration of node highlighting styles.
+   *  This directive is simply a shorthand for using a {@link PropsDirective}.
+   *
+   *  Directives are simply stringed together as they're found.
+   *  This directive is for convinence, and doesn't have any scoping behavior.
+   *  @example
+   *  style = { style: {
+   *    'Function': t.function(t.name)
+   *  } } */
+  style: Record<string, Tag | readonly Tag[] | undefined>
+  // typescript bug makes me require undefined here, I have no idea why
+}
+
+/** @see BracketsDirective#brackets */
+export interface BracketsDirective {
+  /** A directive that allows defining {@link Bracket} definitions inline.
+   *
+   *  Directives are simply stringed together as they're found.
+   *  This directive is for convinence, and doesn't have any scoping behavior.
+   *  @example
+   *  brackets = { brackets: [
+   *    { name: 'BlockComment', tag: 't.blockComment' }
+   *  ] } */
+  brackets: Bracket[]
+}
+
+/** @see VariablesDirective#variables */
+export interface VariablesDirective {
+  /** A directive that allows defining {@link Variable} definitions inline.
+   *
+   *  Directives are simply stringed together as they're found.
+   *  This directive is for convinence, and doesn't have any scoping behavior.
+   *
+   *  There is a caveat to that last statement - variables are fetched and
+   *  stored _as they're found_, not before any rules are processed.
+   *  You need to declare variables - when they're inline - before a rule
+   *  can use them.
+   *
+   *  Additionally, variables are added by merging the new variables
+   *  into the global variables object.
+   *  This means that variables - when inline - can overwrite each other.
+   *  @example
+   *  variables = { variables: {
+   *    keywords: ['const', 'let', 'var']
+   *  } } */
+  variables: Record<string, Variable>
+}
+
+/** A `Rule` is a definition that, altogether,
+ *  describes a {@link Match} <-> {@link Action} pair.
+ *  It can be given either as a terse array or a verbose object.
+ *  As an array, it has a very loose syntax.
+ *
+ *  An array rule has the following order(s):
+ *  ```raw
+ *  [match -> type? -> group? -> next? -> extraOptions?]
+ *  [match -> substate]
+ *  ```
+ *  @example
+ *  rule = [/(\{\$)(.*?)(\})/, 'IncludeVariable', ['@BR:vi', 't.variableName', '@BR:vi']]
+ *  rule = [/@@.*?@@/, 't.escape']
+ *  rule = [/(@bsc)(\S+?)(\s*@be)/, 'BlockContainerNode', [
+ *    't.bracket',
+ *    { optional: false, state: [['module', 't.keyword'], [/\S+?/, 't.tagName']] },
+ *    't.bracket'
+ *  ], { parser: '>>/BlockContainer' }]
+ *  @see Match
+ *  @see Action
+ *  @see SubState */
+export type Rule = RuleArray | RuleObject
+
+// prettier-ignore
+type RuleArray =
+  | [match: Match]
+  | [match: Match, ...action: Action ]
+
+type RuleObject = { match: Match } & (ActionObject | SubState)
+
+// prettier-ignore
+/** An `Action` definition tells the grammar what
+ *  to do when a {@link Rule} has {@link Match | matched} something.
+ *  It can be given either as a terse array or a verbose object.
+ *  As an array, it has a very loose syntax.
+ *
+ *  An array rule has the following order(s):
+ *  ```text
+ *  [type? -> group? -> next? -> extraOptions?]
+ *  [type? -> substate?]
+ *  ```
+ *  @see ActionObject for info on the properties that can be given.
+ *  @see Rule for more info and examples. */
+export type Action =
+  | [action: ActionObject]
+  | [substate: SubState]
+  | [type: Type, substate: SubState]
+  | [type: Type,                             opts?: ActionObject]
+  | [type: Type, group?: Group, next?: Next, opts?: ActionObject]
+  | [type: Type,                next?: Next, opts?: ActionObject]
+  | [type: Type, group?: Group,              opts?: ActionObject]
+  | [            group:  Group,              opts?: ActionObject]
+  | [            group:  Group, next?: Next, opts?: ActionObject]
+
+/** Verbose object variant of an {@link Action}.
+ *
+ * | | |
+ * | :-- | :-- |
+ * | `type`     | Assigns the matched text to the specified type.                     |
+ * | `group`    | Assigns additional actions to the capturing groups of the match.    |
+ * | `next`     | Pushes, or pops states from the stack.                              |
+ * | `switchTo` | Switches to states without pushing additional states on the stack.  |
+ * | `embedded` | Informs the parser what language to nest with, or to stop.          |
+ * | `parser`   | Directs the parser to open or close syntax blocks.                  |
+ * | `context`  | Mutates a persistent context object.                                |
+ * | `log`      | Logs a message whenever the associated rule is matched.             */
+export interface ActionObject {
+  /** The `type` specifies what node type matched text should be "scoped" or "tagged"
+   *  with in the emitted tree.
+   *  It can be specified in a few different ways:
+   *  ```text
+   *  '[Name]'      | Capitalized custom scope name.
+   *  't.[tagname]' | Shorthand for automatically using a CodeMirror highlighting tag.
+   *  '@RE'         | Special type that causes the tokenizer to completely reverse the
+   *                  current match's progress, and then restart the tokenizer from that
+   *                  point again. The purpose is that state changes are still processed.
+   *                  This allows you to 'cancel' or 'lookahead' with state changes.
+   *  '@BR'         | See `Bracket` for usage.
+   *  ```
+   *  @example
+   *  rule = [/foo/, 'CustomName']
+   *  rule = [/foo/, 't.keyword']
+   *  rule = [/foo/, '@RE']
+   *  rule = [/foo/, '@BR']
+   *  @see Bracket */
+  type?: Type
+  /** Describes a group of {@link Action} objects.
+   *  Each particular `Action` is associated, in order, to the capturing
+   *  groups of a rule's regex.
+   *  If there is no capturing groups, the group itself is invalid.
+   *  @example
+   *  rule = [/(match1)(match2)(match3)/, [action1, action2, action3]] */
+  group?: Group
+  /** The {@link Next} {@link State} to go to before the next match.
+   *  A state's name must be preceeded with a `#`.
+   *
+   *  It can take three special values: `@pop`, `@popall`, and `@push`.
+   *
+   *  This property can be used with a {@link Substitute}.
+   *  @example
+   *  action = { next: '#next_state' }
+   *  action = { next: '@pop' } */
+  next?: Next | Substitute
+  /** The `switchTo` property is like the `next` property,
+   *  except the state specified is switched to without altering the stack.
+   *
+   *  Special {@link Next} values can't be used with this property.
+   *
+   *  This property can be used with a {@link Substitute}.
+   *  @see Next */
+  switchTo?: StateRef | Substitute
+  /** The `parser` property attaches special meaning to the tokens it is defined on.
+   *  Tokens with this property inform the parser to make special decisions
+   *  regarding opening and closing syntax nodes.
+   *
+   *  The syntax for the property is:
+   *  `[mode][type]`, where `[type]` is any non-special {@link Type},
+   *  and `[mode]` is either `>>` or `<<`. `>>` is _inclusive_, and `<<` is _exclusive_.
+   *  Following the arrows with a `/` indicates closing, rather than opening.
+   *  @example
+   *  action = { parser: '>>BlockComment' }
+   *  action = { parser: '>>/BlockComment' }
+   *  action = { parser: ['<<BlockNode', '>>/BlockContainer'] } */
+  parser?: ParserTarget | ParserTarget[]
+  /** The `embedded` property looks somewhat like the `next` property,
+   *  but instead of states it nests embedded languages.
+   *  Unlike `next`, you cannot stack `embedded`.
+   *  It is more like a flag that is set, with the tokenizer tracking what range of text
+   *  should be filled in with the specified language.
+   *
+   *  If an exclamation mark is found at the end of the language name, that will signify
+   *  to the tokenizer that the language should be embedded for only this token.
+   *
+   *  Do note: if you use this feature, other properties of the rule won't be considered
+   *  when tokenizing.
+   *
+   *  This property can be used with a {@link Substitute}. */
+  embedded?: "@pop" | `${Substitute | string}${"!" | ""}`
+  /** The `context` property modifies the current stack context.
+   *  These values are "merged" into the current context, rather than replacing the
+   *  current context in its entirety.
+   *
+   *  You can use the value of a `context` property in any {@link Substitute} property.
+   *  To do this, you use the `::[key]` syntax.
+   *
+   *  Additionally, the value of the keys can accept substitutions.
+   *  @example
+   *  action = { context: { myValue: 'foo' } }
+   *  rule = ['::myValue', 'foo', 'SomeAction'] */
+  context?: Context
+  /** The `log` property logs (with `console.log`) the
+   *  specified message whenever the associated rule is matched.
+   *
+   *  This property can be used with {@link Substitute} anywhere in the message. */
+  log?: string
+}
+
+/** Describes a group of {@link Action} objects.
+ *
+ *  Each `Action` is associated, in order, to the 'capturing' groups of a {@link Match}.
+ *  If there are no capturing groups, or a disjointed quantity, the group will throw.
+ *  @example
+ *  rule = [/(match1)(match2)(match3)/, [action1, action2, action3]] */
+export type Group = (Type | Action | ActionObject | SubState)[]
+
+/** A `SubState` definition is a {@link State} syntax that the grammar can "fall into".
+ *  This allows a parser to take matched text and _parse it again_.
+ *  The results will be inserted into the final group of matches.
+ *
+ *  This definition extends {@link ActionObject} - but excludes the `group` property.
+ *
+ *  | | |
+ *  | :-- | :-- |
+ *  | `repeat`   | Sets the state to repeat until the entire string is consumed.      |
+ *  | `optional` | Determines if the substate is allowed to fail to match any rules.  |
+ *  | `all`      | Determines if the substate must match every character to be valid. |
+ *  | `strict`   | Helper to set the `repeat`, `optional`, and`all` properties.       |
+ *  | `state`    | List of substate rules.                                           */
+export interface SubState extends Omit<ActionObject, "group"> {
+  /** The `repeat` property specifies if the substate will repeatedly match
+   *  against the captured string.
+   *  If it is false, the substate can only match one rule before the substate is exited.
+   *
+   *  Defaults to `true` if `strict` is false. */
+  repeat?: boolean
+  /** The `optional` property specifies if it is valid to fail to match any rule.
+   *  If it is false, then the substate _must_ match for it not to invalidate the rule.
+   *
+   *  Defaults to `true` if `strict` is false. */
+  optional?: boolean
+  /** The `all` property specifies if the substate must provide a token
+   *  for every character of the captured string.
+   *
+   * Defaults to `false` if `strict` is false. */
+  all?: boolean
+  /** The `strict` property is a helper property which sets the
+   *  properties `repeat`, `optional`, and `all` to
+   *  `false`, `false`, and `true` respectively.
+   *
+   * Defaults to `true`. */
+  strict?: boolean
+  /** The `rules` property is the list of {@link Rule}, {@link SubRule},
+   *  or {@link IncludeDirective} definitions for the state.
+   *
+   *  Alternatively, a state reference (e.g. `'#foo'`) can be provided,
+   *  which acts like an {@link IncludeDirective}. */
+  rules: (Directive | SubRule | Rule | RuleState)[] | StateRef
+}
+
+/** A special type of {@link Rule} that allows for a `target` property to be provided.
+ *  The `target` property is a {@link Substitute} string that specifies what the
+ *  rule's {@link Match} will test against.
+ *
+ *  It is important to note that the subrule's match will be _inherited_, rather than
+ *  capturing strings from the specified target. */
+export type SubRule =
+  | [target: SubRuleTarget, ...rule: RuleArray]
+  | ({ target: SubRuleTarget } & RuleObject)
+
+// TODO: document
+export interface RuleState {
+  begin: Rule
+  end: Rule
+  type?: TagType | CustomType | ""
+  embedded?: `${Substitute | string}!`
+  rules?: StateRef | (Directive | Rule | RuleState)[]
+}
+
+/** A special function can be provided in place of a {@link Matchable}.
+ *  It is valid to return `[]`, an empty array.
+ *  This signifies a successful match - but doesn't advance the input. */
+export type MatchFunction = (
+  cx: GrammarContext,
+  str: string,
+  pos: number
+) => string[] | null
+
+// Basic Types
+
+// sins... deep sins
+// prettier-ignore
+type Alphabet =
+  |'A'|'B'|'C'|'D'|'E'|'F'|'G'|'H'|'I'|'J'|'K'|'L'|'M'
+  |'N'|'O'|'P'|'Q'|'R'|'S'|'T'|'U'|'V'|'W'|'X'|'Y'|'Z'
+
+/** The `type` specifies what node type matched text should be "scoped" or
+ *  "tagged" with in the emitted tree.
+ *  It can be specified in a few different ways:
+ *  ```raw
+ *  '[Name]'      | Capitalized custom scope name.
+ *  't.[tagname]' | Shorthand for automatically using a CodeMirror highlighting tag.
+ *  '@RE'         | Special type that causes the tokenizer to completely reverse the
+ *                  current match's progress, and then restart the tokenizer from that
+ *                  point again. The purpose is that state changes are still processed.
+ *                  This allows you to 'cancel' or 'lookahead' with state changes.
+ *  '@BR'         | See `Bracket` for usage.
+ *  ```
+ *  @example
+ *  rule = [/foo/, 'CustomName']
+ *  rule = [/foo/, 't.keyword']
+ *  rule = [/foo/, '@RE']
+ *  rule = [/foo/, '@BR']
+ *  @see Bracket */
+export type Type = SpecialType | TagType | CustomType | ""
+
+/** Ordinary node type. */
+type CustomType = `${Alphabet}${string}`
+/** CodeMirror highlighting tag. */
+type TagType = `t.${keyof typeof tags}`
+/** Special rematching or bracket shorthand tag. */
+type SpecialType = "@RE" | `@BR${"/O" | "/C" | ""}${`:${string}` | ""}`
+
+/** References a key in the grammar's current {@link Context} object. */
+export type ContextRef = `::${string}`
+/** References a variable in the grammar's {@link Language#variables} object. */
+export type VariableRef = `@${string}`
+/** References a named state in the grammar's {@link Language#states} object. */
+export type StateRef = `#${string}`
+
+/** Most {@link Action} properties can make use of _substitutions_,
+ *  which are literal substitutions (substring replacement)
+ *  derived from either the matched text or the current state/sub-states.
+ *
+ *  | | |
+ *  | :-- | :-- |
+ *  | `$#`        | Substitutes the rule's match, or match group in a group match.   |
+ *  | `$[n]`      | Substitutes for the *n*th group. The entire match is group `$0`. |
+ *  | `$S`        | Substitutes the current state of the grammar.                    |
+ *  | `::[name]`  | Substitutes for a key in the current {@link Context} object.     | */
+export type Substitute = `\$${"S" | "#" | number}` | ContextRef
+
+/** @see SubRule */
+export type SubRuleTarget = Substitute
+
+/** A `variable` is a referrable {@link Match}-like object
+ *  (string, string array, or regex).
+ *  It can be referenced through the `@[var]` syntax inside of a match.
+ *  @example
+ *  control = /[>+-]/
+ *  rule = [/\w+(?!@control)/] */
+export type Variable = RegExp | string | string[] | MatchFunction
+
+/** Specifies a {@link State} to go to. A state's name must be preceeded with a `#`.
+ *
+ *  Can take three special values: `@pop`, `@popall`, and `@push`.
+ *  @example
+ *  action = { next: '#next_state' }
+ *  action = { next: '@pop' } */
+export type Next = "@push" | "@popall" | "@pop" | StateRef
+
+/** A `match`, or `matcher`, describes a pattern to match against text.
+ *
+ *  This pattern ({@link Matchable}), which can be by itself or in a chain of patterns,
+ *  is either a: `RegExp`, `string`, {@link Substitute}, or a {@link MatchFunction}.
+ *  Using a `string` is preferred, as this uses a more optimized method than a regex.
+ *
+ *  You can reference any {@link Variable} using the `@[var]` syntax.
+ *
+ *  With a `RegExp` match, Tarnation supports full lookahead and lookbehind,
+ *  up to a certain search length.
+ *  @example
+ *  rule = [/foo/, 'bar']
+ *  rule = ['foo', 'bar']
+ *  rule = [[/foo/, /bar/, /@variable/], 'bar']
+ *  rule = [['foo', '@variable1', /@variable2/], 'bar']
+ *  @see Matchable */
+export type Match = Matchable | Matchable[] | "@DEFAULT"
+
+/** A {@link Match} compatible pattern.
+ *  If null, this signifies an error - this is to allow a grammar to
+ *  safely ignore an errored rule. */
+export type Matchable = MatchFunction | RegExp | string | Substitute | null
+
+/** Defines a set of values to be added to the current stack context.
+ *  These values are "merged" into the current context, rather than replacing the current
+ *  context in its entirety.
+ *
+ *  You can use the value of the current `context` in any {@link Substitute} property.
+ *  To do this, you use the `::[key]` syntax.
+ *
+ *  Additionally, the value of the keys can accept substitutions.
+ *  @example
+ *  action = { context: { myValue: 'foo' } }
+ *  rule = ['::myValue', 'foo', 'SomeAction'] */
+export type Context = Record<string, string | undefined>
+
+/** Describes a `parser` directive for how to handle the nesting of nodes.
+ *
+ *  The syntax is: `[mode][type]`, where `[type]` is any non-special {@link Type},
+ *  and `[mode]` is either `>>` or `<<`. `>>` is _inclusive_, and `<<` is _exclusive_.
+ *  Following the arrows with a `/` indicates closing, rather than opening.
+ *
+ *  This type can be used with a {@link Substitute}.
+ *
+ *  Note: For the sake of TypeScript performance, the string template of this
+ *  type is simplified. Regardless, it only accepts what a
+ *  non-special {@link Type} would accept.
+ *
+ *  ```ts
+ *  // actual type
+ *  type ParserTarget =
+ *    `${'<<' | '>>' | '<</' | '>>/'}${TagType |  CustomType | Substitute}`
+ *  ```
+ *  @example
+ *  action = { parser: '>>BlockComment' }
+ *  action = { parser: '>>/BlockComment' }
+ *  action = { parser: ['<<BlockNode', '>>/BlockContainer'] }
+ *  @see Type */
+export type ParserTarget =
+  | PTInclusiveOpen
+  | PTInclusiveClose
+  | PTExclusiveOpen
+  | PTExclusiveClose
+
+/** Inclusively open a nesting element. */
+type PTInclusiveOpen = `${">>"}${string}`
+/** Inclusively close a nesting element. */
+type PTInclusiveClose = `${">>/"}${string}`
+/** Exclusively open a nesting element. */
+type PTExclusiveOpen = `${"<<"}${string}`
+/** Exclusively close a nesting element. */
+type PTExclusiveClose = `${"<</"}${string}`

--- a/client/modules/cm-tarnation/src/grammar/demangler.ts
+++ b/client/modules/cm-tarnation/src/grammar/demangler.ts
@@ -1,0 +1,219 @@
+import { isArray, isObjectLike, isString } from "is-what"
+import { klona } from "klona"
+import { has, hasSigil, removeUndefined, unSigil } from "wj-util"
+import type * as DF from "./definition"
+
+export type ParserAction = [type: string, inclusive: number][]
+
+export interface Grammar {
+  fallback?: Action
+  ignoreCase?: boolean
+  brackets?: DF.Bracket[]
+  variables?: Record<string, DF.Variable>
+  start?: string
+  global?: (DF.Directive | Rule | RuleState)[]
+  states: Record<string, (DF.Directive | Rule | RuleState)[]>
+}
+
+export interface Rule {
+  target?: DF.SubRuleTarget
+  match?: DF.Match
+  action?: Action
+}
+
+export interface RuleState {
+  begin: Rule
+  end: Rule
+  type?: string
+  embedded?: `${DF.Substitute | string}!`
+  rules?: string | (DF.Directive | Rule | RuleState)[]
+}
+
+export interface Action {
+  type?: string
+  group?: Action[]
+  next?: string
+  open?: ParserAction
+  close?: ParserAction
+  switchTo?: string
+  embedded?: string
+  context?: string
+  log?: string
+  repeat?: boolean
+  optional?: boolean
+  all?: boolean
+  strict?: boolean
+  rules?: string | (DF.Directive | Rule | RuleState)[]
+}
+
+type RuleDefs = DF.Directive | DF.SubRule | DF.Rule | DF.RuleState
+
+export function demangleGrammar(grammar: DF.Grammar): Grammar {
+  const { variables, start, ignoreCase, global, fallback, brackets, states } = grammar
+
+  // demangle states
+  const newStates: Record<string, (DF.Directive | Rule | RuleState)[]> = {}
+  if (states) {
+    for (const state in states) {
+      newStates[state] = states[state].map(rule => demangleRule(rule))
+    }
+  }
+
+  // merge what we can
+  const demangled: Grammar = { variables, start, ignoreCase, brackets, states: newStates }
+
+  if (fallback) demangled.fallback = demangleAction(fallback)
+  if (global) demangled.global = global.map(rule => demangleRule(rule))
+
+  return removeUndefined(demangled)
+}
+
+export function demangleRule(rule: RuleDefs): DF.Directive | Rule | RuleState {
+  if (
+    "include" in rule ||
+    "props" in rule ||
+    "style" in rule ||
+    "brackets" in rule ||
+    "variables" in rule
+  ) {
+    if ("include" in rule) return { include: unSigil(rule.include, "#") }
+    return rule
+  }
+
+  if ("begin" in rule) {
+    const { begin, end, type, embedded, rules } = rule
+    return removeUndefined({
+      begin: demangleRule(begin) as Rule,
+      end: demangleRule(end) as Rule,
+      type: demangleType(type),
+      embedded,
+      rules: rules
+        ? isString(rules)
+          ? demangleNext(rules)
+          : rules.map(rule => demangleRule(rule))
+        : undefined
+    })
+  }
+
+  let target!: DF.Substitute
+  let match!: DF.Match
+  let action!: string | DF.Action | DF.ActionObject | DF.SubState | []
+
+  if (isArray(rule)) {
+    if (isSubRule(rule)) [target, match, ...action] = rule
+    else [match, ...action] = rule
+  } else if (isSubRule(rule)) {
+    ;({ target, match, ...action } = rule)
+  } else {
+    ;({ match, ...action } = rule)
+  }
+
+  return removeUndefined({ target, match, action: demangleAction(action) })
+}
+
+export function demangleAction(
+  action: string | DF.Action | DF.ActionObject | DF.SubState | []
+): Action {
+  if (isString(action)) return { type: demangleType(action) }
+
+  let parsed: any = {}
+
+  if (!isArray(action)) parsed = klona(action) as Action
+  // incompatible types are addressed later
+  else {
+    const [idx0, idx1, idx2] = klona(action)
+
+    // check for substate
+    if (isObjectLike<DF.SubState>(idx0)) {
+      parsed = idx0
+    } else if (isString(idx0) && isObjectLike<DF.SubState>(idx1)) {
+      parsed = { type: idx0, ...idx1 }
+    }
+    // normal action
+    else {
+      // find action object - if it exists
+      const last = action[action.length - 1]
+      if (last && !isString(last) && !isArray(last) && !has("rules", last)) {
+        parsed = klona(last) as DF.ActionObject
+      }
+
+      // check idx0 (type string or group)
+      if (isString(idx0)) parsed.type = idx0
+      else if (isArray(idx0)) parsed.group = idx0
+
+      // check idx1 (next or group)
+      if (isString(idx1)) parsed.next = idx1
+      else if (isArray(idx1)) parsed.group = idx1
+
+      // check idx2 (next)
+      if (isString(idx2)) parsed.next = idx2
+
+      // idx3 will always be undefined or opts
+    }
+  }
+
+  // demangle group
+  if (parsed.group) {
+    const groups: Action[] = []
+    for (const action of parsed.group as DF.Group) {
+      groups.push(demangleAction(action))
+    }
+    parsed.group = groups
+  }
+
+  // demangle rules
+  if (parsed.rules) {
+    if (isString(parsed.rules)) {
+      parsed.rules = demangleNext(parsed.rules)
+    } else {
+      const rules: (DF.Directive | Rule | RuleState)[] = []
+      for (const rule of parsed.rules) {
+        rules.push(demangleRule(rule))
+      }
+      parsed.rules = rules
+    }
+  }
+
+  if (parsed.parser) {
+    const { open, close } = demangleParser(parsed.parser)
+    delete parsed.parser
+    parsed.open = open
+    parsed.close = close
+  }
+
+  // unmangle shorthands and sigil characters
+  const { type, next, switchTo } = parsed as Action
+  if (type) parsed.type = unSigil(type, "t.")
+  if (next) parsed.next = unSigil(next, "#")
+  if (switchTo) parsed.switchTo = unSigil(switchTo, "#")
+
+  return removeUndefined(parsed)
+}
+
+function demangleType(str?: string) {
+  if (!str) return undefined
+  return unSigil(str, "t.")
+}
+
+function demangleNext(str?: string) {
+  if (!str) return undefined
+  return unSigil(str, "#")
+}
+
+function demangleParser(parser: DF.ParserTarget | DF.ParserTarget[]) {
+  const open: ParserAction = []
+  const close: ParserAction = []
+  ;(isArray(parser) ? parser : [parser]).forEach(parse => {
+    const opening = parse[2] !== "/"
+    const inclusive = +hasSigil(parse, ">>")
+    const type = unSigil(parse, ["t.", ">>", "<<", "/"]) as any
+    ;(opening ? open : close).push([type, inclusive])
+  })
+  return { open, close }
+}
+
+function isSubRule(rule: DF.Directive | DF.Rule | DF.SubRule): rule is DF.SubRule {
+  if (!rule) return false
+  if (isArray(rule)) return hasSigil(rule[0], ["$", "::"])
+  return "target" in rule
+}

--- a/client/modules/cm-tarnation/src/grammar/grammar.ts
+++ b/client/modules/cm-tarnation/src/grammar/grammar.ts
@@ -1,0 +1,852 @@
+import {
+  createID,
+  escapeRegExp,
+  has,
+  hasSigil,
+  pointsMatch,
+  unSigil,
+  removeUndefined,
+  toPoints
+} from "wj-util"
+import { styleTags, tags } from "@codemirror/highlight"
+import { NodeProp, NodePropSource } from "lezer-tree"
+import { isArray, isFunction, isRegExp, isString } from "is-what"
+import { demangleGrammar } from "./demangler"
+import { klona } from "klona"
+import type * as DF from "./definition"
+import type * as DM from "./demangler"
+
+/** Stores information about the current state of the {@link Grammar Grammar's} match. */
+export interface GrammarContext {
+  state: string
+  context: DF.Context
+  last?: string[]
+  target?: DF.SubRuleTarget
+  substate?: SubState
+}
+
+/** Represents an individual token emitted by a {@link Grammar}. */
+export interface GrammarToken {
+  type: string
+  from: number
+  to: number
+  empty: boolean
+
+  open?: ParserAction
+  close?: ParserAction
+  next?: string
+  switchTo?: string
+  embedded?: string
+  context?: DF.Context
+}
+
+/** Directs the parser to nest tokens. */
+type ParserAction = [type: string, inclusive: number][]
+
+const SUB_REGEX = /\$(?:S|#|\d+)|::\S+/g
+const BRACKET_REGEX = /@BR(\/[OC])?(?::(.+))?/
+
+export class Grammar {
+  private declare grammar: DM.Grammar
+
+  declare ignoreCase: boolean
+  declare variables: Record<string, DF.Variable>
+  declare start: string
+  declare fallback: Action
+
+  types = new Set<string>()
+  props: NodePropSource[] = []
+
+  private declare global: Set<number>
+
+  private brackets = new Map<string, Action>()
+  private rules = new Map<number, Rule>()
+  private states = new Map<string | SubState, Set<number>>()
+
+  private includeMap = new Map<Set<number>, Set<string>>()
+
+  constructor(def: DF.Grammar) {
+    const grammar = demangleGrammar(def)
+    const { ignoreCase = false, variables = {}, start = "root" } = grammar
+
+    this.grammar = grammar
+    this.ignoreCase = ignoreCase
+    this.variables = variables
+    this.start = start
+
+    this.init(grammar)
+  }
+
+  private init(def: DM.Grammar) {
+    const { fallback, brackets = [], global = [], states } = def
+
+    if (fallback) this.fallback = new Action(this, fallback)
+
+    this.global = this.addRules(global)
+
+    for (const bracket of brackets) this.addBracket(bracket)
+    for (const name in states) this.addState(name)
+
+    this.includeMap.forEach((includes, state) => {
+      for (const include of includes) {
+        const ids = this.addState(include)
+        ids.forEach(id => state.add(id))
+      }
+    })
+  }
+
+  // PUBLIC UTILITY METHODS
+
+  static sub(
+    { context = {}, state = "", last: [total = "", ...captures] = [] }: GrammarContext,
+    str: string
+  ) {
+    return str.replace(SUB_REGEX, (sub: string) => {
+      if (sub === "$#") return total
+      if (sub === "$S") return state
+      if (sub.startsWith("::")) return context[sub.slice(2)] ?? ""
+      return [total, ...captures][parseInt(sub.slice(1))] ?? ""
+    })
+  }
+
+  static variableForRegex(variable?: DF.Variable | null) {
+    if (isString(variable)) return escapeRegExp(variable)
+    if (isRegExp(variable)) return variable.source
+    if (isArray(variable)) return variable.map(str => escapeRegExp(str)).join("|")
+    return null
+  }
+
+  static variableForString(variable?: DF.Variable | null) {
+    if (isString(variable)) return variable
+    if (isRegExp(variable)) return variable.source
+    return null
+  }
+
+  /** Resolves and replaces the `@` variables in a `RegExp` or `string`. */
+  static expand(vars: Record<string, DF.Variable>, input: string | RegExp) {
+    const regex = isRegExp(input)
+    let count = 0
+    let str = regex ? (input as RegExp).source : (input as string)
+    while (/@\w/.test(str) && count < 5) {
+      count++
+      str = str.replace(/@(\w+)/g, (_, ident: string) => {
+        const variable = regex
+          ? this.variableForRegex(vars[ident])
+          : this.variableForString(vars[ident])
+        if (!variable) return ""
+        return regex ? `(?:${variable})` : variable
+      })
+    }
+    return str
+  }
+
+  // BRACKETS
+
+  // str_::_mode_::_hint
+  private static makeBracketString(str: string, mode: boolean | null, hint: string) {
+    return `${str}${mode !== null ? `_::_${mode ? "open" : "close"}` : ""}${
+      hint ? `_::_${hint}` : ""
+    }`
+  }
+
+  findBracket(str: string, type: string) {
+    if (!BRACKET_REGEX.test(type)) return null
+    const [, modeStr, hint = ""] = BRACKET_REGEX.exec(type)!
+    const mode = modeStr === "/O" ? true : modeStr === "/C" ? false : null
+    const bracket = Grammar.makeBracketString(str, mode, hint)
+    return this.brackets.get(bracket) ?? null
+  }
+
+  private addBracket({ name, pair, hint = "", tag, parented }: DF.Bracket) {
+    if (name.indexOf("_::_") !== -1) throw new Error("Invalid bracket name!")
+
+    const tagged = hasSigil(name, "t.")
+    const openType = tagged ? unSigil(name, "t.") : (`${name}Open` as DF.Type)
+    const closeType = tagged ? unSigil(name, "t.") : (`${name}Close` as DF.Type)
+
+    if (pair) {
+      const [open, close] = isString(pair) ? [pair, pair] : pair
+
+      const openAction = new Action(this, { type: openType })
+      const closeAction = new Action(this, { type: closeType })
+
+      if (open !== close) {
+        this.brackets.set(Grammar.makeBracketString(open, null, hint), openAction)
+        this.brackets.set(Grammar.makeBracketString(close, null, hint), closeAction)
+      }
+
+      this.brackets.set(Grammar.makeBracketString(open, true, hint), openAction)
+      this.brackets.set(Grammar.makeBracketString(close, false, hint), closeAction)
+    } else {
+      this.types.add(unSigil(openType, "t."))
+      this.types.add(unSigil(closeType, "t."))
+    }
+
+    if (!tagged) {
+      if (parented === undefined && !pair) parented = true
+      const parent = parented ? `${name}/` : ""
+      this.props.push(
+        NodeProp.openedBy.add({ [closeType]: [openType] }),
+        NodeProp.closedBy.add({ [openType]: [closeType] })
+      )
+      if (tag) {
+        this.props.push(
+          styleTags({
+            [`${parent}${openType} ${parent}${closeType}`]: (tags as any)[tag.slice(2)]!
+          })
+        )
+      }
+    }
+  }
+
+  // RULES
+
+  private addRule(def: DM.Rule) {
+    const id = this.rules.size
+    this.rules.set(id, null as any) // takes the rule slot to avoid rules being overwritten
+    const rule = new Rule(this, id, def)
+    this.rules.set(id, rule)
+    return rule
+  }
+
+  private addRules(rules: (DF.Directive | DM.Rule | DM.RuleState)[]): Set<number> {
+    const ids = new Set<number>()
+    const includes = new Set<string>()
+    this.includeMap.set(ids, includes)
+
+    for (const rule of rules) {
+      // include directive
+      if ("include" in rule) {
+        this.addState(rule.include)
+        includes.add(rule.include)
+      }
+      // props directive
+      else if ("props" in rule) {
+        this.props.push(...rule.props)
+      }
+      // style directive
+      else if ("style" in rule) {
+        this.props.push(styleTags(removeUndefined(rule.style)))
+      }
+      // brackets directive
+      else if ("brackets" in rule) {
+        for (const bracket of rule.brackets) this.addBracket(bracket)
+      }
+      // variables directive
+      else if ("variables" in rule) {
+        Object.assign(this.variables, rule.variables)
+      }
+      // rule state
+      else if ("begin" in rule) {
+        try {
+          const state = createID("rule-state")
+
+          const { embedded, type, rules } = rule
+
+          const begin = klona(rule.begin)
+          const end = klona(rule.end)
+
+          begin.action ??= {}
+          end.action ??= {}
+
+          if (type) {
+            begin.action.open ??= []
+            end.action.close ??= []
+            begin.action.open.unshift([type, 1])
+            end.action.close.push([type, 1])
+          }
+
+          if (embedded || rules) {
+            begin.action.next = state
+            end.action.next = "@pop"
+          }
+
+          if (embedded) {
+            begin.action.embedded = embedded.slice(0, embedded.length - 1)
+            end.action.embedded = "@pop"
+          }
+
+          if (embedded) {
+            this.states.set(state, new Set([this.addRule(end).id]))
+          } else if (rules) {
+            const stateRules = [end, ...(isString(rules) ? [{ include: rules }] : rules)]
+            this.states.set(state, this.addRules(stateRules as any))
+          }
+
+          ids.add(this.addRule(begin).id)
+          if (!embedded && !rules) ids.add(this.addRule(end).id)
+        } catch (err) {
+          console.warn("Grammar: Failed to add rule state. Ignoring...")
+          console.info(rule)
+        }
+      }
+      // normal rule
+      else {
+        try {
+          ids.add(this.addRule(rule).id)
+        } catch (err) {
+          console.warn("Grammar: Failed to add rule. Ignoring...")
+          console.info(rule)
+        }
+      }
+    }
+    return ids
+  }
+
+  // STATES
+
+  addState(name: string): Set<number> {
+    if (this.states.has(name)) return this.states.get(name)!
+    const states = this.grammar.states
+    const state = states[name]
+    if (!state) throw new Error("Undefined state specified in grammar!")
+
+    this.states.set(name, new Set()) // prevents cyclic
+    const ids = this.addRules(state)
+    this.states.set(name, ids)
+
+    return ids
+  }
+
+  addSubstate(
+    substate: SubState,
+    rules: (DF.Directive | DM.Rule | DM.RuleState)[] | Set<number>
+  ) {
+    if (this.states.has(substate)) return this.states.get(substate)!
+
+    this.states.set(substate, new Set()) // prevents cyclic
+    const ids = rules instanceof Set ? rules : this.addRules(rules)
+    this.states.set(substate, ids)
+
+    return ids
+  }
+
+  // MATCH
+
+  match(cx: GrammarContext, str: string, pos: number, offset = 0): Matched | null {
+    const ids = this.states.get(cx.substate ?? cx.state)
+    if (!ids) throw new Error("Undefined state specified in grammar!")
+
+    for (const id of ids) {
+      const rule = this.rules.get(id)!
+      const matches = rule.exec(cx, str, pos)
+      if (!matches) continue
+      if (offset !== pos) matches.offset = offset
+      if (rule.log) console.log(rule.log)
+      return matches
+    }
+
+    if (!cx.substate?.strict) {
+      for (const id of this.global) {
+        const rule = this.rules.get(id)!
+        const matches = rule.exec(cx, str, pos)
+        if (!matches) continue
+        if (offset !== pos) matches.offset = offset
+        if (rule.log) console.log(rule.log)
+        return matches
+      }
+    }
+
+    if (this.fallback) return new Matched(str[pos], this.fallback, offset, cx.context)
+
+    return null
+  }
+}
+
+export class Rule {
+  declare log?: string
+
+  private declare target?: DF.SubRuleTarget
+  private declare matcher: Matcher | "@DEFAULT"
+  private declare action: Action
+
+  constructor(grammar: Grammar, public id: number, rule: DM.Rule) {
+    const { target, match, action } = rule
+
+    if (!match) throw new Error("Rule must have a Match!")
+
+    if (target) this.target = target
+
+    if (match === "@DEFAULT") this.matcher = "@DEFAULT"
+    else this.matcher = new Matcher(grammar, match)
+
+    this.action = new Action(grammar, action)
+    if (this.action.log) this.log = this.action.log
+  }
+
+  exec(cx: GrammarContext, str: string, pos: number) {
+    // always match entire str past pos
+    if (this.matcher === "@DEFAULT") {
+      return this.action.exec(cx, [str.slice(pos)], pos)
+    }
+
+    const { target, last } = cx
+
+    cx.target = this.target
+    const found = this.matcher.exec(cx, str, pos)
+    cx.target = target
+    if (!found) return null
+
+    if (this.target) {
+      if (!cx.last) throw new Error("Rule target specified, but no last match!")
+      return this.action.exec(cx, cx.last, pos)
+    } else {
+      if (!cx.last || !cx.substate) cx.last = found
+      const result = this.action.exec(cx, found, pos)
+      cx.last = last
+      return result
+    }
+  }
+}
+
+const enum MatcherType {
+  RegExp,
+  Points,
+  Substitute,
+  Function
+}
+
+// prettier-ignore
+type MatcherElement =
+  | { matcher: DF.MatchFunction; type: MatcherType.Function }
+  | { matcher: RegExp;           type: MatcherType.RegExp }
+  | { matcher: DF.Substitute;    type: MatcherType.Substitute }
+  | { matcher: number[];         type: MatcherType.Points; source: string }
+
+export class Matcher {
+  private declare elements?: MatcherElement[]
+
+  constructor(grammar: Grammar, matchers: DF.Match) {
+    if (!isArray(matchers)) matchers = [matchers]
+
+    const compiled = matchers.map(matcher => {
+      if (!matcher) {
+        throw new Error("Null matcher given! A helper function likely errored.")
+      } else if (isFunction(matcher)) return matcher
+      else if (hasSigil<DF.Substitute>(matcher, ["$", "::"])) return matcher
+      else return Matcher.compile(grammar, matcher!)
+    })
+
+    this.elements = compiled.map(matcher => {
+      let type: MatcherType
+
+      if (isFunction(matcher)) type = MatcherType.Function
+      else if (isRegExp(matcher)) type = MatcherType.RegExp
+      else if (hasSigil(matcher, ["$", "::"])) type = MatcherType.Substitute
+      else type = MatcherType.Points
+
+      if (type === MatcherType.Points) {
+        const source = String.fromCodePoint(...(matcher as number[]))
+        return { matcher, type, source } as MatcherElement
+      }
+
+      return { matcher, type } as MatcherElement
+    })
+  }
+
+  private static compile(
+    { variables, ignoreCase }: Grammar,
+    matcher: RegExp | string
+  ): RegExp | DF.MatchFunction | number[] {
+    if (isRegExp(matcher)) {
+      const str = Grammar.expand(variables, matcher)
+      // prettier-ignore
+      // eslint-disable-next-line
+      const flags = "ym" +
+        (matcher.dotAll ? "s" : "") +
+        (matcher.unicode ? "u" : "") +
+        (ignoreCase || matcher.ignoreCase ? "i" : "")
+      return new RegExp(str, flags)
+    } else {
+      // entire string is a variable
+      if (/^@\w+$/.test(matcher)) {
+        const variable = variables[matcher.slice(1)]
+        if (isFunction(variable)) return variable
+        else if (isRegExp(variable)) {
+          return this.compile({ variables, ignoreCase } as Grammar, variable)
+        }
+      }
+      return toPoints(Grammar.expand(variables, matcher))
+    }
+  }
+
+  exec(cx: GrammarContext, str: string, pos: number): string[] | null {
+    if (!this.elements) return null
+
+    if (cx.target && cx.last) {
+      const { state, last, target, context } = cx
+      if (hasSigil(target, "$")) {
+        if (target === "$#") str
+        else if (target === "$S") str = state
+        else str = last[parseInt(target.slice(1))] ?? ""
+      } else {
+        const prop = context[str.slice(2)]
+        if (!prop) return null
+        str = prop
+      }
+    }
+
+    const found: string[] = [""]
+    const start = pos
+
+    // for loop is faster and doesn't invoke iterator methods needlessly
+    for (let i = 0; i < this.elements.length; i++) {
+      let total: string | null = null
+      let match: string[] | null = null
+
+      const element = this.elements[i]
+
+      switch (element.type) {
+        case MatcherType.Function: {
+          match = element.matcher(cx, str, pos)
+          break
+        }
+
+        case MatcherType.RegExp: {
+          element.matcher.lastIndex = pos
+          const result = element.matcher.exec(str)
+          if (result) [total, ...match] = result
+          break
+        }
+
+        case MatcherType.Substitute: {
+          const sub = Grammar.sub(cx, element.matcher)
+          if (!sub) break
+          if (pointsMatch(toPoints(sub), str, pos)) match = [sub]
+          break
+        }
+
+        case MatcherType.Points: {
+          if (pointsMatch(element.matcher, str, pos)) {
+            match = [element.source]
+          }
+          break
+        }
+
+        default: {
+          return null
+        }
+      }
+
+      if (!total && !match) return null
+
+      // skip further checking if we don't need to
+      if (this.elements.length === 1) {
+        if (total) return [total, ...(match ?? [])]
+        else if (match) return [match.join(), ...match]
+      }
+
+      if (total) found[0] += total
+
+      if (match?.length) {
+        if (!total) found[0] = found[0].concat(...match)
+        found.push(...match)
+      } else if (total) {
+        found.push(total)
+      }
+
+      if (found[0] && found.length === 1) found[1] = found[0]
+
+      pos = start + found[0].length
+    }
+
+    if (!found.length || (found.length === 1 && !found[0])) return null
+
+    return found
+  }
+}
+
+const enum ActionMode {
+  Normal,
+  SubState,
+  Group,
+  Bracket,
+  Rematch
+}
+
+export class Action {
+  declare type: string
+  declare group?: Action[]
+  declare next?: string
+  declare log?: string
+  declare switchTo?: string
+  declare open?: ParserAction
+  declare close?: ParserAction
+  declare embedded?: string
+  declare context?: DF.Context
+
+  private declare substate?: SubState
+
+  declare mode: ActionMode
+
+  constructor(private grammar: Grammar, action?: DM.Action) {
+    this.type = ""
+
+    if (action) {
+      const { type, next, open, close, log, switchTo, embedded, context } = action
+      Object.assign(
+        this,
+        removeUndefined({ type, next, open, close, log, switchTo, embedded, context })
+      )
+      if (has("rules", action)) this.substate = new SubState(grammar, action)
+      else if (action.group) {
+        this.group = action.group.map(act => new Action(grammar, act))
+      }
+    }
+
+    if (this.substate) this.mode = ActionMode.SubState
+    else if (hasSigil(this.type, "@RE")) this.mode = ActionMode.Rematch
+    else if (hasSigil(this.type, "@BR")) this.mode = ActionMode.Bracket
+    else if (this.group) this.mode = ActionMode.Group
+    else this.mode = ActionMode.Normal
+
+    // add types
+    if (this.type && !hasSigil(this.type, "@")) grammar.types.add(this.type)
+    if (this.open) for (const [type] of this.open) grammar.types.add(type)
+    if (this.close) for (const [type] of this.close) grammar.types.add(type)
+  }
+
+  private setContext(cx: GrammarContext) {
+    if (!this.context) return cx.context
+    const added: DF.Context = {}
+    for (const key in this.context) {
+      const prop = this.context[key]
+      if (prop) added[key] = Grammar.sub(cx, prop)
+    }
+    return (cx.context = { ...cx.context, ...added })
+  }
+
+  exec(cx: GrammarContext, found: string[], pos: number): Matched | null {
+    const matched = new Matched(found[0], this, pos)
+
+    switch (this.mode) {
+      case ActionMode.Normal: {
+        matched.context = this.setContext(cx)
+        return matched
+      }
+
+      case ActionMode.Bracket: {
+        matched.context = this.setContext(cx)
+        const action = this.grammar.findBracket(found[0], this.type)
+        if (action) return Matched.extend(matched, [new Matched(found[0], action, pos)])
+        return null
+      }
+
+      case ActionMode.Rematch: {
+        return new Matched("", this, pos, this.setContext(cx))
+      }
+
+      case ActionMode.SubState: {
+        const sub = this.substate!.exec(cx, found[0], pos)
+        if (!sub) return null
+        matched.context = this.setContext(cx)
+        return Matched.extend(matched, sub)
+      }
+
+      case ActionMode.Group: {
+        const [, ...captures] = found
+        let offset = pos
+        const group: (Matched | null)[] = []
+        for (let i = 0; i < captures.length; i++) {
+          const capture = captures[i]
+          const action = this.group![i]
+          if (!action) throw new Error("Disjointed match group count!")
+          if (!capture) continue
+          group.push(action.exec(cx, [capture], offset))
+          offset += capture.length
+        }
+        matched.context = this.setContext(cx)
+        return Matched.extend(matched, group)
+      }
+
+      default: {
+        return null
+      }
+    }
+  }
+}
+
+export class SubState {
+  declare repeat: boolean
+  declare optional: boolean
+  declare all: boolean
+  declare strict: boolean
+
+  constructor(
+    public grammar: Grammar,
+    { strict = true, repeat, optional, all, rules }: DM.Action
+  ) {
+    if (!rules) throw new Error("Substate must have rules!")
+
+    this.repeat = strict ? false : repeat ?? true
+    this.optional = strict ? false : optional ?? true
+    this.all = strict ? true : all ?? false
+    this.strict = strict
+
+    if (isString(rules)) grammar.addSubstate(this, grammar.addState(rules))
+    else grammar.addSubstate(this, rules)
+  }
+
+  exec(cx: GrammarContext, str: string, pos: number): Matched[] | null {
+    const lastSubstate = cx.substate
+    const matches: Matched[] = []
+
+    cx.substate = this
+
+    let offset = 0
+    let match: Matched | null = null
+    // prettier-ignore
+    while (offset < str.length &&
+      ((match = this.grammar.match(cx, str, offset)) || (!this.all && this.repeat))
+    ) {
+      if (!match) {
+        offset += 1
+        continue
+      }
+      match.offset = pos + offset
+      matches.push(match)
+      offset += match.length
+      if (!this.repeat) break
+    }
+
+    cx.substate = lastSubstate
+
+    if (!this.optional && !matches.length) return null
+    if (this.all && offset < str.length) return null
+    return matches
+  }
+}
+
+// MISC.
+
+export function createContext(state: string, context: DF.Context = {}): GrammarContext {
+  return { state, context }
+}
+
+export function createToken({ from, to, action, context }: Matched): GrammarToken {
+  const { type, open, close, next, switchTo, embedded } = action
+  const empty = !(type || open || close || next || switchTo || embedded || context)
+  return { type, from, to, empty, open, close, next, switchTo, embedded, context }
+}
+
+/** Wraps a list of {@link GrammarToken} with the token data of a {@link Match}.
+ *
+ *  Effectively, this mutates the list of tokens as if the given {@link Match}
+ *  "was" the list of tokens. If the token data of the match were to cause
+ *  the tokenizer to manipulate the stack, it will make the token list given
+ *  do the same. */
+export function wrapTokens(
+  tokens: GrammarToken[],
+  { context, action: { type, mode, next, switchTo, open, close, embedded } }: Matched
+) {
+  const first = tokens[0]
+  const last = tokens[tokens.length - 1]
+
+  if (context) last.context = { ...last.context, ...context }
+
+  if (next || switchTo) {
+    tokens.unshift(
+      createToken({
+        from: last.to,
+        to: last.to,
+        action: { type: "", next, switchTo }
+      } as Matched)
+    )
+  }
+
+  if (embedded && !embedded.endsWith("!")) {
+    if (embedded === "@pop") first.embedded = embedded
+    else last.embedded = embedded
+  }
+
+  if (type || open || close) {
+    // add arrays if missing
+    open ??= []
+    close ??= []
+    first.open ??= []
+    last.close ??= []
+    if (type && mode !== ActionMode.Bracket && mode !== ActionMode.Rematch) {
+      first.open.unshift(...klona(open), [type, 1])
+      last.close.push([type, 1], ...klona(close))
+    } else {
+      first.open.unshift(...klona(open))
+      last.close.push(...klona(close))
+    }
+  }
+
+  return tokens
+}
+
+export interface MatchedOpts {
+  total: string
+  action: Action
+  captures?: Matched[]
+  offset?: number
+  context?: DF.Context
+}
+
+export class Matched {
+  declare total: string
+  declare action: Action
+  declare captures: Set<Matched>
+  declare size: number
+  declare length: number
+  declare from: number
+  declare to: number
+  declare context?: DF.Context
+
+  constructor(
+    total: string,
+    action: Action,
+    offset: number,
+    context?: DF.Context,
+    captures?: Matched[]
+  ) {
+    this.total = total
+    this.action = action
+    this.captures = new Set(captures)
+    this.size = this.captures.size
+    this.length = total.length
+    this.from = offset
+    this.to = total.length + offset
+    this.context = context
+  }
+
+  set offset(offset: number) {
+    let pos = offset
+    for (const match of this.captures) {
+      match.offset = pos
+      pos += match.length
+    }
+    this.from = offset
+    this.to = this.total.length + offset
+  }
+
+  compile(): GrammarToken[] {
+    if (!this.size) return [createToken(this)]
+
+    const tokens: GrammarToken[] = []
+    for (const match of this.captures) {
+      for (const token of match.compile()) {
+        tokens.push(token)
+      }
+    }
+
+    return wrapTokens(tokens, this)
+  }
+
+  static extend(matched: Matched | null, captures?: (Matched | null)[]) {
+    if (!matched) return null
+    if (!captures || captures.length === 0) return matched
+    for (let i = 0; i < captures.length; i++) {
+      if (!captures[i]) return null
+    }
+    matched.captures = new Set(captures as Matched[])
+    matched.size = matched.captures.size
+    return matched
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.captures
+  }
+}

--- a/client/modules/cm-tarnation/src/grammar/helpers.ts
+++ b/client/modules/cm-tarnation/src/grammar/helpers.ts
@@ -1,0 +1,129 @@
+import { pointsMatch, toPoints } from "wj-util"
+import type * as DF from "./definition"
+
+const REGEX_SPLIT = /^([^]*)\/([^]+)\/([^]*)$/
+
+/** Safely compiles a regular expression.
+ *  @example
+ *  // returns null if features aren't supported (e.g. Safari)
+ *  const regex = re`/(?<=\d)\w+/d` */
+export function re(str: TemplateStringsArray) {
+  const split = REGEX_SPLIT.exec(str.raw[0])
+  if (!split) return null
+  const [, , src = "", flags = ""] = split
+  if (!src) return null
+  try {
+    return new RegExp(src, flags)
+  } catch {
+    return null
+  }
+}
+
+/** Creates a highly efficient "lookup" matching function for a list of strings.
+ *
+ *  The function does not match the entire string.
+ *  Instead, it will find the first match for the start of the string.
+ *
+ *  It's safe to use overlap values - longer strings are tried before shorter ones. */
+export function lkup(arr: string[]): DF.MatchFunction {
+  if (arr.length === 0) throw new Error("Empty string array!")
+
+  // longest string first
+  const sorted = [...arr].sort((a, b) => b.length - a.length)
+  const max = sorted[0].length
+
+  const set = new Set<number[]>(sorted.map(str => toPoints(str)))
+
+  return (_cx, str, pos) => {
+    const against = toPoints(str.slice(pos, pos + max))
+    for (const points of set) {
+      if (pointsMatch(points, against, 0)) {
+        return [String.fromCodePoint(...points)]
+      }
+    }
+    return null
+  }
+}
+
+type CompiledMatcher = ((input: string, pos: number) => boolean) | null
+
+/** Creates a {@link CompiledMatcher} from a `RegExp` or a `string`. */
+function createMatcher(str: string, behind = false): CompiledMatcher {
+  try {
+    const split = REGEX_SPLIT.exec(str)
+
+    // compile string
+    if (!split) {
+      if (str) {
+        if (str.startsWith("\\!")) str = str.slice(2)
+        const negated = str.startsWith("!")
+        if (negated) str = str.slice(1)
+
+        const len = behind ? str.length : 0
+        const points = toPoints(str)
+
+        return (input, pos) => {
+          const test = pointsMatch(points, input, pos - len)
+          return negated ? !test : test
+        }
+      }
+      return null
+    }
+
+    // compile regex
+    const [, offsetStr = "", src = "", flags = ""] = split
+    if (!src) return null
+
+    const negated = offsetStr.startsWith("!")
+    const offset = behind ? parseInt(negated ? offsetStr.slice(1) : offsetStr) : 0
+    const regex = new RegExp(src, flags + (flags.indexOf("y") !== -1 ? "" : "y"))
+
+    return (input, pos) => {
+      regex.lastIndex = pos - offset
+      const test = regex.test(behind ? input.slice(0, pos) : input)
+      return negated ? !test : test
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Lookahead utility.
+ *  Given a `RegExp` or `string` (in `string` form, keep in mind), it will create
+ *  a function that will determine if the input ahead of the search position matches.
+ *
+ *  Lead the `RegExp` or `string` with a `!` to negate the result.
+ *  `RegExp` inputs can be given flags.
+ *
+ *  @example
+ *  matcher = la`foo`
+ *  matcher = la`/foo\w+/i`
+ *  matcher = la`!foo`
+ *  matcher = la`!/foo\w+/i` */
+export function la({ raw: [str] }: TemplateStringsArray): DF.MatchFunction | null {
+  const matcher = createMatcher(str)
+  if (!matcher) return null
+  return (_cx, input, pos) => (matcher(input, pos) ? [] : null)
+}
+
+/** Lookbehind utility.
+ *  Given a `RegExp` or `string` (in `string` form, keep in mind), it will create
+ *  a function that will determine if the input behind of the search position matches.
+ *
+ *  Unlike a `RegExp` lookbehind, the compiled function cannot traverse infinitely far
+ *  behind. Instead, it must be given an offset.
+ *  This is given in front of the `/` character.
+ *
+ *  Lead the `RegExp` or `string` with a `!` to negate the result.
+ *  `RegExp` inputs can be given flags.
+ *
+ *  @example
+ *  matcher = lb`foo`
+ *  matcher = lb`3/foo/i`
+ *  matcher = lb`!foo`
+ *  matcher = lb`!3/foo/i` */
+export function lb({ raw: [str] }: TemplateStringsArray): DF.MatchFunction | null {
+  const matcher = createMatcher(str, true)
+  if (!matcher) return null
+  return (_cx, input, pos) => (matcher(input, pos) ? [] : null)
+}

--- a/client/modules/cm-tarnation/src/index.ts
+++ b/client/modules/cm-tarnation/src/index.ts
@@ -1,0 +1,223 @@
+import {
+  Language,
+  LanguageSupport,
+  defineLanguageFacet,
+  LanguageDescription,
+  languageDataProp,
+  EditorParseContext
+} from "@codemirror/language"
+import { styleTags, Tag, tags } from "@codemirror/highlight"
+import type { Extension } from "@codemirror/state"
+
+import { removeUndefined } from "wj-util"
+import { Parser } from "./parser"
+import { Tokenizer } from "./tokenizer"
+import { Buffer, BufferCache } from "./buffer"
+import { Grammar } from "./grammar/grammar"
+import type * as DF from "./grammar/definition"
+
+import { Input, NodeProp, NodePropSource, NodeSet, NodeType, Tree } from "lezer-tree"
+import { isFunction } from "is-what"
+
+export * from "./grammar/helpers"
+
+// TODO: reuse ahead buffer rather than just always viewport skipping
+// TODO: fix string with variable array expansion (convert to array of codepoints)
+// TODO: add substitution to next, switchto
+// TODO: better document the grammar classes
+// TODO: better document the parser classes
+
+type AddNodeSpec = { name: string } & Omit<
+  Parameters<typeof NodeType["define"]>[0],
+  "id" | "name"
+>
+
+interface ParserConfiguration {
+  props?: NodePropSource[]
+}
+
+/** The options / interface required to create a Tarnation language. */
+export interface TarnationLanguageDefinition {
+  /** The name of the language.
+   *  This property is important for CodeMirror, so make sure it's reasonable. */
+  name: string
+  /** The grammar that will be used to tokenize the language.
+   *
+   *  This value can be provided as a function,
+   *  which will cause the grammar to be lazily evaluated. */
+  grammar: DF.Grammar | (() => DF.Grammar)
+  /** A list of `LanguageDescription` objects that will
+   *  be used when the parser nests in a language. */
+  nestLanguages?: LanguageDescription[]
+  /** Configuration options for the parser, such as node props. */
+  configure?: ParserConfiguration
+  /** A list of aliases for the name of the language. (e.g. 'go' -> ['golang']) */
+  alias?: string[]
+  /** A list of file extensions. (e.g. ['.ts']) */
+  extensions?: string[]
+  /** The 'languageData' field for the language.
+   *  CodeMirror plugins use this data to interact with the language. */
+  languageData?: Record<string, any>
+  /** Extra extensions to be loaded. */
+  supportExtensions?: Extension[]
+}
+
+/** Global handler for a Tarnation language.
+ *  The language constructed will not be processed until the `load` function is called.
+ *  @see TarnationLanguageDefinition */
+export class TarnationLanguage {
+  declare description: LanguageDescription
+  declare grammar?: Grammar
+  declare nodes?: NodeMap
+  declare support?: LanguageSupport
+  declare language?: Language
+  declare state?: State
+
+  declare nestLanguages: LanguageDescription[]
+
+  private declare languageData: Record<string, any>
+  private declare grammarData: DF.Grammar | (() => DF.Grammar)
+  private declare configure: ParserConfiguration
+  private declare extensions: Extension[]
+
+  loaded = false
+
+  constructor({
+    name,
+    grammar,
+    nestLanguages = [],
+    configure = {},
+    alias,
+    extensions,
+    languageData = {},
+    supportExtensions = []
+  }: TarnationLanguageDefinition) {
+    const dataDescription = removeUndefined({ name, alias, extensions })
+
+    this.languageData = { ...dataDescription, ...languageData }
+    this.nestLanguages = nestLanguages
+    this.grammarData = grammar
+    this.configure = configure
+    this.extensions = supportExtensions
+
+    this.description = LanguageDescription.of({
+      ...dataDescription,
+      load: async () => this.load()
+    })
+  }
+
+  /** Loads and processes the language.
+   *  Calling this function repeatedly will
+   *  just return the previously loaded language. */
+  load() {
+    if (this.description?.support) return this.description.support
+    const def = isFunction(this.grammarData) ? this.grammarData() : this.grammarData
+    this.grammar = new Grammar(def)
+
+    const facet = defineLanguageFacet(this.languageData)
+    const facetProp = languageDataProp.set(Object.create(null), facet)
+
+    const nodes = (this.nodes = new NodeMap())
+    const topNode = nodes.add(
+      new (NodeType as any)(this.description.name, facetProp, 0, 1),
+      "Document"
+    )!
+    this.grammar.types.forEach(name => nodes.add({ name }))
+
+    if (this.grammar.props.length) {
+      nodes.configure({ props: this.grammar.props })
+    }
+
+    if (this.configure.props) {
+      nodes.configure(this.configure)
+    }
+
+    const state = (this.state = new State(this))
+
+    const parser = {
+      startParse(input: Input, pos: number, context: EditorParseContext) {
+        return new Parser(state, input, pos, context)
+      }
+    }
+
+    this.language = new Language(facet, parser, topNode)
+    this.support = new LanguageSupport(this.language, this.extensions)
+
+    this.loaded = true
+
+    console.log(this)
+
+    return this.support
+  }
+}
+
+export class State {
+  cache = new BufferCache()
+  tokenizer = new Tokenizer(this)
+
+  constructor(public language: TarnationLanguage) {}
+
+  get grammar() {
+    return this.language.grammar!
+  }
+  get nodes() {
+    return this.language.nodes!
+  }
+  get nestLanguages() {
+    return this.language.nestLanguages
+  }
+
+  /** Utility for building a {@link Tree}. */
+  buildTree(nodeBuffer: Buffer, start?: number, length?: number) {
+    const { buffer, reused } = nodeBuffer.compile()
+    const tree = Tree.build({
+      topID: 0,
+      nodeSet: this.nodes.set,
+      buffer,
+      reused,
+      length,
+      start
+    })
+    this.cache.attach(nodeBuffer, tree)
+    return tree
+  }
+}
+
+export class NodeMap {
+  map = new Map<string, number>()
+  types: NodeType[] = []
+  set = new NodeSet(this.types)
+
+  private tags: Record<string, Tag> = { ...(tags as any) }
+
+  get(name: string) {
+    return this.map.get(name)
+  }
+
+  add(spec: AddNodeSpec, name?: string): NodeType | null
+  add(spec: NodeType, name: string): NodeType | null
+  add(spec: AddNodeSpec | NodeType, name?: string): NodeType | null {
+    const { map, types, tags } = this
+    if (spec instanceof NodeType && name) {
+      map.set(name, spec.id)
+      types.push(spec)
+      return spec
+    }
+    if (!(spec instanceof NodeType)) {
+      const id = map.size
+      const props: (NodePropSource | [NodeProp<any>, any])[] = [...(spec.props ?? [])]
+      if (spec.name && spec.name[0].toUpperCase() !== spec.name[0]) {
+        props.push(styleTags({ [`${spec.name}/...`]: tags[spec.name] ?? NodeType.none }))
+      }
+      const node = NodeType.define({ ...spec, name: spec.name || undefined, id, props })
+      map.set(name ?? spec.name, id)
+      types.push(node)
+      return node
+    }
+    return null
+  }
+
+  configure(config: ParserConfiguration) {
+    if ("props" in config) this.set = this.set.extend(...config.props!)
+  }
+}

--- a/client/modules/cm-tarnation/src/index.ts
+++ b/client/modules/cm-tarnation/src/index.ts
@@ -51,12 +51,13 @@ export interface TarnationLanguageDefinition {
   nestLanguages?: LanguageDescription[]
   /** Configuration options for the parser, such as node props. */
   configure?: ParserConfiguration
-  /** A list of aliases for the name of the language. (e.g. 'go' -> ['golang']) */
+  /** A list of aliases for the name of the language. (e.g. 'go' -> `['golang']`) */
   alias?: string[]
-  /** A list of file extensions. (e.g. ['.ts']) */
+  /** A list of file extensions. (e.g. `['.ts']`) */
   extensions?: string[]
-  /** The 'languageData' field for the language.
-   *  CodeMirror plugins use this data to interact with the language. */
+  /** The 'languageData' field inherit to the {@link Language}.
+   *  CodeMirror plugins are defined by, or use, the data in this field.
+   *  e.g. indentation, autocomplete, etc. */
   languageData?: Record<string, any>
   /** Extra extensions to be loaded. */
   supportExtensions?: Extension[]
@@ -204,6 +205,13 @@ export class NodeMap {
       return spec
     }
     if (!(spec instanceof NodeType)) {
+      /*
+       * There is two ways a node can be interpreted:
+       * 1. The node's name is lowercased. That means it is a shortcut for a
+       *    CodeMirror highlighting tag.
+       * 2. The node's name is capitalized. That means it is a custom name,
+       *    and no assumptions will be made about its highlighting or styling.
+       */
       const id = map.size
       const props: (NodePropSource | [NodeProp<any>, any])[] = [...(spec.props ?? [])]
       if (spec.name && spec.name[0].toUpperCase() !== spec.name[0]) {

--- a/client/modules/cm-tarnation/src/parser.ts
+++ b/client/modules/cm-tarnation/src/parser.ts
@@ -1,0 +1,445 @@
+import { perfy } from "wj-util"
+import { Context, Buffer, BufferToken, BufferCache } from "./buffer"
+import { EditorParseContext, LanguageDescription } from "@codemirror/language"
+import { Input, PartialParse, Tree } from "lezer-tree"
+import { klona } from "klona"
+import type { State } from "./index"
+import type { EmbeddedRange, Tokenizer } from "./tokenizer"
+
+export type ParserElementStack = [name: number, start: number, children: number][]
+
+export interface SerializedEmbedded {
+  pending: BufferToken[]
+  parsers: [token: BufferToken, range: EmbeddedRange][]
+}
+
+export class Parser {
+  private declare caching: boolean
+  private declare context: Context
+  private declare embed: EmbeddedHandler
+  private declare tokenizer: Tokenizer
+  private declare viewport?: { from: number; to: number }
+
+  private buffer = new Buffer()
+
+  /** Number of parse steps per `advance()` call. */
+  private steps = 10
+  private lookaheadMargin = 50 // chars
+  private checkpointSpacing = 250 // chars
+  private logPerf?: () => void
+  private debug = false
+
+  private lastCheckpointPos = 0
+
+  pos = 0
+
+  constructor(
+    private state: State,
+    private input: Input,
+    private start: number,
+    private editorContext?: EditorParseContext
+  ) {
+    this.caching = !!editorContext?.state
+
+    if (this.caching) {
+      this.viewport = editorContext!.viewport
+      if (editorContext?.fragments?.length) {
+        for (const f of editorContext.fragments) {
+          if (f.from > start || f.to < start) continue
+          const buffer = Parser.findBuffer(state.cache, f.tree, start, f.to)
+          if (buffer) {
+            const found = buffer.findContext(start, f.to - this.lookaheadMargin)
+            if (found) {
+              const { context, index } = found
+              this.lastCheckpointPos = context.pos
+              this.buffer = buffer.cut(index, true)
+              this.context = context
+              this.pos = context.pos
+              // if (this.debug) console.log(`starting at: ${editorContext.state.doc.lineAt(this.pos).number}`)
+              break
+            }
+          }
+        }
+      }
+    }
+
+    if (!this!.context) {
+      this.context = new Context(this.start)
+      this.pos = this.start
+    }
+
+    this.embed = new EmbeddedHandler(state, input, this.context, editorContext)
+    this.tokenizer = state.tokenizer
+    this.tokenizer.context = this.context
+
+    if (this.debug) this.logPerf = perfy("parser", 2.5)
+  }
+
+  private get doc() {
+    return this.editorContext?.state.doc ?? null
+  }
+
+  private get ended() {
+    return this.pos >= this.input.length
+  }
+
+  private skipped = false
+  private get skipping() {
+    if (this.skipped) return true
+    if (this.ended || !this.editorContext || !this.embed.done) return false
+
+    const { viewport, start, pos } = this
+
+    // viewport diff hopefully adds enough buffer
+    if (start <= viewport!.to && pos >= viewport!.to + (viewport!.to - viewport!.from)) {
+      this.skipped = true
+      return true
+    }
+
+    return false
+  }
+
+  private static findBuffer(
+    cache: BufferCache,
+    tree: Tree,
+    startPos: number,
+    before: number,
+    off = 0
+  ): Buffer | null {
+    const buffer =
+      off >= startPos && off + tree.length >= before ? cache.get(tree) : undefined
+    if (buffer) return buffer
+    // check children
+    for (let i = tree.children.length - 1; i >= 0; i--) {
+      const child = tree.children[i]
+      const pos = off + tree.positions[i]
+      if (!(child instanceof Tree && pos < before)) continue
+      const found = this.findBuffer(cache, child, startPos, before, pos)
+      if (found) return found
+    }
+    return null
+  }
+
+  private compileTree() {
+    const { start, buffer, state, doc } = this
+
+    let length = this.pos - start
+
+    // filthy
+    // not sure why this is needed, to be honest
+    // the length of the document can somehow be disjointed from the input length
+    // this causes issues when remapping the tree, apparently
+    if (doc && doc.length < length) length = doc.length
+
+    const tree = state.buildTree(buffer, start, length)
+
+    return tree
+  }
+
+  private finish() {
+    const { input, buffer, context, pos, skipping, editorContext, viewport } = this
+    const { parser: stack } = context
+
+    // handle unfinished stack
+    while (stack.length) {
+      const [startid, startpos, children] = stack.pop()!
+      buffer.add([startid, startpos, pos, children * 4 + 4])
+      stack.increment()
+    }
+
+    if (skipping) editorContext!.skipUntilInView(viewport!.to, input.length)
+
+    const tree = this.compileTree()
+    if (this.debug && this.logPerf) this.logPerf()
+    // if (this.debug && editorContext) {
+    //   console.log(`ending at: ${editorContext.state.doc.lineAt(this.pos).number}`)
+    // }
+    return tree
+  }
+
+  private step() {
+    if (!this.ended && !this.skipped) {
+      const { input, buffer, context, embed, tokenizer } = this
+      const { parser: stack } = context
+
+      let pos = this.pos
+
+      const { tokens, popped, length } = tokenizer.exec(input, pos) ?? {}
+
+      if (tokens) {
+        for (const token of tokens) {
+          const [type, from, to, open, close] = token
+          if (type === -1) {
+            const token = buffer.add([0, from, to, -1, Tree.empty]) as BufferToken
+            stack.increment()
+            embed.push(token)
+            continue
+          }
+
+          // opening
+          if (open) {
+            open.forEach(([id, inclusive]) => {
+              stack.push(id, inclusive ? from : to, type ? (inclusive ? 0 : -1) : 0)
+            })
+          }
+
+          // closing
+          let pushed = false
+          if (close && stack.length) {
+            close.forEach(([id, inclusive]) => {
+              const idx = stack.last(id)
+              if (idx !== null) {
+                // cuts off anything past our closing stack element
+                stack.close(idx)
+                // if we're inclusive of the end token we need to push the token early
+                if (type && inclusive && !pushed) {
+                  buffer.add([type, from, to, 4])
+                  stack.increment()
+                  pushed = true
+                }
+                const [startid, startpos, children] = stack.pop()!
+                buffer.add([startid, startpos, inclusive ? to : from, children * 4 + 4])
+                stack.increment()
+              }
+            })
+          }
+
+          // token itself
+          if (type && !pushed) {
+            buffer.add([type, from, to, 4])
+            stack.increment()
+          }
+        }
+      }
+
+      if (popped) for (const range of popped) embed.push(range)
+
+      pos += length
+
+      const ended = this.ended
+
+      if (ended) pos = input.length
+      this.pos = pos
+      context.pos = pos
+      context.embed = embed.serialize()
+
+      if (
+        this.caching &&
+        !ended &&
+        pos - this.lastCheckpointPos >= this.checkpointSpacing
+      ) {
+        this.lastCheckpointPos = pos
+        buffer.add(context)
+      }
+    }
+
+    // advance nested
+    this.embed.advance()
+  }
+
+  forceFinish() {
+    const { input, pos } = this
+
+    // if we're very close to the end, we'll finish the parse anyways
+    // this catches some flukey behavior
+    if (input.length - pos < 500) {
+      let done: Tree | null = null
+      while (!(done = this.advance())) {}
+      return done
+    }
+
+    return this.compileTree()
+  }
+
+  advance() {
+    for (let step = this.steps; step > 0; step--) this.step()
+
+    if ((this.ended || this.skipping) && this.embed.done) return this.finish()
+    return null
+  }
+}
+
+export class ParserStack {
+  declare stack: ParserElementStack
+
+  constructor(stack: ParserElementStack = []) {
+    this.stack = stack.map(element => [...element])
+  }
+
+  get length() {
+    return this.stack.length
+  }
+
+  /** Add a child to every element. */
+  increment() {
+    this.stack.forEach(element => element[2]++)
+  }
+
+  /** Add a new element. */
+  push(id: number, start: number, children: number) {
+    this.stack.push([id, start, children])
+  }
+
+  /** Remove and return the last element. */
+  pop() {
+    return this.stack.pop()
+  }
+
+  /** Remove every element past the index given. */
+  close(idx: number) {
+    this.stack = this.stack.slice(0, idx + 1)
+  }
+
+  /** Returns the last element with the given ID. */
+  last(id: number) {
+    const idx = this.stack.map(element => element[0]).lastIndexOf(id)
+    if (idx === -1) return null
+    return idx
+  }
+
+  /** Returns a safe copy of the stack's internal array. */
+  serialize() {
+    return klona(this.stack)
+  }
+}
+
+export class EmbeddedHandler {
+  private declare start: number
+
+  private pending: BufferToken[] = []
+  private parsers: {
+    token: BufferToken
+    lang: EmbeddedLanguage
+    parser?: PartialParse
+  }[] = []
+
+  fullyLoaded = true
+
+  constructor(
+    private state: State,
+    private input: Input,
+    private context: Context,
+    private editorContext?: EditorParseContext
+  ) {
+    this.start = this.context.pos
+    const embed = this.context.embed
+    this.pending = [...embed.pending]
+    this.parsers = embed.parsers.map(([token, range]) => ({
+      lang: new EmbeddedLanguage(this.state, range),
+      token
+    }))
+  }
+
+  get done() {
+    return this.parsers.length === 0
+  }
+
+  push(embed: BufferToken | EmbeddedRange) {
+    if (embed instanceof BufferToken) this.pending.push(embed)
+    else {
+      if (this.pending.length === 0) {
+        throw new Error("Attempted to push an unassigned language!")
+      }
+      const token = this.pending.shift()!
+      const lang = new EmbeddedLanguage(this.state, embed)
+      this.parsers.push({ token, lang })
+    }
+  }
+
+  advance() {
+    if (this.done) return true
+    const { parsers, start: startPos, editorContext } = this
+    const { token, lang } = parsers[0]
+    const { start, end } = lang.range
+
+    if (token.tree !== Tree.empty && startPos >= end) {
+      parsers.shift()
+      if (this.done) return true
+      return null
+    }
+
+    const parser = (parsers[0].parser ||= lang.parse(
+      this.input.clip(end),
+      start,
+      editorContext
+    ))
+
+    // effectively marks the tree as stale
+    if (token.tree !== Tree.empty) token.tree = Tree.empty
+
+    const done = parser.advance()
+    if (done) {
+      token.tree = done
+      parsers.shift()
+      if (!lang.ready) this.fullyLoaded = false
+      if (this.done) return true
+    }
+    return null
+  }
+
+  serialize(): SerializedEmbedded {
+    return {
+      pending: [...this.pending],
+      parsers: this.parsers.map(parser => [parser.token, klona(parser.lang.range)])
+    }
+  }
+}
+
+/** Fake {@link PartialParse} implementation that
+ *  immediately returns a specified {@link Tree}. */
+class FakeParse {
+  constructor(private input: Input, private tree: Tree) {}
+  get pos() {
+    return this.input.length
+  }
+  advance() {
+    return this.tree
+  }
+  forceFinish() {
+    return this.tree
+  }
+}
+
+class EmbeddedLanguage {
+  private declare loading
+  private declare parser
+
+  lang: LanguageDescription | null = null
+
+  constructor(public state: State, public range: EmbeddedRange) {
+    if (state.nestLanguages.length) {
+      this.lang = LanguageDescription.matchLanguageName(state.nestLanguages, range.lang)
+      if (this.lang?.support) this.parser = this.bindParser()
+      else this.loading = this.init(this.lang)
+    }
+  }
+
+  get ready() {
+    return Boolean(this.parser)
+  }
+
+  private bindParser() {
+    if (!this.lang?.support) throw new Error("Could not bind unloaded language!")
+    const parser = this.lang.support.language.parser
+    return parser.startParse.bind(parser)
+  }
+
+  private async init(lang: LanguageDescription | null) {
+    if (!lang) this.parser = input => new FakeParse(input, Tree.empty)
+    else {
+      await lang.load()
+      return (this.parser = this.bindParser())
+    }
+  }
+
+  private fallbackParser(context?: EditorParseContext) {
+    return !context
+      ? (input: Input) => new FakeParse(input, Tree.empty)
+      : // eslint-disable-next-line @typescript-eslint/unbound-method
+        EditorParseContext.getSkippingParser(this.loading).startParse
+  }
+
+  parse(input: Input, start: number, context?: EditorParseContext) {
+    return (this.parser ?? this.fallbackParser(context))(input, start, context ?? {})
+  }
+}

--- a/client/modules/cm-tarnation/src/parser.ts
+++ b/client/modules/cm-tarnation/src/parser.ts
@@ -63,7 +63,7 @@ export class Parser {
       }
     }
 
-    if (!this!.context) {
+    if (!this.context) {
       this.context = new Context(this.start)
       this.pos = this.start
     }

--- a/client/modules/cm-tarnation/src/parser.ts
+++ b/client/modules/cm-tarnation/src/parser.ts
@@ -39,7 +39,7 @@ export class Parser {
     private start: number,
     private editorContext?: EditorParseContext
   ) {
-    this.caching = !!editorContext?.state
+    this.caching = Boolean(editorContext?.state)
 
     if (this.caching) {
       this.viewport = editorContext!.viewport

--- a/client/modules/cm-tarnation/src/tokenizer.ts
+++ b/client/modules/cm-tarnation/src/tokenizer.ts
@@ -1,0 +1,292 @@
+import { createContext, GrammarToken } from "./grammar/grammar"
+import { klona } from "klona"
+import type * as DF from "./grammar/definition"
+import type { NodeMap, State } from "./index"
+import type { Context } from "./buffer"
+import type { Input } from "lezer-tree"
+
+/** Directs the parser to nest tokens using the node's type ID. */
+export type MappedParserAction = [id: number, inclusive: number][]
+
+/** A more efficient representation of `GrammarToken` used in the parser.  */
+export type MappedToken = [
+  type: number,
+  from: number,
+  to: number,
+  open?: MappedParserAction,
+  close?: MappedParserAction
+]
+
+/** Represents a region of an embedded language. */
+export type EmbeddedRange = { lang: string; start: number; end: number }
+
+/** Represents a stack node in a {@link TokenizerStack}. */
+export type TokenizerStackElement = [state: string, context: DF.Context]
+/** A serialized (just data) form of a {@link TokenizerStack}. */
+export interface SerializedTokenizerStack {
+  stack: TokenizerStackElement[]
+  embedded: null | { lang: string; start: number }
+}
+
+/** Handles the tokenization of a {@link Grammar}. */
+export class Tokenizer {
+  declare stack?: TokenizerStack
+
+  private declare lastInput?: Input
+  private declare lastStr?: string
+  private declare lastPos?: number
+
+  /** Determines how wide of an input region will be tokenized. */
+  private padding = 1000
+
+  constructor(private state: State, context?: Context) {
+    if (context) this.context = context
+  }
+
+  get grammar() {
+    return this.state.grammar
+  }
+  get nodes() {
+    return this.state.nodes
+  }
+
+  set context(context: Context) {
+    this.stack = context.tokenizer
+    if (this.stack.depth === 0) {
+      this.stack.push(this.grammar.start ?? "root")
+    }
+  }
+
+  /** Compiles a {@link GrammarToken} into a {@link MappedToken}.
+   *  This primarily involves remapping the token names into IDs. */
+  private static compileToken(token: GrammarToken, nodes: NodeMap): MappedToken {
+    const { type, from, to, open, close } = token
+    const out: MappedToken = [nodes.get(type)!, from, to]
+    if (open) out[3] = open.map(([type, inclusive]) => [nodes.get(type)!, inclusive])
+    if (close) out[4] = close.map(([type, inclusive]) => [nodes.get(type)!, inclusive])
+    return out
+  }
+
+  /** Returns whether or not the given last {@link MappedToken} can be merged
+   *  with the next given {@link GrammarToken}. */
+  private canContinue(last?: MappedToken, next?: GrammarToken) {
+    if (!last || !next) return false // tokens are invalid
+    // parser directives present
+    if (last.length > 2 || next.open || next.close) return false
+    // embedded handling token
+    if (last[0] === -1 || next.embedded) return false
+    // types aren't equivalent
+    if (last[0] !== this.nodes.get(next.type)) return false
+    // tokens aren't inline
+    if (last[2] !== next.from) return false
+    // tokens are effectively equivalent
+    return true
+  }
+
+  /** Executes a tokenization step. */
+  exec(input: Input, pos: number) {
+    if (!this.stack) {
+      throw new Error("Attempted to tokenize without a stack/context being set!")
+    }
+    const { grammar, nodes, stack, padding, lastInput, lastPos, lastStr } = this
+
+    let str: string
+    let start: number
+
+    // prevent a document slice by reusing the last string made if it seems safe
+    // prettier-ignore
+    if (lastStr && lastPos && lastInput === input
+      && pos > lastPos && pos - lastPos < padding / 2) {
+      str = lastStr
+      start = (lastPos < padding ? lastPos : padding) + (pos - lastPos)
+    } else {
+      str = input.read(pos - padding, pos + padding)
+      start = pos < padding ? pos : padding
+      this.lastInput = input
+      this.lastStr = str
+      this.lastPos = pos
+    }
+
+    const context = createContext(stack.state, stack.context)
+    const match = grammar.match(context, str, start, pos)
+
+    if (!match) return { tokens: null, popped: null, length: 1 }
+
+    const tokens = match.compile()
+
+    if (!tokens.length) return { tokens: null, popped: null, length: match.length }
+
+    const mapped = new Set<MappedToken>()
+    const popped = new Set<EmbeddedRange>()
+
+    let last!: MappedToken
+
+    for (const token of tokens) {
+      const { next, switchTo, embedded, context, from, to } = token
+
+      stack.changed = false
+      let pushEmbedded = false
+
+      if (embedded) {
+        if (!stack.embedded && embedded.endsWith("!")) {
+          const lang = embedded.slice(0, embedded.length - 1)
+          mapped.add((last = [-1, from, to]))
+          popped.add({ lang, start: from, end: to })
+          continue
+        } else if (embedded === "@pop") {
+          popped.add(stack.endEmbedded(from))
+        } else if (!stack.embedded) {
+          pushEmbedded = true
+          stack.setEmbedded(embedded, to)
+        }
+      }
+
+      if (next) {
+        switch (next) {
+          case "@pop": {
+            stack.pop()
+            break
+          }
+          case "@popall": {
+            stack.popall()
+            break
+          }
+          case "@push": {
+            stack.push(next, context)
+            break
+          }
+          default: {
+            stack.push(next, context)
+          }
+        }
+      } else if (switchTo) {
+        stack.switchTo(switchTo, context)
+      } else if (context) {
+        stack.context = context
+      }
+
+      if (!token.empty && (!stack.embedded || pushEmbedded)) {
+        if (last && !stack.changed && this.canContinue(last, token)) last[2] = token.to
+        else mapped.add((last = Tokenizer.compileToken(token, nodes)))
+      }
+
+      if (pushEmbedded) mapped.add((last = [-1, to, to]))
+    }
+
+    return { tokens: mapped, popped, length: match.length }
+  }
+}
+
+/** State/stack object for a {@link Tokenizer}. */
+export class TokenizerStack {
+  /** Specifies if the state has changed since the last time this property has been set. */
+  changed = false
+
+  /** Embedded language data, if present. */
+  embedded: null | { lang: string; start: number }
+
+  /** The internal stack. */
+  private declare stack: TokenizerStackElement[]
+
+  constructor(serialized: SerializedTokenizerStack = { stack: [], embedded: null }) {
+    const { stack, embedded } = klona(serialized)
+    this.stack = stack
+    this.embedded = embedded
+  }
+
+  private get last() {
+    return this.stack[this.stack.length - 1]
+  }
+  private set last(element) {
+    this.stack[this.stack.length - 1] = element
+  }
+
+  /** The top-most state of the stack. */
+  get state() {
+    return this.last[0]
+  }
+  /** The length (depth), or number of stack nodes, in the stack. */
+  get depth() {
+    return this.stack.length
+  }
+  /** The parent of the stack, i.e. the state of the stack if it were to be popped. */
+  get parent() {
+    const parent = this.clone()
+    parent.pop()
+    return parent
+  }
+
+  get context() {
+    return this.last?.[1] ?? {}
+  }
+  set context(context) {
+    this.last[1] = context ?? {}
+  }
+
+  /** Push a new state to the top of the stack. */
+  push(state: string, context = this.context) {
+    this.changed = true
+    this.stack.push([state, context])
+  }
+
+  /** Switch to a new state, replacing the current one. */
+  switchTo(state: string, context = this.context) {
+    this.changed = true
+    this.last = [state, context]
+  }
+
+  /** Remove the top-most state of the stack. */
+  pop() {
+    this.changed = true
+    return this.stack.pop()?.[0]
+  }
+
+  /** Remove all states from the stack except the very first. */
+  popall() {
+    this.changed = true
+    this.stack = [this.stack.shift() ?? ["root", {}]]
+  }
+
+  /** Returns a deep clone of the stack. */
+  clone() {
+    return new TokenizerStack(this.serialize())
+  }
+
+  /** Sets the embedded data. */
+  setEmbedded(lang: string, start: number) {
+    this.changed = true
+    this.embedded = { lang, start }
+  }
+
+  /** Removes the embedded data. */
+  endEmbedded(end: number): EmbeddedRange {
+    if (!this.embedded) throw new Error("Tried to end a non-existent embedded range!")
+    this.changed = true
+    const embedded = this.embedded
+    this.embedded = null
+    return { ...embedded, end }
+  }
+
+  /** Serializes the stack and embedded data into a list of strings. */
+  serialize(): SerializedTokenizerStack {
+    const { stack, embedded } = this
+    return { stack: klona(stack), embedded: klona(embedded) }
+  }
+
+  /** Compares two stacks and returns if they are equal.
+   *  They can be pure `MonarchStack` objects or already serialized. */
+  static isEqual(
+    stack1: SerializedTokenizerStack | TokenizerStack,
+    stack2: SerializedTokenizerStack | TokenizerStack
+  ) {
+    // convert to just string arrays
+    if ("serialize" in stack1) stack1 = stack1.serialize()
+    if ("serialize" in stack2) stack2 = stack2.serialize()
+    // check lengths
+    if (stack1.stack.length !== stack2.stack.length) return false
+    // check for every value
+    return stack1.stack.every(
+      ([str], idx) => str === (stack2 as SerializedTokenizerStack).stack[idx][0]
+    )
+  }
+}

--- a/client/modules/cm-tarnation/tests/grammar.ts
+++ b/client/modules/cm-tarnation/tests/grammar.ts
@@ -1,0 +1,71 @@
+import * as uvu from "uvu"
+import * as assert from "uvu/assert"
+
+import * as lib from "../src/grammar/grammar"
+import type * as DF from "../src/grammar/definition"
+
+// TODO: a lot more tests here
+// there is a better way of testing this lib, which is Lezer's method
+// but for right now this is kind of a smoke test
+
+const Grammar = uvu.suite<{ grammar: lib.Grammar }>("Grammar", {} as any)
+
+Grammar("make Grammar", cx => {
+  // wikimath (tex)
+  const def: DF.Grammar = {
+    start: "root",
+    variables: {
+      texBrackets: ["(", ")", "[", "]", "{", "}"],
+      texSymbols: ["+", "-", "=", "!", "/", "<", ">", "|", "'", ":", "*", "^"]
+    },
+    brackets: [
+      { name: "t.paren", pair: ["(", ")"] },
+      { name: "t.brace", pair: ["{", "}"] },
+      { name: "t.squareBracket", pair: ["[", "]"] }
+    ],
+    fallback: ["t.emphasis"],
+    states: {
+      root: [
+        [/%.*$/, "t.comment"],
+        [/([a-zA-Z]+)(?=\([^]*?\))/, "Function"],
+        [
+          /(\\#?[a-zA-Z0-9]+)(\{)([^]*?)(\})/,
+          "CommandGroup",
+          ["Command", "@BR", "t.string", "@BR"]
+        ],
+        [/\\#?[a-zA-Z0-9]+/, "Command"],
+        [/\\[,>;!]/, "t.string"],
+        [/\\+/, "t.escape"],
+        [/\^(?!\d)|[_&]/, "t.keyword"],
+        [/\d+/, "t.unit"],
+        [/@texSymbols/, "t.operator"],
+        [/@texBrackets/, "@BR"]
+      ]
+    }
+  }
+
+  const grammar = new lib.Grammar(def)
+  assert.instance(grammar, lib.Grammar)
+  cx.grammar = grammar
+})
+
+Grammar("match Grammar", ({ grammar }) => {
+  const context = lib.createContext("root")
+  const match = grammar.match(context, "% foobar", 0)
+  assert.equal(match.compile(), [
+    {
+      type: "comment",
+      from: 0,
+      to: 8,
+      empty: false,
+      open: undefined,
+      close: undefined,
+      next: undefined,
+      switchTo: undefined,
+      embedded: undefined,
+      context: {}
+    }
+  ])
+})
+
+Grammar.run()

--- a/client/modules/cm-tarnation/tests/helpers.ts
+++ b/client/modules/cm-tarnation/tests/helpers.ts
@@ -1,0 +1,16 @@
+import * as uvu from "uvu"
+import * as assert from "uvu/assert"
+
+import * as lib from "../src/grammar/helpers"
+
+// TODO: flesh out, this is mostly just placeholder
+
+const Helpers = uvu.suite("Helpers")
+
+Helpers("safe regex (re)", () => {
+  const { re } = lib
+  assert.instance(re`/foo\w+/`, RegExp)
+  assert.is(re`/[\]\w+/`, null) // bad regexp
+})
+
+Helpers.run()

--- a/client/modules/cm-tarnation/tsconfig.json
+++ b/client/modules/cm-tarnation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["./src"],
+  "exclude": ["./node_modules"]
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -36,7 +36,8 @@
     { "path": "./modules/wj-util" },
     { "path": "./modules/node-snowpack-workers" },
     { "path": "./modules/sheaf-core" },
-    { "path": "./modules/ftml-wasm" }
+    { "path": "./modules/ftml-wasm" },
+    { "path": "./modules/cm-tarnation" }
   ],
 
   "typeAcquisition": {


### PR DESCRIPTION
This is _easily_ the biggest module that will be added for the initial Sheaf implementation. It is the heart and soul of how Sheaf will be parsing FTML, as the other parsing solutions available for CodeMirror 6 aren't up to the task.

It's quite complex. I do think it's coded fairly cleanly, although it's still a WIP. It's very functional, though. It'll likely get many updates as Sheaf gets new features.

There is probably too much here to grasp in one code review, and I don't really feel like skyrocketing past 150 comments. I also can't just split this up into chunks either, lol. My hope is once I get an editor instance with HTML live preview, we can relax and go over some of these modules in detail. I'm very anxious to get the editor in a state where it can actually get worked on.