### PR TITLE
[WJ-478] HTML attribute safety

### DIFF
--- a/ftml/src/parsing/boolean.rs
+++ b/ftml/src/parsing/boolean.rs
@@ -19,7 +19,7 @@
  */
 
 /// Parse a boolean string into its corresponding value.
-pub fn parse_boolean<S: AsRef<str>>(s: S) -> Result<bool, ()> {
+pub fn parse_boolean<S: AsRef<str>>(s: S) -> Result<bool, NonBooleanValue> {
     const NAMES: [(&str, bool); 8] = [
         ("true", true),
         ("false", false),
@@ -38,5 +38,11 @@ pub fn parse_boolean<S: AsRef<str>>(s: S) -> Result<bool, ()> {
         }
     }
 
-    Err(())
+    Err(NonBooleanValue)
 }
+
+/// Error value for `parse_boolean()`.
+/// Returned if the given string value is not a loose boolean,
+/// for instance `"yes"` or `"true"`.
+#[derive(Debug)]
+pub struct NonBooleanValue;

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -46,7 +46,6 @@ mod prelude {
     pub use crate::tree::{Element, Elements, ElementsIterator};
 }
 
-use self::boolean::parse_boolean;
 use self::depth::{process_depths, DepthItem, DepthList};
 use self::paragraph::{gather_paragraphs, NO_CLOSE_CONDITION};
 use self::parser::Parser;
@@ -57,6 +56,7 @@ use crate::tokenizer::Tokenization;
 use crate::tree::SyntaxTree;
 use std::borrow::Cow;
 
+pub use self::boolean::parse_boolean;
 pub use self::exception::{ParseException, ParseWarning, ParseWarningKind};
 pub use self::outcome::ParseOutcome;
 pub use self::result::{ParseResult, ParseSuccess};

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -56,7 +56,7 @@ use crate::tokenizer::Tokenization;
 use crate::tree::SyntaxTree;
 use std::borrow::Cow;
 
-pub use self::boolean::parse_boolean;
+pub use self::boolean::{parse_boolean, NonBooleanValue};
 pub use self::exception::{ParseException, ParseWarning, ParseWarningKind};
 pub use self::outcome::ParseOutcome;
 pub use self::result::{ParseResult, ParseSuccess};

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -39,8 +39,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing blockquote block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Blockquote doesn't allow special variant");
-    assert_eq!(modifier, false, "Blockquote doesn't allow modifier variant");
+    assert!(!special, "Blockquote doesn't allow special variant");
+    assert!(!modifier, "Blockquote doesn't allow modifier variant");
     assert_block_name(&BLOCK_BLOCKQUOTE, name);
 
     let arguments = parser.get_head_map(&BLOCK_BLOCKQUOTE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Bold doesn't allow special variant");
-    assert_eq!(modifier, false, "Bold doesn't allow modifier variant");
+    assert!(!special, "Bold doesn't allow special variant");
+    assert!(!modifier, "Bold doesn't allow modifier variant");
     assert_block_name(&BLOCK_BOLD, name);
 
     let arguments = parser.get_head_map(&BLOCK_BOLD, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -58,8 +58,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing character / HTML entity block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Char doesn't allow special variant");
-    assert_eq!(modifier, false, "Char doesn't allow modifier variant");
+    assert!(!special, "Char doesn't allow special variant");
+    assert!(!modifier, "Char doesn't allow modifier variant");
     assert_block_name(&BLOCK_CHAR, name);
 
     // Parse the entity and get the string

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -45,7 +45,7 @@ fn parse_fn<'r, 't>(
         "special" => special,
     );
 
-    assert_eq!(modifier, false, "Checkbox doesn't allow modifier variant");
+    assert!(!modifier, "Checkbox doesn't allow modifier variant");
     assert_block_name(&BLOCK_CHECKBOX, name);
 
     let arguments = parser.get_head_map(&BLOCK_CHECKBOX, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -39,8 +39,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing code block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Code doesn't allow special variant");
-    assert_eq!(modifier, false, "Code doesn't allow modifier variant");
+    assert!(!special, "Code doesn't allow special variant");
+    assert!(!modifier, "Code doesn't allow modifier variant");
     assert_block_name(&BLOCK_CODE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_CODE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -44,11 +44,8 @@ fn parse_fn<'r, 't>(
         "in-head" => in_head,
     );
 
-    assert_eq!(special, false, "Collapsible doesn't allow special variant");
-    assert_eq!(
-        modifier, false,
-        "Collapsible doesn't allow modifier variant",
-    );
+    assert!(!special, "Collapsible doesn't allow special variant");
+    assert!(!modifier, "Collapsible doesn't allow modifier variant");
     assert_block_name(&BLOCK_COLLAPSIBLE, name);
 
     let mut arguments = parser.get_head_map(&BLOCK_COLLAPSIBLE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -39,8 +39,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing CSS block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "CSS doesn't allow special variant");
-    assert_eq!(modifier, false, "CSS doesn't allow modifier variant");
+    assert!(!special, "CSS doesn't allow special variant");
+    assert!(!modifier, "CSS doesn't allow modifier variant");
     assert_block_name(&BLOCK_CSS, name);
 
     parser.get_head_none(&BLOCK_CSS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Deletion doesn't allow special variant");
-    assert_eq!(modifier, false, "Deletion doesn't allow modifier variant");
+    assert!(!special, "Deletion doesn't allow special variant");
+    assert!(!modifier, "Deletion doesn't allow modifier variant");
     assert_block_name(&BLOCK_DEL, name);
 
     let arguments = parser.get_head_map(&BLOCK_DEL, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Div doesn't allow special variant");
+    assert!(!special, "Div doesn't allow special variant");
     assert_block_name(&BLOCK_DIV, name);
 
     let arguments = parser.get_head_map(&BLOCK_DIV, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Hidden doesn't allow special variant");
-    assert_eq!(modifier, false, "Hidden doesn't allow modifier variant");
+    assert!(!special, "Hidden doesn't allow special variant");
+    assert!(!modifier, "Hidden doesn't allow modifier variant");
     assert_block_name(&BLOCK_HIDDEN, name);
 
     let arguments = parser.get_head_map(&BLOCK_HIDDEN, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/html.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/html.rs
@@ -39,8 +39,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing HTML block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "HTML doesn't allow special variant");
-    assert_eq!(modifier, false, "HTML doesn't allow modifier variant");
+    assert!(!special, "HTML doesn't allow special variant");
+    assert!(!modifier, "HTML doesn't allow modifier variant");
     assert_block_name(&BLOCK_HTML, name);
 
     parser.get_head_none(&BLOCK_HTML, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -39,8 +39,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing iframe block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "iframe doesn't allow special variant");
-    assert_eq!(modifier, false, "iframe doesn't allow modifier variant");
+    assert!(!special, "iframe doesn't allow special variant");
+    assert!(!modifier, "iframe doesn't allow modifier variant");
     assert_block_name(&BLOCK_IFRAME, name);
 
     let (url, arguments) = parser.get_head_name_map(&BLOCK_IFRAME, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/include.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include.rs
@@ -48,8 +48,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Found invalid include block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Include doesn't allow special variant");
-    assert_eq!(modifier, false, "Include doesn't allow modifier variant");
+    assert!(!special, "Include doesn't allow special variant");
+    assert!(!modifier, "Include doesn't allow modifier variant");
     assert_block_name(&BLOCK_INCLUDE, name);
 
     // Includes are handled specially, so we should never actually be

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Ins doesn't allow special variant");
-    assert_eq!(modifier, false, "Ins doesn't allow modifier variant");
+    assert!(!special, "Ins doesn't allow special variant");
+    assert!(!modifier, "Ins doesn't allow modifier variant");
     assert_block_name(&BLOCK_INS, name);
 
     let arguments = parser.get_head_map(&BLOCK_INS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Invisible doesn't allow special variant");
-    assert_eq!(modifier, false, "Invisible doesn't allow modifier variant");
+    assert!(!special, "Invisible doesn't allow special variant");
+    assert!(!modifier, "Invisible doesn't allow modifier variant");
     assert_block_name(&BLOCK_INVISIBLE, name);
 
     let arguments = parser.get_head_map(&BLOCK_INVISIBLE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Italics doesn't allow special variant");
-    assert_eq!(modifier, false, "Italics doesn't allow modifier variant");
+    assert!(!special, "Italics doesn't allow special variant");
+    assert!(!modifier, "Italics doesn't allow modifier variant");
     assert_block_name(&BLOCK_ITALICS, name);
 
     let arguments = parser.get_head_map(&BLOCK_ITALICS, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -40,8 +40,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing newlines block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Lines doesn't allow special variant");
-    assert_eq!(modifier, false, "Lines doesn't allow modifier variant");
+    assert!(!special, "Lines doesn't allow special variant");
+    assert!(!modifier, "Lines doesn't allow modifier variant");
     assert_block_name(&BLOCK_LINES, name);
 
     let count = parser.get_head_value(&BLOCK_LINES, in_head, parse_count)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Mark doesn't allow special variant");
-    assert_eq!(modifier, false, "Mark doesn't allow modifier variant");
+    assert!(!special, "Mark doesn't allow special variant");
+    assert!(!modifier, "Mark doesn't allow modifier variant");
     assert_block_name(&BLOCK_MARK, name);
 
     let arguments = parser.get_head_map(&BLOCK_MARK, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
@@ -53,9 +53,8 @@ fn build_module_rule_map(module_rules: &'static [ModuleRule]) -> ModuleRuleMap {
             "Module name does not start with 'module-'.",
         );
 
-        assert_eq!(
-            module_rule.accepts_names.is_empty(),
-            false,
+        assert!(
+            !module_rule.accepts_names.is_empty(),
             "Module has no accepted names",
         );
 

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -40,8 +40,8 @@ fn parse_fn<'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Parsing module block"; "in-head" => in_head);
 
-    assert_eq!(special, false, "Module doesn't allow special variant");
-    assert_eq!(modifier, false, "Module doesn't allow modifier variant");
+    assert!(!special, "Module doesn't allow special variant");
+    assert!(!modifier, "Module doesn't allow modifier variant");
     assert_block_name(&BLOCK_MODULE, name);
 
     // Get module name and arguments

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Monospace doesn't allow special variant");
-    assert_eq!(modifier, false, "Monospace doesn't allow modifier variant");
+    assert!(!special, "Monospace doesn't allow special variant");
+    assert!(!modifier, "Monospace doesn't allow modifier variant");
     assert_block_name(&BLOCK_MONOSPACE, name);
 
     let arguments = parser.get_head_map(&BLOCK_MONOSPACE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -45,10 +45,7 @@ fn parse_fn<'r, 't>(
         "special" => special,
     );
 
-    assert_eq!(
-        modifier, false,
-        "Radio buttons don't allow modifier variant",
-    );
+    assert!(!modifier, "Radio buttons don't allow modifier variant");
     assert_block_name(&BLOCK_RADIO, name);
 
     let (name, arguments) = parser.get_head_name_map(&BLOCK_RADIO, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -46,8 +46,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Size doesn't allow special variant");
-    assert_eq!(modifier, false, "Size doesn't allow modifier variant");
+    assert!(!special, "Size doesn't allow special variant");
+    assert!(!modifier, "Size doesn't allow modifier variant");
     assert_block_name(&BLOCK_SIZE, name);
 
     let size =

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Span doesn't allow special variant");
+    assert!(!special, "Span doesn't allow special variant");
     assert_block_name(&BLOCK_SPAN, name);
 
     let arguments = parser.get_head_map(&BLOCK_SPAN, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -44,14 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(
-        special, false,
-        "Strikethrough doesn't allow special variant",
-    );
-    assert_eq!(
-        modifier, false,
-        "Strikethrough doesn't allow modifier variant",
-    );
+    assert!(!special, "Strikethrough doesn't allow special variant");
+    assert!(!modifier, "Strikethrough doesn't allow modifier variant");
     assert_block_name(&BLOCK_STRIKETHROUGH, name);
 
     let arguments = parser.get_head_map(&BLOCK_STRIKETHROUGH, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Subscript doesn't allow special variant");
-    assert_eq!(modifier, false, "Subscript doesn't allow modifier variant");
+    assert!(!special, "Subscript doesn't allow special variant");
+    assert!(!modifier, "Subscript doesn't allow modifier variant");
     assert_block_name(&BLOCK_SUBSCRIPT, name);
 
     let arguments = parser.get_head_map(&BLOCK_SUBSCRIPT, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -44,11 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Superscript doesn't allow special variant");
-    assert_eq!(
-        modifier, false,
-        "Superscript doesn't allow modifier variant",
-    );
+    assert!(!special, "Superscript doesn't allow special variant");
+    assert!(!modifier, "Superscript doesn't allow modifier variant");
     assert_block_name(&BLOCK_SUPERSCRIPT, name);
 
     let arguments = parser.get_head_map(&BLOCK_SUPERSCRIPT, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -44,8 +44,8 @@ fn parse_fn<'r, 't>(
         "name" => name,
     );
 
-    assert_eq!(special, false, "Underline doesn't allow special variant");
-    assert_eq!(modifier, false, "Underline doesn't allow modifier variant");
+    assert!(!special, "Underline doesn't allow special variant");
+    assert!(!modifier, "Underline doesn't allow modifier variant");
     assert_block_name(&BLOCK_UNDERLINE, name);
 
     let arguments = parser.get_head_map(&BLOCK_UNDERLINE, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -77,9 +77,8 @@ fn build_block_rule_map(block_rules: &'static [BlockRule]) -> BlockRuleMap {
             "Block name does not start with 'block-'.",
         );
 
-        assert_eq!(
-            block_rule.accepts_names.is_empty(),
-            false,
+        assert!(
+            !block_rule.accepts_names.is_empty(),
             "Rule has no accepted names",
         );
 

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -228,9 +228,8 @@ where
     {
         trace!(&self.log(), "Running generic in block body parser");
 
-        debug_assert_eq!(
-            block_rule.accepts_names.is_empty(),
-            false,
+        debug_assert!(
+            !block_rule.accepts_names.is_empty(),
             "List of valid end block names is empty, no success is possible",
         );
 

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -217,7 +217,7 @@ impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
             self.in_tag = false;
         }
 
-        assert_eq!(self.in_contents, false, "Already in tag contents");
+        assert!(!self.in_contents, "Already in tag contents");
         self.in_contents = true;
     }
 

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -122,8 +122,14 @@ impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
         //
         // For instance, ("checked", &[]) in input produces
         // <input checked> rather than <input checked="...">
+        //
+        // Alternatively, if it's only composed of empty strings,
+        // the same intent is signalled.
+        //
+        // Because .all() is true for empty slices, this expression
+        // checks both:
 
-        let has_value = !value_parts.is_empty();
+        let has_value = !value_parts.iter().all(|s| s.is_empty());
 
         self.attr_key(key, has_value);
 

--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -125,6 +125,47 @@ lazy_static! {
             "wrap",
         ]
     };
+
+    /// List of all HTML5 attributes with special boolean behavior.
+    ///
+    /// That is, you set them to "true" by having the attribute present without
+    /// a value, and "false" by excluding them.
+    ///
+    /// A notable example is "checked" for `<input>`:
+    /// * `<input type="checkbox" checked>` means the checkbox starts checked
+    /// * `<input type="checkbox">` means it starts unchecked
+    ///
+    /// This list includes all such attributes, even if they are not part of
+    /// `SAFE_ATTRIBUTES`.
+    pub static ref BOOLEAN_ATTRIBUTES: HashSet<UniCase<&'static str>> = {
+        hashset_unicase![
+            "allowfullscreen",
+            "allowpaymentrequest",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "controls",
+            "default",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "selected",
+            "truespeed",
+        ]
+    };
 }
 
 pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 1] = ["data-"];

--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -101,7 +101,6 @@ lazy_static! {
             "reversed",
             "rows",
             "rowspan",
-            "sandbox",
             "scope",
             "selected",
             "shape",

--- a/ftml/test/checkbox-style.html
+++ b/ftml/test/checkbox-style.html
@@ -1,1 +1,1 @@
-<p><input type="checkbox" id="apple" style="color: red;">Apple<br><input type="checkbox" id="banana" style="color: yellow;">Banana</p>
+<p><input type="checkbox" disabled id="apple" style="color: red;">Apple<br><input type="checkbox" id="banana" style="color: yellow;">Banana</p>

--- a/ftml/test/checkbox-style.json
+++ b/ftml/test/checkbox-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[checkbox id=\"apple\" style=\"color: red;\"]] Apple\n[[checkbox id=\"banana\" style=\"color: yellow;\"]] Banana",
+    "input": "[[checkbox id=\"apple\" style=\"color: red;\" disabled=\"yes\"]] Apple\n[[checkbox id=\"banana\" style=\"color: yellow;\"]] Banana",
     "tree": {
         "elements": [
             {
@@ -13,6 +13,7 @@
                             "data": {
                                 "checked": false,
                                 "attributes": {
+                                    "disabled": "",
                                     "id": "apple",
                                     "style": "color: red;"
                                 }

--- a/ftml/test/checkbox-style.json
+++ b/ftml/test/checkbox-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[checkbox id=\"apple\" style=\"color: red;\" disabled=\"yes\"]] Apple\n[[checkbox id=\"banana\" style=\"color: yellow;\"]] Banana",
+    "input": "[[checkbox id=\"apple\" style=\"color: red;\" disabled=\"yes\"]] Apple\n[[checkbox id=\"banana\" style=\"color: yellow;\" disabled=\"false\"]] Banana",
     "tree": {
         "elements": [
             {


### PR DESCRIPTION
This PR removes `sandbox`, an unsafe HTML attribute. It also modifies how handling works for boolean HTML5 attributes which base their logic off of the presence/absence of a solo key rather than `key="value"`. There is also a test for this behavior.