### PR TITLE
[FTML-82] Change "modifier" to be a block property rather than ad-hoc derived.

### DIFF
--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -59,12 +59,13 @@ cfg_if! {
 
             pub fn build_terminal_logger() -> slog::Logger {
                 use sloggers::terminal::TerminalLoggerBuilder;
-                use sloggers::types::Severity;
+                use sloggers::types::{OverflowStrategy, Severity};
                 use sloggers::Build;
 
                 TerminalLoggerBuilder::new()
                     .level(Severity::Trace)
-                    .channel_size(256)
+                    .overflow_strategy(OverflowStrategy::Block)
+                    .channel_size(4096)
                     .build()
                     .expect("Unable to initialize logger")
             }

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -64,6 +64,7 @@ cfg_if! {
 
                 TerminalLoggerBuilder::new()
                     .level(Severity::Trace)
+                    .channel_size(256)
                     .build()
                     .expect("Unable to initialize logger")
             }

--- a/ftml/src/parsing/exception.rs
+++ b/ftml/src/parsing/exception.rs
@@ -124,6 +124,9 @@ pub enum ParseWarningKind {
     /// This block does not allow special invocation.
     InvalidSpecialBlock,
 
+    /// This block does not allow modifier invocation.
+    InvalidModifierBlock,
+
     /// This block does not specify a name.
     BlockMissingName,
 

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -25,6 +25,7 @@ pub const BLOCK_ANCHOR: BlockRule = BlockRule {
     name: "block-anchor",
     accepts_names: &["a", "a_", "anchor", "anchor_"],
     accepts_special: true,
+    accepts_modifier: true,
     accepts_newlines: false,
     parse_fn,
 };
@@ -34,6 +35,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -51,7 +53,7 @@ fn parse_fn<'r, 't>(
 
     // "a" means we wrap interpret as-is
     // "a_" means we strip out any newlines or paragraph breaks
-    let strip_line_breaks = name.ends_with('_');
+    let strip_line_breaks = modifier;
 
     // Get anchor target depending on special
     let target = if special {

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -23,7 +23,7 @@ use crate::tree::AnchorTarget;
 
 pub const BLOCK_ANCHOR: BlockRule = BlockRule {
     name: "block-anchor",
-    accepts_names: &["a", "a_", "anchor", "anchor_"],
+    accepts_names: &["a", "anchor"],
     accepts_special: true,
     accepts_modifier: true,
     accepts_newlines: false,

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -24,6 +24,7 @@ pub const BLOCK_BLOCKQUOTE: BlockRule = BlockRule {
     name: "block-blockquote",
     accepts_names: &["blockquote", "quote"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,11 +34,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing blockquote block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "blockquote doesn't allow special variant");
+    assert_eq!(special, false, "Blockquote doesn't allow special variant");
+    assert_eq!(modifier, false, "Blockquote doesn't allow modifier variant");
     assert_block_name(&BLOCK_BLOCKQUOTE, name);
 
     let arguments = parser.get_head_map(&BLOCK_BLOCKQUOTE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -24,6 +24,7 @@ pub const BLOCK_BOLD: BlockRule = BlockRule {
     name: "block-bold",
     accepts_names: &["b", "bold", "strong"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Bold doesn't allow special variant");
+    assert_eq!(modifier, false, "Bold doesn't allow modifier variant");
     assert_block_name(&BLOCK_BOLD, name);
 
     let arguments = parser.get_head_map(&BLOCK_BOLD, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -43,6 +43,7 @@ pub const BLOCK_CHAR: BlockRule = BlockRule {
     name: "block-char",
     accepts_names: &["char", "character"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -52,11 +53,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing character / HTML entity block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Char doesn't allow special variant");
+    assert_eq!(modifier, false, "Char doesn't allow modifier variant");
     assert_block_name(&BLOCK_CHAR, name);
 
     // Parse the entity and get the string

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -24,6 +24,7 @@ pub const BLOCK_CHECKBOX: BlockRule = BlockRule {
     name: "block-checkbox",
     accepts_names: &["checkbox"],
     accepts_special: true,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
         "special" => special,
     );
 
+    assert_eq!(modifier, false, "Checkbox doesn't allow modifier variant");
     assert_block_name(&BLOCK_CHECKBOX, name);
 
     let arguments = parser.get_head_map(&BLOCK_CHECKBOX, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -24,6 +24,7 @@ pub const BLOCK_CODE: BlockRule = BlockRule {
     name: "block-code",
     accepts_names: &["code"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,11 +34,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing code block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Code doesn't allow special variant");
+    assert_eq!(modifier, false, "Code doesn't allow modifier variant");
     assert_block_name(&BLOCK_CODE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -25,6 +25,7 @@ pub const BLOCK_COLLAPSIBLE: BlockRule = BlockRule {
     name: "block-collapsible",
     accepts_names: &["collapsible"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -34,6 +35,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,10 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Collapsible doesn't allow special variant");
+    assert_eq!(
+        modifier, false,
+        "Collapsible doesn't allow modifier variant",
+    );
     assert_block_name(&BLOCK_COLLAPSIBLE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -24,6 +24,7 @@ pub const BLOCK_CSS: BlockRule = BlockRule {
     name: "block-css",
     accepts_names: &["css"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,11 +34,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing CSS block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Code doesn't allow special variant");
+    assert_eq!(special, false, "CSS doesn't allow special variant");
+    assert_eq!(modifier, false, "CSS doesn't allow modifier variant");
     assert_block_name(&BLOCK_CSS, name);
 
     parser.get_head_none(&BLOCK_CSS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -24,6 +24,7 @@ pub const BLOCK_DEL: BlockRule = BlockRule {
     name: "block-del",
     accepts_names: &["del", "deletion"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Deletion doesn't allow special variant");
+    assert_eq!(modifier, false, "Deletion doesn't allow modifier variant");
     assert_block_name(&BLOCK_DEL, name);
 
     let arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -45,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Div doesn't allow special variant");
+    assert_eq!(modifier, false, "Div doesn't allow modifier variant");
     assert_block_name(&BLOCK_DIV, name);
 
     let arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 
 pub const BLOCK_DIV: BlockRule = BlockRule {
     name: "block-div",
-    accepts_names: &["div", "div_"],
+    accepts_names: &["div"],
     accepts_special: false,
     accepts_modifier: true,
     accepts_newlines: true,

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -45,7 +45,6 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Div doesn't allow special variant");
-    assert_eq!(modifier, false, "Div doesn't allow modifier variant");
     assert_block_name(&BLOCK_DIV, name);
 
     let arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -24,6 +24,7 @@ pub const BLOCK_DIV: BlockRule = BlockRule {
     name: "block-div",
     accepts_names: &["div", "div_"],
     accepts_special: false,
+    accepts_modifier: true,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -49,7 +51,7 @@ fn parse_fn<'r, 't>(
 
     // "div" means we wrap in paragraphs, like normal
     // "div_" means we don't wrap it
-    let wrap_paragraphs = !name.ends_with('_');
+    let wrap_paragraphs = !modifier;
 
     // Get body content, based on whether we want paragraphs or not
     let (elements, exceptions) = parser

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -24,6 +24,7 @@ pub const BLOCK_HIDDEN: BlockRule = BlockRule {
     name: "block-hidden",
     accepts_names: &["hidden"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Hidden doesn't allow special variant");
+    assert_eq!(modifier, false, "Hidden doesn't allow modifier variant");
     assert_block_name(&BLOCK_HIDDEN, name);
 
     let arguments = parser.get_head_map(&BLOCK_HIDDEN, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/html.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/html.rs
@@ -24,6 +24,7 @@ pub const BLOCK_HTML: BlockRule = BlockRule {
     name: "block-html",
     accepts_names: &["html"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,11 +34,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing HTML block"; "in-head" => in_head);
 
     assert_eq!(special, false, "HTML doesn't allow special variant");
+    assert_eq!(modifier, false, "HTML doesn't allow modifier variant");
     assert_block_name(&BLOCK_HTML, name);
 
     parser.get_head_none(&BLOCK_HTML, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -24,6 +24,7 @@ pub const BLOCK_IFRAME: BlockRule = BlockRule {
     name: "block-iframe",
     accepts_names: &["iframe"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,11 +34,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing iframe block"; "in-head" => in_head);
 
     assert_eq!(special, false, "iframe doesn't allow special variant");
+    assert_eq!(modifier, false, "iframe doesn't allow modifier variant");
     assert_block_name(&BLOCK_IFRAME, name);
 
     let (url, arguments) = parser.get_head_name_map(&BLOCK_IFRAME, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -33,6 +33,7 @@ pub const BLOCK_INCLUDE: BlockRule = BlockRule {
     name: "block-include",
     accepts_names: &["include"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -42,11 +43,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Found invalid include block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Include doesn't allow special variant");
+    assert_eq!(modifier, false, "Include doesn't allow modifier variant");
     assert_block_name(&BLOCK_INCLUDE, name);
 
     // Includes are handled specially, so we should never actually be

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -24,6 +24,7 @@ pub const BLOCK_INS: BlockRule = BlockRule {
     name: "block-ins",
     accepts_names: &["ins", "insertion"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Ins doesn't allow special variant");
+    assert_eq!(modifier, false, "Ins doesn't allow modifier variant");
     assert_block_name(&BLOCK_INS, name);
 
     let arguments = parser.get_head_map(&BLOCK_INS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -24,6 +24,7 @@ pub const BLOCK_INVISIBLE: BlockRule = BlockRule {
     name: "block-invisible",
     accepts_names: &["invisible"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Invisible doesn't allow special variant");
+    assert_eq!(modifier, false, "Invisible doesn't allow modifier variant");
     assert_block_name(&BLOCK_INVISIBLE, name);
 
     let arguments = parser.get_head_map(&BLOCK_INVISIBLE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -24,6 +24,7 @@ pub const BLOCK_ITALICS: BlockRule = BlockRule {
     name: "block-italics",
     accepts_names: &["i", "italics", "em", "emphasis"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Italics doesn't allow special variant");
+    assert_eq!(modifier, false, "Italics doesn't allow modifier variant");
     assert_block_name(&BLOCK_ITALICS, name);
 
     let arguments = parser.get_head_map(&BLOCK_ITALICS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/later.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/later.rs
@@ -33,6 +33,7 @@ pub const BLOCK_LATER: BlockRule = BlockRule {
     name: "block-later",
     accepts_names: &["later"],
     accepts_special: true,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -42,6 +43,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     _special: bool,
+    _modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing later block (easter egg)"; "in-head" => in_head);

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -25,6 +25,7 @@ pub const BLOCK_LINES: BlockRule = BlockRule {
     name: "block-lines",
     accepts_names: &["lines", "newlines"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -34,11 +35,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing newlines block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Lines doesn't allow special variant");
+    assert_eq!(modifier, false, "Lines doesn't allow modifier variant");
     assert_block_name(&BLOCK_LINES, name);
 
     let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -24,6 +24,7 @@ pub const BLOCK_MARK: BlockRule = BlockRule {
     name: "block-mark",
     accepts_names: &["mark", "highlight"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Mark doesn't allow special variant");
+    assert_eq!(modifier, false, "Mark doesn't allow modifier variant");
     assert_block_name(&BLOCK_MARK, name);
 
     let arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -25,6 +25,7 @@ pub const BLOCK_MODULE: BlockRule = BlockRule {
     name: "block-module",
     accepts_names: &["module", "module654"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: true,
     parse_fn,
 };
@@ -34,11 +35,13 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing module block"; "in-head" => in_head);
 
     assert_eq!(special, false, "Module doesn't allow special variant");
+    assert_eq!(modifier, false, "Module doesn't allow modifier variant");
     assert_block_name(&BLOCK_MODULE, name);
 
     // Get module name and arguments

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -24,6 +24,7 @@ pub const BLOCK_MONOSPACE: BlockRule = BlockRule {
     name: "block-monospace",
     accepts_names: &["tt", "mono", "monospace"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Monospace doesn't allow special variant");
+    assert_eq!(modifier, false, "Monospace doesn't allow modifier variant");
     assert_block_name(&BLOCK_MONOSPACE, name);
 
     let arguments = parser.get_head_map(&BLOCK_MONOSPACE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -24,6 +24,7 @@ pub const BLOCK_RADIO: BlockRule = BlockRule {
     name: "block-radio",
     accepts_names: &["radio", "radio-button"],
     accepts_special: true,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,10 @@ fn parse_fn<'r, 't>(
         "special" => special,
     );
 
+    assert_eq!(
+        modifier, false,
+        "Radio buttons don't allow modifier variant",
+    );
     assert_block_name(&BLOCK_RADIO, name);
 
     let (name, arguments) = parser.get_head_name_map(&BLOCK_RADIO, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -26,6 +26,7 @@ pub const BLOCK_SIZE: BlockRule = BlockRule {
     name: "block-size",
     accepts_names: &["size"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -35,6 +36,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -45,6 +47,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Size doesn't allow special variant");
+    assert_eq!(modifier, false, "Size doesn't allow modifier variant");
     assert_block_name(&BLOCK_SIZE, name);
 
     let size =

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -24,6 +24,7 @@ pub const BLOCK_SPAN: BlockRule = BlockRule {
     name: "block-span",
     accepts_names: &["span", "span_"],
     accepts_special: false,
+    accepts_modifier: true,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -49,7 +51,7 @@ fn parse_fn<'r, 't>(
 
     // "span" means we wrap interpret as-is
     // "span_" means we strip out any newlines or paragraph breaks
-    let strip_line_breaks = name.ends_with('_');
+    let strip_line_breaks = modifier;
 
     // Get body content, without paragraphs
     let (mut elements, exceptions) = parser.get_body_elements(&BLOCK_SPAN, false)?.into();

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 
 pub const BLOCK_SPAN: BlockRule = BlockRule {
     name: "block-span",
-    accepts_names: &["span", "span_"],
+    accepts_names: &["span"],
     accepts_special: false,
     accepts_modifier: true,
     accepts_newlines: false,

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -45,7 +45,6 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Span doesn't allow special variant");
-    assert_eq!(modifier, false, "Span doesn't allow modifier variant");
     assert_block_name(&BLOCK_SPAN, name);
 
     let arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -45,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Span doesn't allow special variant");
+    assert_eq!(modifier, false, "Span doesn't allow modifier variant");
     assert_block_name(&BLOCK_SPAN, name);
 
     let arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -24,6 +24,7 @@ pub const BLOCK_STRIKETHROUGH: BlockRule = BlockRule {
     name: "block-strikethrough",
     accepts_names: &["s", "strikethrough"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -45,6 +47,10 @@ fn parse_fn<'r, 't>(
     assert_eq!(
         special, false,
         "Strikethrough doesn't allow special variant",
+    );
+    assert_eq!(
+        modifier, false,
+        "Strikethrough doesn't allow modifier variant",
     );
     assert_block_name(&BLOCK_STRIKETHROUGH, name);
 

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -24,6 +24,7 @@ pub const BLOCK_SUBSCRIPT: BlockRule = BlockRule {
     name: "block-subscript",
     accepts_names: &["sub", "subscript"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Subscript doesn't allow special variant");
+    assert_eq!(modifier, false, "Subscript doesn't allow modifier variant");
     assert_block_name(&BLOCK_SUBSCRIPT, name);
 
     let arguments = parser.get_head_map(&BLOCK_SUBSCRIPT, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -24,6 +24,7 @@ pub const BLOCK_SUPERSCRIPT: BlockRule = BlockRule {
     name: "block-superscript",
     accepts_names: &["sup", "super", "superscript"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,10 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Superscript doesn't allow special variant");
+    assert_eq!(
+        modifier, false,
+        "Superscript doesn't allow modifier variant",
+    );
     assert_block_name(&BLOCK_SUPERSCRIPT, name);
 
     let arguments = parser.get_head_map(&BLOCK_SUPERSCRIPT, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -24,6 +24,7 @@ pub const BLOCK_UNDERLINE: BlockRule = BlockRule {
     name: "block-underline",
     accepts_names: &["u", "underline"],
     accepts_special: false,
+    accepts_modifier: false,
     accepts_newlines: false,
     parse_fn,
 };
@@ -33,6 +34,7 @@ fn parse_fn<'r, 't>(
     parser: &mut Parser<'r, 't>,
     name: &'t str,
     special: bool,
+    modifier: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(
@@ -43,6 +45,7 @@ fn parse_fn<'r, 't>(
     );
 
     assert_eq!(special, false, "Underline doesn't allow special variant");
+    assert_eq!(modifier, false, "Underline doesn't allow modifier variant");
     assert_block_name(&BLOCK_UNDERLINE, name);
 
     let arguments = parser.get_head_map(&BLOCK_UNDERLINE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -62,7 +62,8 @@ lazy_static! {
 
 #[inline]
 pub fn get_block_rule_with_name(name: &str) -> Option<&'static BlockRule> {
-    let name = UniCase::ascii(name);
+    let name = name.strip_suffix('_').unwrap_or(name); // modifier
+    let name = UniCase::ascii(name); // case-insensitive
 
     BLOCK_RULE_MAP.get(&name).copied()
 }

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -62,6 +62,12 @@ pub struct BlockRule {
     /// `[[user aismallard]]` and `[[*user aismallard]]`.
     accepts_special: bool,
 
+    /// Whether this block accepts `_` as a modifier.
+    ///
+    /// For instance, div can be invoked as both
+    /// `[[div]]` and `[[div_]]`.
+    accepts_modifier: bool,
+
     /// Whether this block optionally allows its head and tail to be separated by newlines.
     /// These newlines will be consumed and not be interpreted as line breaks.
     ///
@@ -110,6 +116,7 @@ impl Debug for BlockRule {
             .field("name", &self.name)
             .field("accepts_names", &self.accepts_names)
             .field("accepts_special", &self.accepts_special)
+            .field("accepts_modifier", &self.accepts_modifier)
             .field("accepts_newlines", &self.accepts_newlines)
             .field("parse_fn", &(self.parse_fn as *const ()))
             .finish()
@@ -128,6 +135,7 @@ pub type BlockParseFn = for<'r, 't> fn(
     &Logger,
     &mut Parser<'r, 't>,
     &'t str,
+    bool,
     bool,
     bool,
 ) -> ParseResult<'r, 't, Elements<'t>>;

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -178,6 +178,9 @@ where
             // since it's just more text
             let name = parser.get_end_block()?;
 
+            // Remove underscore for modifier
+            let name = name.strip_suffix('_').unwrap_or(name);
+
             // Check if it's valid
             for end_block_name in block_rule.accepts_names {
                 if name.eq_ignore_ascii_case(end_block_name) {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -76,7 +76,7 @@ fn block_skip<'r, 't>(
     // See if there's a block upcoming
     let result = parser.evaluate_fn(|parser| {
         // Make sure this is the start of a block
-        if current.token != Token::LeftBlock && current.token != Token::LeftBlockSpecial {
+        if ![Token::LeftBlock, Token::LeftBlockSpecial].contains(&current.token) {
             return Ok(false);
         }
 

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -91,6 +91,7 @@ fn block_skip<'r, 't>(
     });
 
     if result {
+        info!(log, "Skipping newline due to upcoming line-terminated block");
         ok!(Elements::None)
     } else {
         Err(parser.make_warn(ParseWarningKind::RuleFailed))

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -126,6 +126,11 @@ where
     let (name, in_head) = parser.get_block_name(special)?;
     trace!(log, "Got block name"; "name" => name, "in-head" => in_head);
 
+    let (name, modifier) = match name.strip_suffix('_') {
+        Some(name) => (name, true),
+        None => (name, false),
+    };
+
     // Get the block rule for this name
     let block = match get_block_rule_with_name(name) {
         Some(block) => block,
@@ -147,5 +152,5 @@ where
     // This is responsible for parsing any arguments,
     // and terminating the block (the ']]' token),
     // then processing the body (if any) and tail block.
-    (block.parse_fn)(log, parser, name, special, in_head)
+    (block.parse_fn)(log, parser, name, special, modifier, in_head)
 }

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -145,6 +145,11 @@ where
         return Err(parser.make_warn(ParseWarningKind::InvalidSpecialBlock));
     }
 
+    // Check if this block allows modifier invocation ('_' after name)
+    if !block.accepts_modifier && modifier {
+        return Err(parser.make_warn(ParseWarningKind::InvalidModifierBlock));
+    }
+
     parser.get_optional_space()?;
 
     // Run the parse function until the end.

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -91,7 +91,11 @@ fn block_skip<'r, 't>(
     });
 
     if result {
-        info!(log, "Skipping newline due to upcoming line-terminated block");
+        info!(
+            log,
+            "Skipping newline due to upcoming line-terminated block",
+        );
+
         ok!(Elements::None)
     } else {
         Err(parser.make_warn(ParseWarningKind::RuleFailed))


### PR DESCRIPTION
Previously we did `name.ends_with('_')` to determine if the modifier flag should be set. This PR changes the block rule so that it's derived during block parsing and handed as an argument.