### PR TITLE
Update FTML compile settings (WASM-specific)

### DIFF
--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -61,7 +61,6 @@ web-sys = { version = "0.3", features = ["console"] }
 
 [profile.release]
 lto = true
-#opt-level = 's' # Uncomment when building WASM
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-O4']
+wasm-opt = ["-O4", "-c"]


### PR DESCRIPTION
Removes the recommendation to compile with `opt-level = 's'`, as this caused a fairly significant performance hit if done. This also adds the `wasm-opt` `-c` flag, which causes the optimizer to be ran multiple times until the file size converges. This has some nice effects on binary size.