### PR TITLE
Change ftml crate type to dylib

### DIFF
--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018" # this refers to the Cargo.toml version
 
 [lib]
 name = "ftml"
-crate-type = ["lib", "dylib, "cdylib"]
+crate-type = ["lib", "dylib", "cdylib"]
 
 [features]
 default  = ["ffi", "log"]

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018" # this refers to the Cargo.toml version
 
 [lib]
 name = "ftml"
-crate-type = ["cdylib", "lib"]
+crate-type = ["dylib", "lib"]
 
 [features]
 default  = ["ffi", "log"]

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018" # this refers to the Cargo.toml version
 
 [lib]
 name = "ftml"
-crate-type = ["dylib", "lib"]
+crate-type = ["lib", "dylib, "cdylib"]
 
 [features]
 default  = ["ffi", "log"]


### PR DESCRIPTION
When building on Docker:
```
warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-linux-musl`

warning: 1 warning emitted
```