### PR TITLE
[WJ-452] Add crossorigin to images and iframes

### DIFF
--- a/ftml/src/render/html/element/iframe.rs
+++ b/ftml/src/render/html/element/iframe.rs
@@ -33,7 +33,11 @@ pub fn render_iframe(
         "url" => url,
     );
 
-    ctx.html().iframe().attr("src", &[url]).attr_map(attributes);
+    ctx.html()
+        .iframe()
+        .attr("src", &[url])
+        .attr("crossorigin", &[])
+        .attr_map(attributes);
 }
 
 pub fn render_html(log: &Logger, ctx: &mut HtmlContext, contents: &str) {
@@ -45,5 +49,8 @@ pub fn render_html(log: &Logger, ctx: &mut HtmlContext, contents: &str) {
 
     // Submit HTML to be hosted on wjfiles, then get back its URL for the iframe.
     let iframe_url = ctx.handle().post_html(log, ctx.info(), contents);
-    ctx.html().iframe().attr("src", &[&iframe_url]);
+    ctx.html()
+        .iframe()
+        .attr("src", &[&iframe_url])
+        .attr("crossorigin", &[]);
 }

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -58,10 +58,14 @@ pub fn render_image(
         .attr("class", &image_classes)
         .contents(|ctx| {
             let build_image = |ctx: &mut HtmlContext| {
-                ctx.html()
-                    .img()
-                    .attr("src", &[&source_url])
+                let mut tag = ctx.html().img();
+
+                tag.attr("src", &[&source_url])
                     .attr_map_prepend(attributes, ("class", "image"));
+
+                if add_crossorigin {
+                    tag.attr("crossorigin", &[]);
+                }
             };
 
             match link {

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -46,7 +46,6 @@ pub fn render_image(
     );
 
     let source_url = ctx.handle().get_image_link(log, ctx.info(), source);
-    let add_crossorigin = source.external_link();
 
     let image_classes = match alignment {
         Some(align) => ["image-container", " ", align.html_class()],
@@ -58,14 +57,11 @@ pub fn render_image(
         .attr("class", &image_classes)
         .contents(|ctx| {
             let build_image = |ctx: &mut HtmlContext| {
-                let mut tag = ctx.html().img();
-
-                tag.attr("src", &[&source_url])
+                ctx.html()
+                    .img()
+                    .attr("src", &[&source_url])
+                    .attr("crossorigin", &[])
                     .attr_map_prepend(attributes, ("class", "image"));
-
-                if add_crossorigin {
-                    tag.attr("crossorigin", &[]);
-                }
             };
 
             match link {

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -46,6 +46,7 @@ pub fn render_image(
     );
 
     let source_url = ctx.handle().get_image_link(log, ctx.info(), source);
+    let add_crossorigin = source.external_link();
 
     let image_classes = match alignment {
         Some(align) => ["image-container", " ", align.html_class()],

--- a/ftml/src/tree/image.rs
+++ b/ftml/src/tree/image.rs
@@ -83,11 +83,6 @@ impl<'t> ImageSource<'t> {
         self.into()
     }
 
-    #[inline]
-    pub fn external_link(&self) -> bool {
-        matches!(self, ImageSource::Url(_))
-    }
-
     pub fn to_owned(&self) -> ImageSource<'static> {
         match self {
             ImageSource::Url(url) => ImageSource::Url(string_to_owned(url)),

--- a/ftml/src/tree/image.rs
+++ b/ftml/src/tree/image.rs
@@ -83,6 +83,11 @@ impl<'t> ImageSource<'t> {
         self.into()
     }
 
+    #[inline]
+    pub fn external_link(&self) -> bool {
+        matches!(self, ImageSource::Url(_))
+    }
+
     pub fn to_owned(&self) -> ImageSource<'static> {
         match self {
             ImageSource::Url(url) => ImageSource::Url(string_to_owned(url)),

--- a/ftml/test/html-block.html
+++ b/ftml/test/html-block.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com/"></iframe>
+<iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/html-empty.html
+++ b/ftml/test/html-empty.html
@@ -1,1 +1,1 @@
-<p>Empty</p><iframe src="https://example.com/"></iframe>
+<p>Empty</p><iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/html-inline-empty.html
+++ b/ftml/test/html-inline-empty.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com/"></iframe>
+<iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/html-inline.html
+++ b/ftml/test/html-inline.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com/"></iframe>
+<iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/html-multiple.html
+++ b/ftml/test/html-multiple.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com/"></iframe><iframe src="https://example.com/"></iframe>
+<iframe src="https://example.com/" crossorigin></iframe><iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/html.html
+++ b/ftml/test/html.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com/"></iframe>
+<iframe src="https://example.com/" crossorigin></iframe>

--- a/ftml/test/iframe-http.html
+++ b/ftml/test/iframe-http.html
@@ -1,1 +1,1 @@
-<iframe src="http://scp-wiki.wikidot.com/scp-1000"></iframe>
+<iframe src="http://scp-wiki.wikidot.com/scp-1000" crossorigin></iframe>

--- a/ftml/test/iframe-style.html
+++ b/ftml/test/iframe-style.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com" class="example" id="my-iframe"></iframe>
+<iframe src="https://example.com" crossorigin class="example" id="my-iframe"></iframe>

--- a/ftml/test/iframe-uppercase.html
+++ b/ftml/test/iframe-uppercase.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com" id="iframe" width="100%"></iframe>
+<iframe src="https://example.com" crossorigin id="iframe" width="100%"></iframe>

--- a/ftml/test/iframe.html
+++ b/ftml/test/iframe.html
@@ -1,1 +1,1 @@
-<iframe src="https://example.com"></iframe>
+<iframe src="https://example.com" crossorigin></iframe>

--- a/ftml/test/image-attributes.html
+++ b/ftml/test/image-attributes.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image-attributes/green_apple.png" alt="A green apple" class="image fruity" style="width: 100%;" title="Take a big bite!"></div> B</p>
+<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image-attributes/green_apple.png" crossorigin alt="A green apple" class="image fruity" style="width: 100%;" title="Take a big bite!"></div> B</p>

--- a/ftml/test/image-center.html
+++ b/ftml/test/image-center.html
@@ -1,1 +1,1 @@
-<p><div class="image-container aligncenter"><img src="https://test.wjfiles.com/local--files/page-image-center/landscape.png" class="image"></div></p>
+<p><div class="image-container aligncenter"><img src="https://test.wjfiles.com/local--files/page-image-center/landscape.png" crossorigin class="image"></div></p>

--- a/ftml/test/image-external.html
+++ b/ftml/test/image-external.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://example.com/my-image.png" class="image" crossorigin></div> B</p>
+<p>A <div class="image-container"><img src="https://example.com/my-image.png" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-external.html
+++ b/ftml/test/image-external.html
@@ -1,0 +1,1 @@
+<p>A <div class="image-container"><img src="https://example.com/my-image.png" class="image" crossorigin></div> B</p>

--- a/ftml/test/image-external.json
+++ b/ftml/test/image-external.json
@@ -1,0 +1,48 @@
+{
+    "input": "A [[image https://example.com/my-image.png]] B",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "A"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "image",
+                            "data": {
+                                "source": {
+                                    "type": "url",
+                                    "data": "https://example.com/my-image.png"
+                                },
+                                "link": null,
+                                "alignment": null,
+                                "attributes": {}
+                            }
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "B"
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/image-external.txt
+++ b/ftml/test/image-external.txt
@@ -1,0 +1,1 @@
+A Image: https://example.com/my-image.png B

--- a/ftml/test/image-file1.html
+++ b/ftml/test/image-file1.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image-file1/my-picture.jpeg" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image-file1/my-picture.jpeg" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-file2-slash.html
+++ b/ftml/test/image-file2-slash.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-file2.html
+++ b/ftml/test/image-file2.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-file3-slash.html
+++ b/ftml/test/image-file3-slash.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-file3.html
+++ b/ftml/test/image-file3.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg" crossorigin class="image"></div> B</p>

--- a/ftml/test/image-float-left.html
+++ b/ftml/test/image-float-left.html
@@ -1,1 +1,1 @@
-<p><div class="image-container floatleft"><img src="https://test.wjfiles.com/local--files/page-image-float-left/landscape.png" class="image"></div></p>
+<p><div class="image-container floatleft"><img src="https://test.wjfiles.com/local--files/page-image-float-left/landscape.png" crossorigin class="image"></div></p>

--- a/ftml/test/image-float-right.html
+++ b/ftml/test/image-float-right.html
@@ -1,1 +1,1 @@
-<p><div class="image-container floatright"><img src="https://test.wjfiles.com/local--files/page-image-float-right/landscape.png" class="image"></div></p>
+<p><div class="image-container floatright"><img src="https://test.wjfiles.com/local--files/page-image-float-right/landscape.png" crossorigin class="image"></div></p>

--- a/ftml/test/image-left.html
+++ b/ftml/test/image-left.html
@@ -1,1 +1,1 @@
-<p><div class="image-container alignleft"><img src="https://test.wjfiles.com/local--files/page-image-left/landscape.png" class="image"></div></p>
+<p><div class="image-container alignleft"><img src="https://test.wjfiles.com/local--files/page-image-left/landscape.png" crossorigin class="image"></div></p>

--- a/ftml/test/image-link-anchor.html
+++ b/ftml/test/image-link-anchor.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><a href="#section"><img src="https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png" class="image"></a></div> B</p>
+<p>A <div class="image-container"><a href="#section"><img src="https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png" crossorigin class="image"></a></div> B</p>

--- a/ftml/test/image-link-page.html
+++ b/ftml/test/image-link-page.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><a href="/scp-001"><img src="https://test.wjfiles.com/local--files/page-image-link-page/filename.png" class="image"></a></div> B</p>
+<p>A <div class="image-container"><a href="/scp-001"><img src="https://test.wjfiles.com/local--files/page-image-link-page/filename.png" crossorigin class="image"></a></div> B</p>

--- a/ftml/test/image-link.html
+++ b/ftml/test/image-link.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><a href="https://example.com/"><img src="https://test.wjfiles.com/local--files/page-image-link/filename.png" class="image"></a></div> B</p>
+<p>A <div class="image-container"><a href="https://example.com/"><img src="https://test.wjfiles.com/local--files/page-image-link/filename.png" crossorigin class="image"></a></div> B</p>

--- a/ftml/test/image-right.html
+++ b/ftml/test/image-right.html
@@ -1,1 +1,1 @@
-<p><div class="image-container alignright"><img src="https://test.wjfiles.com/local--files/page-image-right/landscape.png" class="image"></div></p>
+<p><div class="image-container alignright"><img src="https://test.wjfiles.com/local--files/page-image-right/landscape.png" crossorigin class="image"></div></p>

--- a/ftml/test/image.html
+++ b/ftml/test/image.html
@@ -1,1 +1,1 @@
-<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image/filename.png" class="image"></div> B</p>
+<p>A <div class="image-container"><img src="https://test.wjfiles.com/local--files/page-image/filename.png" crossorigin class="image"></div> B</p>


### PR DESCRIPTION
Complement to #249 

Since all images and iframes are going to be hosted on wjfiles, which is not the same site, all tags needs `crossorigin` so they will be loaded. 