### PR TITLE
Export render_text()

### DIFF
--- a/ftml/src/wasm/mod.rs
+++ b/ftml/src/wasm/mod.rs
@@ -41,5 +41,5 @@ pub use self::log::ConsoleLogger;
 pub use self::misc::version;
 pub use self::parsing::{parse, ParseOutcome, SyntaxTree};
 pub use self::preproc::preprocess;
-pub use self::render::render_html;
+pub use self::render::{render_html, render_text};
 pub use self::tokenizer::{tokenize, Tokenization};


### PR DESCRIPTION
These `pub use`s aren't actually utilized, but as convention here I'm making anything being exposed to the wasm `pub` and used, as if a Rust crate was depending on this. This PR adds `render_text()` as an export, as it is presently missing.