### PR TITLE
[WJ-463] Add feature flag for wikitext backend

### DIFF
--- a/install/aws/dev/docker/php-fpm/wikijump.ini
+++ b/install/aws/dev/docker/php-fpm/wikijump.ini
@@ -343,6 +343,17 @@ file = wikijump.log
 
 
 ;;;;
+; Feature Flags
+[feature]
+
+; [wikitext_backend]
+; Purpose: Which wikitext parser/renderer backend to use. Choose from "text_wiki", "ftml", or "null".
+; GlobalProperties Reference: $FEATURE_WIKITEXT_BACKEND
+; Default: "text_wiki"
+wikitext_backend = "text_wiki"
+
+
+;;;;
 ; Miscellaneous Items
 [misc]
 

--- a/install/aws/prod/docker/php-fpm/wikijump.ini
+++ b/install/aws/prod/docker/php-fpm/wikijump.ini
@@ -343,6 +343,17 @@ file = wikijump.log
 
 
 ;;;;
+; Feature Flags
+[feature]
+
+; [wikitext_backend]
+; Purpose: Which wikitext parser/renderer backend to use. Choose from "text_wiki", "ftml", or "null".
+; GlobalProperties Reference: $FEATURE_WIKITEXT_BACKEND
+; Default: "text_wiki"
+wikitext_backend = "text_wiki"
+
+
+;;;;
 ; Miscellaneous Items
 [misc]
 

--- a/install/local/dev/php-fpm/wikijump.ini
+++ b/install/local/dev/php-fpm/wikijump.ini
@@ -343,6 +343,17 @@ file = wikijump.log
 
 
 ;;;;
+; Feature Flags
+[feature]
+
+; [wikitext_backend]
+; Purpose: Which wikitext parser/renderer backend to use. Choose from "text_wiki", "ftml", or "null".
+; GlobalProperties Reference: $FEATURE_WIKITEXT_BACKEND
+; Default: "text_wiki"
+wikitext_backend = "ftml"
+
+
+;;;;
 ; Miscellaneous Items
 [misc]
 

--- a/web/conf/wikijump.ini.example
+++ b/web/conf/wikijump.ini.example
@@ -341,7 +341,18 @@ level = error
 ; Purpose: Not yet implemented, but will be used to specify the filename to dump logs to.
 ; GlobalProperties Reference: $LOGGER_FILE
 ; Default: "wikijump.log"
-file = wikijump.log
+wikitext_backend = wikijump.log
+
+
+;;;;
+; Feature Flags
+[feature]
+
+; [wikitext_backend]
+; Purpose: Which wikitext parser/renderer backend to use. Choose from "text_wiki", "ftml", or "null".
+; GlobalProperties Reference: $FEATURE_WIKITEXT_BACKEND
+; Default: "text_wiki"
+file = "text_wiki"
 
 
 ;;;;

--- a/web/php/Utils/GlobalProperties.php
+++ b/web/php/Utils/GlobalProperties.php
@@ -234,6 +234,9 @@ class GlobalProperties
         self::$LOGGER_LEVEL             = $_ENV["WIKIJUMP_LOGGER_LEVEL"] ?? self::fromIni("log", "level", "error");
         self::$LOGGER_FILE              = $_ENV["WIKIJUMP_LOGGER_FILE"] ?? self::fromIni("log", "file", "wikijump.log"); // TODO: use this setting
 
+        // feature flags
+        self::$FEATURE_WIKITEXT_BACKEND = $_ENV["FEATURE_WIKITEXT_BACKEND"] ?? self::fromIni("feature", "wikitext_backend", "text_wiki");
+
         // other settings
         self::$CACHE_FILES_FOR          = $_ENV["WIKIJUMP_CACHE_FILES_FOR"] ?? self::fromIni("misc", "cache_files_for", 0);
         self::$URL_DOCS                 = $_ENV["WIKIJUMP_URL_DOCS"] ?? self::fromIni("misc", "doc_url", self::$HTTP_SCHEMA. "://" . self::$URL_HOST . "/doc");


### PR DESCRIPTION
Adds a new section for feature flags, as we will doubtlessly have more in the future. This adds a new property `FEATURE_WIKITEXT_BACKEND`, which is presently unused, but exists as a precursor to an upcoming PR to allow PHP to select the wikitext backend based on this value.