### PR TITLE
[WJ-401] Enable FFI in our PHP containers

### DIFF
--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -43,6 +43,11 @@ RUN apk add --update --no-cache \
     # Memcached PHP lib
     /src/setup-memcached.sh
 
+# Configure PHP-FFI
+RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+    && docker-php-ext-configure ffi --with-ffi \
+    && docker-php-ext-install ffi
+
 # Install the Wikijump repository
 WORKDIR /var/www
 

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -2,8 +2,6 @@ FROM php:7.4-fpm-alpine
 
 EXPOSE 80
 
-# TODO: copy from bluesoul's container Dockerfile
-
 # Build variables
 ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_DIR="wikijump"

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -45,6 +45,11 @@ RUN apk add --update --no-cache \
     tidyhtml-dev \
     gettext-dev
 
+# Configure PHP-FFI
+RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+    && docker-php-ext-configure ffi --with-ffi \
+    && docker-php-ext-install ffi
+
 # Memcached PHP lib
 RUN /src/setup-memcached.sh
 

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -44,6 +44,11 @@ RUN apk add --update --no-cache \
     # Memcached PHP lib
     /src/setup-memcached.sh
 
+# Configure PHP-FFI
+RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+    && docker-php-ext-configure ffi --with-ffi \
+    && docker-php-ext-install ffi
+
 ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # !! Put your IP for debugging here.

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -2,8 +2,6 @@ FROM php:7.4-fpm-alpine
 
 EXPOSE 9000
 
-# TODO: copy from bluesoul's container Dockerfile
-
 # Build variables
 ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_DIR="wikijump"


### PR DESCRIPTION
As a pre-requisite to [WJ-401](https://scuttle.atlassian.net/browse/WJ-401) (creating an FFI for ftml for PHP), we need to enable FFI within PHP.