### PR TITLE
[WJ-481] Add schema files for ftml block / module data

### DIFF
--- a/ftml/conf/blocks.schema.toml
+++ b/ftml/conf/blocks.schema.toml
@@ -48,14 +48,6 @@ head = "map"
 # values: "none", "raw", "elements", "other"
 body = "elements"
 
-# Which arguments (if any) this block accepts.
-# Does not include HTML attributes, see below.
-#
-# Only applies to blocks that have head = "map" or "value+map".
-#
-# type: string[], optional
-arguments = ["hideLocation", "show", "hide"]
-
 # Whether this block accepts safe HTML attributes as arguments.
 # These are then ported to the final HTML element in rendering,
 # with possible changes for safety or correctness.
@@ -90,3 +82,38 @@ html-output = "html,span"
 # type: string, enum, optional
 # values: "", "module"
 special = ""
+
+# Each argument that this block accepts gets its own sub-key.
+# Case-insensitive.
+[block-name.argument-name]
+
+# The high-level type of this argument.
+# If it ends in "[]", then it is a list of that kind.
+#
+# type: string
+# values: "string", "int", "float"
+type = "string"
+
+# What values this can argument can take, if it's an enum.
+# If this field is excluded, then the argument can take any value.
+#
+# type: $argument_type[], optional
+enum = [
+    "top",
+    "bottom",
+    "both",
+    "neither",
+]
+
+# What the maximum and minimum bounds this argument can take, if it's a numerical value.
+# If one or both of these fields are excluded, then there is no upper limit.
+#
+# type: $argument_type, optional
+min-value = 0
+max-value = 500
+
+# What value this argument has by default, if not excluded.
+# Implies that the argument is optional.
+#
+# type: $argument_type, optional
+default = "both"

--- a/ftml/conf/blocks.schema.toml
+++ b/ftml/conf/blocks.schema.toml
@@ -85,7 +85,9 @@ special = ""
 
 # Each argument that this block accepts gets its own sub-key.
 # Case-insensitive.
-[block-name.argument-name]
+#
+# For instance, "collapsible.arguments.hideLocation".
+[block-name.arguments.argument-name]
 
 # The high-level type of this argument.
 # If it ends in "[]", then it is a list of that kind.

--- a/ftml/conf/blocks.schema.toml
+++ b/ftml/conf/blocks.schema.toml
@@ -1,6 +1,6 @@
 # Schema for blocks.toml
 #
-# This describes what properties bloks can have, as mentioned in docs/Blocks.md
+# This describes what properties blocks can have, as mentioned in docs/Blocks.md
 
 [block-name]
 

--- a/ftml/conf/blocks.schema.toml
+++ b/ftml/conf/blocks.schema.toml
@@ -1,0 +1,92 @@
+# Schema for blocks.toml
+#
+# This describes what properties bloks can have, as mentioned in docs/Blocks.md
+
+[block-name]
+
+# Whether this block is deprecated or not.
+# Deprecated blocks should be clearly marked as such, and
+# should not be actively recommended to users.
+#
+# If this is set, then the deprecation-message in the corresponding
+# language file should be populated.
+#
+# type: bool, optional
+deprecated = false
+
+# What aliases (if any) this block accepts, in addition to its name.
+# Case-insensitive.
+#
+# type: string[], optional
+aliases = ["a", "anchor"]
+
+# Whether this block accepts the star (*) modifier.
+#
+# type: bool, optional
+accepts-star = false
+
+# Whether this block accepts the score (_) modifier.
+#
+# type: bool, optional
+accepts-score = true
+
+# Whether this block accepts newline delimition for its sections.
+#
+# type: bool, optional
+accepts-newlines = true
+
+# What kind of head this block expects.
+# See the document "Blocks.md" for more information.
+#
+# type: string, enum
+# values: "none", "value", "map", "value+map"
+head = "map"
+
+# What kind of body this block expects, if any.
+#
+# type: string, enum
+# values: "none", "raw", "elements", "other"
+body = "elements"
+
+# Which arguments (if any) this block accepts.
+# Does not include HTML attributes, see below.
+#
+# Only applies to blocks that have head = "map" or "value+map".
+#
+# type: string[], optional
+arguments = ["hideLocation", "show", "hide"]
+
+# Whether this block accepts safe HTML attributes as arguments.
+# These are then ported to the final HTML element in rendering,
+# with possible changes for safety or correctness.
+#
+# Only applies to blocks that have head = "map" or "value+map".
+#
+# type: bool, optional
+html-attributes = true
+
+# What kind of HTML output this block produces.
+#
+# This field is formatted a bit particularly:
+#
+# "none"
+#  -> No output.
+# "html,$element[,$class]"
+#  -> This produces a DOM element of the given type. For instance, "html,iframe"
+#     If the third element is specified, then it ensures that this element has
+#     the given class added. "html,div,test" means that '<div class="test">' is produced.
+# "css"
+#  -> This modifies the page's CSS rules in some way.
+# "other"
+#  -> This produces some other kind of output that does not fit in the above.
+#     Because it is not "none" it produces some DOM elements, but it cannot be readily
+#     described, perhaps because it is context-sensitive or variable.
+html-output = "html,span"
+
+# Whether this block has behavior that needs special handling logic.
+# The value describes the kind of behavior to expect, and code
+# should look for this flag rather than hardcoding based on block name.
+#
+# type: string, enum, optional
+# values: "", "module"
+special = ""

--- a/ftml/conf/modules.schema.toml
+++ b/ftml/conf/modules.schema.toml
@@ -41,6 +41,8 @@ attributes = true
 
 # Each argument that this module accepts gets its own sub-key.
 # Case-insensitive.
-[module-name.argument-name]
+#
+# For instance, "join.arguments.button"
+[module-name.arguments.argument-name]
 
 # Schema for arguments is the same as for blocks. See blocks.schema.toml

--- a/ftml/conf/modules.schema.toml
+++ b/ftml/conf/modules.schema.toml
@@ -1,0 +1,40 @@
+# Schema for modules.toml
+#
+# This describes what properties modules can have, as mentioned in docs/Modules.md
+# Modules are a subset of blocks, specified with the block [[module XYZ]],
+# where "XYZ" is the module's name.
+#
+# See also blocks.schema.toml
+
+[module-name]
+
+# Whether this module is deprecated or not.
+# Deprecated modules should be clearly marked as such, and
+# should not be actively recommended to users.
+#
+# If this is set, then the deprecation-message in the corresponding
+# language file should be populated.
+#
+# type: bool, optional
+deprecated = false
+
+# What aliases (if any) this module accepts.
+# Case-insensitive.
+#
+# type: string[], optional
+aliases = ["PageTree", "PageForest"]
+
+# What kind of body this module expects, if any.
+#
+# type: string, enum
+# values: "none", "raw", "elements", "other"
+body = "elements"
+
+# Whether this module accepts safe HTML attributes as arguments.
+# These are then ported to the final HTML element in rendering,
+# with possible changes for safety or correctness.
+#
+# Only applies to modules that have head = "map" or "value+map".
+#
+# type: bool, optional
+attributes = true

--- a/ftml/conf/modules.schema.toml
+++ b/ftml/conf/modules.schema.toml
@@ -38,3 +38,9 @@ body = "elements"
 #
 # type: bool, optional
 attributes = true
+
+# Each argument that this module accepts gets its own sub-key.
+# Case-insensitive.
+[module-name.argument-name]
+
+# Schema for arguments is the same as for blocks. See blocks.schema.toml


### PR DESCRIPTION
The actual data files are coming later, named as `blocks.toml` and `modules.toml` respectively. This PR just exposes the schema they will follow.