### PR TITLE
[WJ-464] Build ftml in php-fpm containers

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -461,9 +461,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libflate"
@@ -1127,11 +1127,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi",
  "winapi",
 ]
 
@@ -1279,9 +1280,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/install/aws/dev/docker/nginx/Dockerfile
+++ b/install/aws/dev/docker/nginx/Dockerfile
@@ -1,3 +1,5 @@
+# Build static assets using npm
+
 FROM node:alpine as npm
 
 # Please note this arg is also defined in the nginx layer further down.
@@ -19,6 +21,8 @@ WORKDIR /src/${WIKIJUMP_REPO_DIR}/web
 
 RUN npm install
 RUN npm run build
+
+# Main nginx container
 
 FROM nginx:alpine
 ARG WIKIJUMP_REPO_DIR="wikijump"

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -59,6 +59,7 @@ RUN apt install -y \
     libfreetype6-dev \
     imagemagick \
     git \
+    zip \
     html2text \
     libmemcached-dev \
     postgresql-common \
@@ -123,5 +124,9 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
     chown -R www-data:www-data .
 
 COPY etc/php/ /usr/local/etc/php/conf.d/
+
+# Clean up packages
+RUN apt autoclean
+RUN apt autoremove -y
 
 CMD ["php-fpm"]

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -52,18 +52,18 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apt install \
-    libgd \
-    libpng-dev \
-    libjpeg-turbo-dev \
-    freetype-dev \
+RUN apt update
+RUN apt install -y \
+    libgd-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
     imagemagick \
+    git \
     html2text \
-    libmemcached-libs \
-    zlib \
-    postgresql-dev \
-    tidyhtml-dev \
-    gettext-dev && \
+    libmemcached-dev \
+    postgresql-common \
+    libtidy-dev \
+    gettext && \
 
     # Memcached PHP lib
     /src/setup-memcached.sh
@@ -80,7 +80,7 @@ COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/libftml.so /usr/l
 # Install the Wikijump repository
 WORKDIR /var/www
 
-COPY --from=rust /src/${WIKIJUMP_REPO_DIR} ${WIKIJUMP_DIR}
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm
+FROM php:7.4-fpm-buster
 
 EXPOSE 9000
 

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -80,7 +80,7 @@ COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/libftml.so /usr/l
 # Install the Wikijump repository
 WORKDIR /var/www
 
-COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -2,7 +2,7 @@
 # Build ftml for parsing and rendering
 #
 
-FROM rust:alpine as rust
+FROM rust:latest as rust
 
 # Please note this arg is also defined in the php-fpm layer further down.
 ARG WIKIJUMP_REPO_DIR="wikijump"
@@ -11,8 +11,9 @@ ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_BRANCH="develop"
 WORKDIR /src
 
-RUN apk add --no-cache \
-    alpine-sdk \
+RUN apt update
+RUN apt install -y \
+    build-essential \
     git
 
 RUN git clone \
@@ -28,7 +29,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm
 
 EXPOSE 9000
 
@@ -54,7 +55,7 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apk add --update --no-cache \
+RUN apt install \
     libgd \
     libpng-dev \
     libjpeg-turbo-dev \
@@ -71,7 +72,7 @@ RUN apk add --update --no-cache \
     /src/setup-memcached.sh
 
 # Configure PHP-FFI
-RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+RUN apt install libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
 

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -43,9 +43,6 @@ ARG FILES_DOMAIN="wjfiles.dev"
 ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 
-# Configure timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
 WORKDIR /src
 
 # Copy scripts

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -125,8 +125,4 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
 
 COPY etc/php/ /usr/local/etc/php/conf.d/
 
-# Clean up packages
-RUN apt autoclean
-RUN apt autoremove -y
-
 CMD ["php-fpm"]

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -1,4 +1,6 @@
-# Build libftml for parsing and rendering
+#
+# Build ftml for parsing and rendering
+#
 
 FROM rust:alpine as rust
 
@@ -9,7 +11,9 @@ ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_BRANCH="develop"
 WORKDIR /src
 
-RUN apk add --no-cache git
+RUN apk add --no-cache \
+    alpine-sdk \
+    git
 
 RUN git clone \
         --depth 10 \
@@ -20,14 +24,15 @@ WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
 
 RUN cargo build --release
 
+#
 # Main php-fpm container
+#
 
 FROM php:7.4-fpm-alpine
 
 EXPOSE 9000
 
 # Build variables
-
 ARG WIKIJUMP_REPO_DIR="wikijump"
 
 ARG MAIN_DOMAIN="wikijump.dev"

--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -1,11 +1,34 @@
+# Build libftml for parsing and rendering
+
+FROM rust:alpine as rust
+
+# Please note this arg is also defined in the php-fpm layer further down.
+ARG WIKIJUMP_REPO_DIR="wikijump"
+
+ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+ARG WIKIJUMP_REPO_BRANCH="develop"
+WORKDIR /src
+
+RUN apk add --no-cache git
+
+RUN git clone \
+        --depth 10 \
+        --branch "${WIKIJUMP_REPO_BRANCH}" \
+        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+
+WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
+
+RUN cargo build --release
+
+# Main php-fpm container
+
 FROM php:7.4-fpm-alpine
 
 EXPOSE 9000
 
 # Build variables
-ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+
 ARG WIKIJUMP_REPO_DIR="wikijump"
-ARG WIKIJUMP_REPO_BRANCH="develop"
 
 ARG MAIN_DOMAIN="wikijump.dev"
 ARG FILES_DOMAIN="wjfiles.dev"
@@ -32,7 +55,6 @@ RUN apk add --update --no-cache \
     libjpeg-turbo-dev \
     freetype-dev \
     imagemagick \
-    git \
     html2text \
     libmemcached-libs \
     zlib \
@@ -48,13 +70,14 @@ RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
 
+# Install libftml
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/ftml.h /usr/local/include/ftml.h
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/libftml.so /usr/local/lib/libftml.so
+
 # Install the Wikijump repository
 WORKDIR /var/www
 
-RUN git clone \
-        --depth 10 \
-        --branch "${WIKIJUMP_REPO_BRANCH}" \
-        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR} ${WIKIJUMP_DIR}
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 

--- a/install/aws/dev/docker/php-fpm/setup-memcached.sh
+++ b/install/aws/dev/docker/php-fpm/setup-memcached.sh
@@ -1,28 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
 # Variables
 readonly cores="$(nproc)"
 
 # Install dependencies
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.phpize-deps \
-		$PHPIZE_DEPS \
+apt install
+readonly dependencies=(
+	'libmemcached-dev'
+	'postgresql-server-dev-11'
+)
 
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.memcached-deps \
-		zlib-dev \
-		libmemcached-dev \
-		cyrus-sasl-dev
+apt install -y "${dependencies[@]}"
 
 # Install igbinary (memcached's deps)
-pecl channel-update pecl.php.net
 pecl install igbinary
 
 # Install memcached
@@ -45,9 +36,14 @@ phpize
 make "-j$cores"
 make install
 
+# Install xdebug
+pecl install xdebug
+
+# Uninstall temporary dependencies
+apt remove -y "${dependencies[@]}"
+
 # Enable PHP extensions and clean up
-docker-php-ext-enable igbinary memcached memcache
-apk del .memcached-deps .phpize-deps
+docker-php-ext-enable igbinary memcached memcache xdebug
 docker-php-ext-install \
 	"-j$cores" \
 		opcache \

--- a/install/aws/dev/docker/php-fpm/setup-memcached.sh
+++ b/install/aws/dev/docker/php-fpm/setup-memcached.sh
@@ -5,7 +5,6 @@ set -eux
 readonly cores="$(nproc)"
 
 # Install dependencies
-apt install
 readonly dependencies=(
 	'libmemcached-dev'
 	'postgresql-server-dev-11'

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -54,21 +54,18 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apt install \
-    libgd \
-    libpng-dev \
-    libjpeg-turbo-dev \
-    freetype-dev \
+RUN apt update
+RUN apt install -y \
+    libgd-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
     imagemagick \
-    nodejs \
-    npm \
+    git \
     html2text \
-    nginx \
-    libmemcached-libs \
-    zlib \
-    postgresql-dev \
-    tidyhtml-dev \
-    gettext-dev
+    libmemcached-dev \
+    postgresql-common \
+    libtidy-dev \
+    gettext && \
 
 # Configure PHP-FFI
 RUN apt install libffi-dev \
@@ -85,11 +82,8 @@ RUN /src/setup-memcached.sh
 # TODO - let's see if we actually need xdiff and if so can we include it as an artifact or docker layer
 
 # Install the Wikijump repository
-WORKDIR /var/www
-RUN git clone \
-    --depth 10 \
-    --branch "${WIKIJUMP_REPO_BRANCH}" \
-    "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+# Copy Wikijump files
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 RUN mkdir -p \

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm
+FROM php:7.4-fpm-buster
 
 EXPOSE 80
 

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -61,6 +61,7 @@ RUN apt install -y \
     libfreetype6-dev \
     imagemagick \
     git \
+    zip \
     html2text \
     libmemcached-dev \
     postgresql-common \
@@ -127,6 +128,10 @@ RUN mkdir /etc/nginx/sites-enabled && \
     rm -f /etc/nginx/sites-enabled/default
 
 RUN install -m 400 -o www-data -g www-data .env.example .env && php artisan key:generate
+
+# Clean up packages
+RUN apt autoclean
+RUN apt autoremove -y
 
 # Main process
 # Let the upstream ENTRYPOINT handle running php-fpm

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -1,11 +1,39 @@
+#
+# Build ftml for parsing and rendering
+#
+
+FROM rust:alpine as rust
+
+# Please note this arg is also defined in the php-fpm layer further down.
+ARG WIKIJUMP_REPO_DIR="wikijump"
+
+ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+ARG WIKIJUMP_REPO_BRANCH="develop"
+WORKDIR /src
+
+RUN apk add --no-cache \
+    alpine-sdk \
+    git
+
+RUN git clone \
+        --depth 10 \
+        --branch "${WIKIJUMP_REPO_BRANCH}" \
+        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+
+WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
+
+RUN cargo build --release
+
+#
+# Main php-fpm container
+#
+
 FROM php:7.4-fpm-alpine
 
 EXPOSE 80
 
 # Build variables
-ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_DIR="wikijump"
-ARG WIKIJUMP_REPO_BRANCH="develop"
 
 ARG MAIN_DOMAIN="wikijump.test"
 ARG FILES_DOMAIN="wjfiles.test"
@@ -36,7 +64,6 @@ RUN apk add --update --no-cache \
     imagemagick \
     nodejs \
     npm \
-    git \
     html2text \
     nginx \
     libmemcached-libs \
@@ -49,6 +76,10 @@ RUN apk add --update --no-cache \
 RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
+
+# Install libftml
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/ftml.h /usr/local/include/ftml.h
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/libftml.so /usr/local/lib/libftml.so
 
 # Memcached PHP lib
 RUN /src/setup-memcached.sh

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -43,9 +43,6 @@ ARG FILES_DOMAIN="wjfiles.test"
 ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 
-# Configure timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
 # Preparation
 RUN mkdir /src
 WORKDIR /src

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -2,7 +2,7 @@
 # Build ftml for parsing and rendering
 #
 
-FROM rust:alpine as rust
+FROM rust:latest as rust
 
 # Please note this arg is also defined in the php-fpm layer further down.
 ARG WIKIJUMP_REPO_DIR="wikijump"
@@ -11,8 +11,9 @@ ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_BRANCH="develop"
 WORKDIR /src
 
-RUN apk add --no-cache \
-    alpine-sdk \
+RUN apt update
+RUN apt install -y \
+    build-essential \
     git
 
 RUN git clone \
@@ -28,7 +29,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm
 
 EXPOSE 80
 
@@ -56,7 +57,7 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apk add --update --no-cache \
+RUN apt install \
     libgd \
     libpng-dev \
     libjpeg-turbo-dev \
@@ -73,7 +74,7 @@ RUN apk add --update --no-cache \
     gettext-dev
 
 # Configure PHP-FFI
-RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+RUN apt install libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
 

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -129,10 +129,6 @@ RUN mkdir /etc/nginx/sites-enabled && \
 
 RUN install -m 400 -o www-data -g www-data .env.example .env && php artisan key:generate
 
-# Clean up packages
-RUN apt autoclean
-RUN apt autoremove -y
-
 # Main process
 # Let the upstream ENTRYPOINT handle running php-fpm
 ADD ./entrypoint.sh /usr/local/bin/

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -83,7 +83,7 @@ RUN /src/setup-memcached.sh
 
 # Install the Wikijump repository
 # Copy Wikijump files
-COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 RUN mkdir -p \

--- a/install/aws/prod/docker/php-fpm/setup-memcached.sh
+++ b/install/aws/prod/docker/php-fpm/setup-memcached.sh
@@ -5,7 +5,6 @@ set -eux
 readonly cores="$(nproc)"
 
 # Install dependencies
-apt install
 readonly dependencies=(
 	'libmemcached-dev'
 	'postgresql-server-dev-11'

--- a/install/aws/prod/docker/php-fpm/setup-memcached.sh
+++ b/install/aws/prod/docker/php-fpm/setup-memcached.sh
@@ -1,25 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
 # Variables
 readonly cores="$(nproc)"
 
 # Install dependencies
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.phpize-deps \
-		$PHPIZE_DEPS \
+apt install
+readonly dependencies=(
+	'libmemcached-dev'
+	'postgresql-server-dev-11'
+)
 
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.memcached-deps \
-		zlib-dev \
-		libmemcached-dev \
-		cyrus-sasl-dev
+apt install -y "${dependencies[@]}"
 
 # Install igbinary (memcached's deps)
 pecl install igbinary
@@ -44,13 +36,19 @@ phpize
 make "-j$cores"
 make install
 
+# Install xdebug
+pecl install xdebug
+
+# Uninstall temporary dependencies
+apt remove -y "${dependencies[@]}"
+
 # Enable PHP extensions and clean up
-docker-php-ext-enable igbinary memcached memcache
-apk del .memcached-deps .phpize-deps
+docker-php-ext-enable igbinary memcached memcache xdebug
 docker-php-ext-install \
 	"-j$cores" \
 		opcache \
 		pgsql \
+		pdo_pgsql \
 		tidy \
 		gd \
 		gettext

--- a/install/local/dev/docker-compose.dev.yaml
+++ b/install/local/dev/docker-compose.dev.yaml
@@ -2,6 +2,10 @@ services:
   php-fpm:
     volumes:
       - type: bind
+        source: ../../../ftml
+        target: /var/www/wikijump/web/ftml
+        read_only: true
+      - type: bind
         source: ../../../web/lib
         target: /var/www/wikijump/web/lib
         read_only: true

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm
+FROM php:7.4-fpm-buster
 
 EXPOSE 9000
 

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -46,9 +46,6 @@ ARG FILES_DOMAIN="wjfiles.test"
 ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 
-# Configure timezone
-RUN ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
 WORKDIR /src
 
 # Copy scripts

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -92,7 +92,7 @@ WORKDIR /var/www
 RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
 
 # Copy Wikijump files
-COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -2,7 +2,7 @@
 # Build ftml for parsing and rendering
 #
 
-FROM rust:alpine as rust
+FROM rust:latest as rust
 
 # Please note this arg is also defined in the php-fpm layer further down.
 ARG WIKIJUMP_REPO_DIR="wikijump"
@@ -12,8 +12,9 @@ ARG WIKIJUMP_REPO_BRANCH="develop"
 ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 WORKDIR /src
 
-RUN apk add --no-cache \
-    alpine-sdk \
+RUN apt update
+RUN apt install -y \
+    build-essential \
     git
 
 # !! Comment out if using local bindings
@@ -30,7 +31,7 @@ RUN cargo build --release
 # Main php-fpm container
 #
 
-FROM php:7.4-fpm-alpine
+FROM php:7.4-fpm
 
 EXPOSE 9000
 
@@ -57,7 +58,7 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apk add --update --no-cache \
+RUN apt install \
     libgd \
     libpng-dev \
     libjpeg-turbo-dev \
@@ -75,7 +76,7 @@ RUN apk add --update --no-cache \
     /src/setup-memcached.sh
 
 # Configure PHP-FFI
-RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
+RUN apt install libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
 
@@ -95,7 +96,7 @@ RUN echo "xdebug.mode = debug" >> ${XDEBUG_INI} \
 WORKDIR /var/www
 
 # !! Workaround for WSL2-enabled development with exposed host volumes, comment out if not needed.
-RUN apk add shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data && \
+RUN apt install shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data && \
 
     git clone \
         --depth 10 \

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -9,7 +9,6 @@ ARG WIKIJUMP_REPO_DIR="wikijump"
 
 ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_BRANCH="develop"
-ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
 WORKDIR /src
 
 RUN apt update
@@ -17,7 +16,6 @@ RUN apt install -y \
     build-essential \
     git
 
-# !! Comment out if using local bindings
 RUN git clone \
         --depth 10 \
         --branch "${WIKIJUMP_REPO_BRANCH}" \
@@ -55,19 +53,17 @@ COPY setup-memcached.sh ./
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Install packages
-RUN apt install \
-    libgd \
-    libpng-dev \
-    libjpeg-turbo-dev \
-    freetype-dev \
+RUN apt update
+RUN apt install -y \
+    libgd-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
     imagemagick \
     git \
     html2text \
-    libmemcached-libs \
-    zlib \
-    postgresql-dev \
-    tidyhtml-dev \
-    gettext-dev && \
+    postgresql-common \
+    libtidy-dev \
+    gettext && \
 
     # Memcached PHP lib
     /src/setup-memcached.sh
@@ -93,12 +89,10 @@ RUN echo "xdebug.mode = debug" >> ${XDEBUG_INI} \
 WORKDIR /var/www
 
 # !! Workaround for WSL2-enabled development with exposed host volumes, comment out if not needed.
-RUN apt install shadow && usermod -u 1000 www-data && groupmod -g 1000 www-data && \
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
 
-    git clone \
-        --depth 10 \
-        --branch "${WIKIJUMP_REPO_BRANCH}" \
-        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+# Copy Wikijump files
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/web ${WIKIJUMP_DIR}/wikijump/web
 
 WORKDIR "${WIKIJUMP_DIR}/web"
 
@@ -141,5 +135,9 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
     chown -R www-data:www-data .
 
 COPY etc/php/ /usr/local/etc/php/conf.d/
+
+# Clean up dependencies
+RUN apt autoclean
+RUN apt autoremove
 
 CMD ["php-fpm"]

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -60,6 +60,7 @@ RUN apt install -y \
     libfreetype6-dev \
     imagemagick \
     git \
+    zip \
     html2text \
     postgresql-common \
     libtidy-dev \
@@ -136,8 +137,8 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
 
 COPY etc/php/ /usr/local/etc/php/conf.d/
 
-# Clean up dependencies
+# Clean up packages
 RUN apt autoclean
-RUN apt autoremove
+RUN apt autoremove -y
 
 CMD ["php-fpm"]

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -1,11 +1,41 @@
+#
+# Build ftml for parsing and rendering
+#
+
+FROM rust:alpine as rust
+
+# Please note this arg is also defined in the php-fpm layer further down.
+ARG WIKIJUMP_REPO_DIR="wikijump"
+
+ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
+ARG WIKIJUMP_REPO_BRANCH="develop"
+ARG WIKIJUMP_DIR="/var/www/${WIKIJUMP_REPO_DIR}"
+WORKDIR /src
+
+RUN apk add --no-cache \
+    alpine-sdk \
+    git
+
+# !! Comment out if using local bindings
+RUN git clone \
+        --depth 10 \
+        --branch "${WIKIJUMP_REPO_BRANCH}" \
+        "${WIKIJUMP_REPO}" "${WIKIJUMP_REPO_DIR}"
+
+WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
+
+RUN cargo build --release
+
+#
+# Main php-fpm container
+#
+
 FROM php:7.4-fpm-alpine
 
 EXPOSE 9000
 
 # Build variables
-ARG WIKIJUMP_REPO="https://github.com/scpwiki/wikijump.git"
 ARG WIKIJUMP_REPO_DIR="wikijump"
-ARG WIKIJUMP_REPO_BRANCH="develop"
 ARG DEBUG_IP="192.168.42.128"
 
 ARG MAIN_DOMAIN="wikijump.test"
@@ -48,6 +78,10 @@ RUN apk add --update --no-cache \
 RUN apk add --no-cache --virtual .persistent-deps libffi-dev \
     && docker-php-ext-configure ffi --with-ffi \
     && docker-php-ext-install ffi
+
+# Install libftml
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/ftml.h /usr/local/include/ftml.h
+COPY --from=rust /src/${WIKIJUMP_REPO_DIR}/ftml/target/release/libftml.so /usr/local/lib/libftml.so
 
 ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -137,8 +137,4 @@ RUN sed -i "s/BASEDOMAIN/${MAIN_DOMAIN}/g" conf/wikijump.ini && \
 
 COPY etc/php/ /usr/local/etc/php/conf.d/
 
-# Clean up packages
-RUN apt autoclean
-RUN apt autoremove -y
-
 CMD ["php-fpm"]

--- a/install/local/dev/php-fpm/setup-memcached.sh
+++ b/install/local/dev/php-fpm/setup-memcached.sh
@@ -5,7 +5,6 @@ set -eux
 readonly cores="$(nproc)"
 
 # Install dependencies
-apt install
 readonly dependencies=(
 	'libmemcached-dev'
 	'postgresql-server-dev-11'

--- a/install/local/dev/php-fpm/setup-memcached.sh
+++ b/install/local/dev/php-fpm/setup-memcached.sh
@@ -1,25 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
 # Variables
 readonly cores="$(nproc)"
 
 # Install dependencies
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.phpize-deps \
-		$PHPIZE_DEPS \
+apt install
+readonly dependencies=(
+	'libmemcached-dev'
+	'postgresql-server-dev-11'
+)
 
-apk add \
-	--no-cache \
-	--update \
-	--virtual \
-		.memcached-deps \
-		zlib-dev \
-		libmemcached-dev \
-		cyrus-sasl-dev
+apt install -y "${dependencies[@]}"
 
 # Install igbinary (memcached's deps)
 pecl install igbinary
@@ -47,9 +39,11 @@ make install
 # Install xdebug
 pecl install xdebug
 
+# Uninstall temporary dependencies
+apt remove -y "${dependencies[@]}"
+
 # Enable PHP extensions and clean up
 docker-php-ext-enable igbinary memcached memcache xdebug
-apk del .memcached-deps .phpize-deps
 docker-php-ext-install \
 	"-j$cores" \
 		opcache \


### PR DESCRIPTION
This modifies the `Dockerfile`s for php-fpm such that they target Debian rather than Alpine. This way we can build ftml against glibc and copy the artifacts into the php-fpm container for use. Additionally, the repo is cloned in the rust step and `web` is copied into the final php-fpm container.