### PR TITLE
Mark vendored ftml files as binary

### DIFF
--- a/client/modules/ftml-wasm/.gitattributes
+++ b/client/modules/ftml-wasm/.gitattributes
@@ -1,0 +1,1 @@
+vendor/* binary


### PR DESCRIPTION
See [customizing git attributes](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes). This tells git that the files in `vendor` are binary, and should not be given diffs, but simply record whether the file changed or not. Because we're not modifying these files directly, this is the correct way to treat them.