### PR TITLE
[WJ-503] Remove set_real_ip from nginx

### DIFF
--- a/install/aws/dev/docker/nginx/nginx.conf
+++ b/install/aws/dev/docker/nginx/nginx.conf
@@ -90,7 +90,6 @@
                  }
 
                  location ~ \.php$ {
-                             # set_real_ip_from reverse-proxy;
                              # regex to split $uri to $fastcgi_script_name and $fastcgi_path
                              fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 

--- a/install/local/dev/nginx/nginx.conf
+++ b/install/local/dev/nginx/nginx.conf
@@ -84,7 +84,6 @@
                  }
 
                  location ~ \.php$ {
-                             set_real_ip_from reverse-proxy;
                              # regex to split $uri to $fastcgi_script_name and $fastcgi_path
                              fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 


### PR DESCRIPTION
As discussed in [WJ-503](the issue), the `set_real_ip` fields are not used in the `nginx` container, as the `php-fpm` container already transmits real IP information.

This is primarily being removed because it causes container crashes on startup:
```
nginx_1          | 2021/05/05 05:37:35 [emerg] 1#1: host not found in set_real_ip_from "reverse-proxy" in /etc/nginx/nginx.conf:87
nginx_1          | nginx: [emerg] host not found in set_real_ip_from "reverse-proxy" in /etc/nginx/nginx.conf:87
wikijump_nginx_1 exited with code 1
```
And was in fact already commented out for the dev deployment.