### PR TITLE
[FTML-10] Normalize URLs in rendering

### DIFF
--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel};
+use wikidot_normalize::normalize;
 
 pub fn render_anchor(
     log: &Logger,
@@ -49,9 +50,16 @@ pub fn render_link(
 ) {
     let handle = ctx.handle();
 
+    // Normalize URL for href
+    let normal_url = {
+        let mut url = str!(url);
+        normalize(&mut url);
+        url
+    };
+
     // Create <a> and set attributes
     let mut tag = ctx.html().a();
-    tag.attr("href", &[url]);
+    tag.attr("href", &[&normal_url]);
 
     if let Some(target) = target {
         tag.attr("target", &[target.html_attr()]);

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -53,7 +53,7 @@ pub fn render_link(
     let handle = ctx.handle();
 
     // Normalize URL for href
-    let normal_url = if is_url(url) {
+    let normal_url = if is_url(url) || url.starts_with('#') {
         Cow::Borrowed(url)
     } else {
         let mut url = str!(url);

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -20,9 +20,7 @@
 
 use super::prelude::*;
 use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel};
-use crate::url::is_url;
-use std::borrow::Cow;
-use wikidot_normalize::normalize;
+use crate::url::normalize_url;
 
 pub fn render_anchor(
     log: &Logger,
@@ -52,19 +50,9 @@ pub fn render_link(
 ) {
     let handle = ctx.handle();
 
-    // Normalize URL for href
-    let normal_url = if is_url(url) || url.starts_with('#') || url == "javascript:;" {
-        Cow::Borrowed(url)
-    } else {
-        let mut url = str!(url);
-        normalize(&mut url);
-        url.insert(0, '/');
-        Cow::Owned(url)
-    };
-
     // Create <a> and set attributes
     let mut tag = ctx.html().a();
-    tag.attr("href", &[&normal_url]);
+    tag.attr("href", &[&normalize_url(url)]);
 
     if let Some(target) = target {
         tag.attr("target", &[target.html_attr()]);

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -20,6 +20,8 @@
 
 use super::prelude::*;
 use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel};
+use crate::url::is_url;
+use std::borrow::Cow;
 use wikidot_normalize::normalize;
 
 pub fn render_anchor(
@@ -51,10 +53,13 @@ pub fn render_link(
     let handle = ctx.handle();
 
     // Normalize URL for href
-    let normal_url = {
+    let normal_url = if is_url(url) {
+        Cow::Borrowed(url)
+    } else {
         let mut url = str!(url);
         normalize(&mut url);
-        url
+        url.insert(0, '/');
+        Cow::Owned(url)
     };
 
     // Create <a> and set attributes

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -53,7 +53,7 @@ pub fn render_link(
     let handle = ctx.handle();
 
     // Normalize URL for href
-    let normal_url = if is_url(url) || url.starts_with('#') {
+    let normal_url = if is_url(url) || url.starts_with('#') || url == "javascript:;" {
         Cow::Borrowed(url)
     } else {
         let mut url = str!(url);

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -24,7 +24,7 @@ use super::TextContext;
 use crate::log::prelude::*;
 use crate::render::ModuleRenderMode;
 use crate::tree::{ContainerType, Element, ListItem, ListType};
-use crate::url::is_url;
+use crate::url::{is_url, normalize_url};
 use std::borrow::Cow;
 
 pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]) {
@@ -254,20 +254,18 @@ fn get_full_url<'a>(log: &Logger, ctx: &TextContext, url: &'a str) -> Cow<'a, st
         return Cow::Borrowed(url);
     }
 
-    // Let's build a full URL:
+    // Let's build a full URL.
+    // First, normalize:
+    let url = normalize_url(url);
+
     let site = &ctx.info().site;
     let mut full_url = ctx.handle().get_url(log, site);
 
     // Ensure there is exactly one slash
-    if !full_url.ends_with('/') && !url.starts_with('/') {
-        full_url.push('/');
-    }
-
-    // Remove duplicate slash, if present
-    if full_url.ends_with('/') && url.starts_with('/') {
+    if full_url.ends_with('/') {
         full_url.pop();
     }
 
-    full_url.push_str(url);
+    full_url.push_str(&url);
     Cow::Owned(full_url)
 }

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -18,6 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use std::borrow::Cow;
+use wikidot_normalize::normalize;
+
 pub const URL_SCHEMES: [&str; 20] = [
     "blob:",
     "chrome-extension://",
@@ -50,4 +53,15 @@ pub fn is_url(url: &str) -> bool {
     }
 
     false
+}
+
+pub fn normalize_url(url: &str) -> Cow<str> {
+    if is_url(url) || url.starts_with('#') || url == "javascript:;" {
+        Cow::Borrowed(url)
+    } else {
+        let mut url = str!(url);
+        normalize(&mut url);
+        url.insert(0, '/');
+        Cow::Owned(url)
+    }
 }

--- a/ftml/test/link-triple-category-new-tab.html
+++ b/ftml/test/link-triple-category-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="system:Recent Pages" target="_blank">Recent Pages</a></p>
+<p><a href="/system:recent-pages" target="_blank">Recent Pages</a></p>

--- a/ftml/test/link-triple-category-new-tab.txt
+++ b/ftml/test/link-triple-category-new-tab.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://www.wikijump.com/system:Recent Pages]
+Recent Pages [https://www.wikijump.com/system:recent-pages]

--- a/ftml/test/link-triple-category-spaces.html
+++ b/ftml/test/link-triple-category-spaces.html
@@ -1,1 +1,1 @@
-<p><a href="system: Recent Pages">Recent Pages</a></p>
+<p><a href="/system:recent-pages">Recent Pages</a></p>

--- a/ftml/test/link-triple-category-spaces.txt
+++ b/ftml/test/link-triple-category-spaces.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://www.wikijump.com/system: Recent Pages]
+Recent Pages [https://www.wikijump.com/system:recent-pages]

--- a/ftml/test/link-triple-category.html
+++ b/ftml/test/link-triple-category.html
@@ -1,1 +1,1 @@
-<p><a href="system:Recent Pages">Recent Pages</a></p>
+<p><a href="/system:recent-pages">Recent Pages</a></p>

--- a/ftml/test/link-triple-category.txt
+++ b/ftml/test/link-triple-category.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://www.wikijump.com/system:Recent Pages]
+Recent Pages [https://www.wikijump.com/system:recent-pages]

--- a/ftml/test/link-triple-label-new-tab.html
+++ b/ftml/test/link-triple-label-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="some-page" target="_blank">Label</a></p>
+<p><a href="/some-page" target="_blank">Label</a></p>

--- a/ftml/test/link-triple-label.html
+++ b/ftml/test/link-triple-label.html
@@ -1,1 +1,1 @@
-<p><a href="some-page">My label</a></p>
+<p><a href="/some-page">My label</a></p>

--- a/ftml/test/link-triple-new-tab.html
+++ b/ftml/test/link-triple-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="SCP-001" target="_blank">SCP-001</a></p>
+<p><a href="/scp-001" target="_blank">SCP-001</a></p>

--- a/ftml/test/link-triple-new-tab.txt
+++ b/ftml/test/link-triple-new-tab.txt
@@ -1,1 +1,1 @@
-SCP-001 [https://www.wikijump.com/SCP-001]
+SCP-001 [https://www.wikijump.com/scp-001]

--- a/ftml/test/link-triple-title-new-tab.html
+++ b/ftml/test/link-triple-title-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="some-page" target="_blank">TODO: actual title (some-page)</a></p>
+<p><a href="/some-page" target="_blank">TODO: actual title (some-page)</a></p>

--- a/ftml/test/link-triple-title.html
+++ b/ftml/test/link-triple-title.html
@@ -1,1 +1,1 @@
-<p><a href="some-page">TODO: actual title (some-page)</a></p>
+<p><a href="/some-page">TODO: actual title (some-page)</a></p>

--- a/ftml/test/link-triple-whitespace-new-tab.html
+++ b/ftml/test/link-triple-whitespace-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="some-page" target="_blank">My label</a></p>
+<p><a href="/some-page" target="_blank">My label</a></p>

--- a/ftml/test/link-triple-whitespace.html
+++ b/ftml/test/link-triple-whitespace.html
@@ -1,1 +1,1 @@
-<p><a href="some-page">My label</a></p>
+<p><a href="/some-page">My label</a></p>

--- a/ftml/test/link-triple.html
+++ b/ftml/test/link-triple.html
@@ -1,1 +1,1 @@
-<p><a href="SCP-001">SCP-001</a></p>
+<p><a href="/scp-001">SCP-001</a></p>

--- a/ftml/test/link-triple.txt
+++ b/ftml/test/link-triple.txt
@@ -1,1 +1,1 @@
-SCP-001 [https://www.wikijump.com/SCP-001]
+SCP-001 [https://www.wikijump.com/scp-001]


### PR DESCRIPTION
Make URLs more clear, especially for text. Since we don't have percent encoding, some browsers might not properly handle these non-normal URLs.

This creates a helper function to perform this properly, and updating the HTML/text tests.