### PR TITLE
Prepare ftml for pushing to crates.io

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -6,7 +6,10 @@
          alt="Build status">
   </a>
 
-  <!-- TODO: put crates.io badge here -->
+  <a href="https://docs.rs/ftml">
+    <img src="https://docs.rs/ftml/badge.svg"
+         alt="docs.rs link">
+  </a>
 </p>
 
 ### Foundation Text Markup Language

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -33,7 +33,7 @@ $ cargo build --release
 You can use this as a dependency by adding the following to your `Cargo.toml`:
 
 ```toml
-ftml = "0.4"
+ftml = "0.10"
 ```
 
 The library comes with two default features, `log` and `ffi`.

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -27,6 +27,69 @@
 //! (with irregular Perl extensions). The aim is to provide an AST
 //! while also maintaining the flexibility and lax parsing that
 //! Wikidot permits.
+//!
+//! The overall flow is the following:
+//!
+//! * Run messy includer
+//! * Run preprocessor
+//! * Run tokenizer
+//! * Run parser
+//! * Run renderer
+//!
+//! Each step of the flow makes extensive use of Rust's
+//! borrowing capabilities, ensuring that as few allocations
+//! are performed as possible. Any strings which are unmodified
+//! are passed by reference. Despite this, all of the exported
+//! structures are both serializable and deserializable via
+//! [`serde`].
+//!
+//! Rendering is performed by the trait [`Render`].
+//! There are two main implementations of note,
+//! [`TextRender`] and [`HtmlRender`], which render to
+//! plain text and full HTML respectively.
+//!
+//! # Features
+//! This crate has several features of note.
+//!
+//! By default the `ffi` and `log` features are enabled.
+//! These enable support for FFI interfacing for the library
+//! via [`cbindgen`] (with a slightly more limited interface),
+//! and logging via [`slog`] respectively.
+//!
+//! If the `log` feature is enabled, then all calls requiring
+//! a `Logger` are replaced with a stub, and all actual logging
+//! calls are replaced with no-ops. Generally you want this
+//! for very performance-sensitive contexts where logging is
+//! simply not worth the overhead.
+//!
+//! # Targets
+//! The library supports being compiled into WebAssembly.
+//! (target `wasm32-unknown-unknown`, see [`wasm-pack`] for more information)
+//!
+//! This adds the feature `wasm-log`, which adds `slog` logging support via
+//! `console.log()` calls to the browser's console. This is very useful for
+//! debugging, but caveat emptor! This spams the console very hard and can cause
+//! lag on some browsers. Do not enable in production.
+//!
+//! Additionally, disabling `log` as a feature compiles out all logging, similar
+//! to the default target.
+//!
+//! Compiling to wasm also disables all FFI integration,
+//! since these are inherently incompatible.
+//!
+//! # Bugs
+//! If you discover any bugs or have any feature requests,
+//! you can submit them via our Atlassian helpdesk [here](https://scuttle.atlassian.net/servicedesk/customer/portal/2).
+//!
+//! Alternatively, you can [get in touch with Wikijump developers directly](https://github.com/scpwiki/wikijump#readme).
+//!
+//! [`Render`]: ./render/trait.Render.html
+//! [`TextRender`]: ./render/html/struct.HtmlRender.html
+//! [`HtmlRender`]: ./render/text/struct.TextRender.html
+//! [`serde`]: https://docs.rs/serde
+//! [`cbindgen`]: https://docs.rs/cbindgen
+//! [`slog`]: https://docs.rs/slog
+//! [`wasm-pack`]: https://rustwasm.github.io/docs/wasm-pack/
 
 // Only list crates which we want global macro imports.
 // Rest are implicit based on Cargo.toml


### PR DESCRIPTION
We haven't uploaded a new version of `ftml` to https://crates.io/ for some time. I've spruced up the documentation a bit and bumped the version so I can publish a new version.

What the new docs look like:
![image](https://user-images.githubusercontent.com/8848022/116794823-12173e80-aa9e-11eb-8996-fb9ee6063c18.png)
