### PR TITLE
Replace ourboros with self_cell in ftml

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,12 +298,12 @@ dependencies = [
  "enum-map",
  "lazy_static",
  "maplit",
- "ouroboros",
  "parking_lot",
  "pest",
  "pest_derive",
  "ref-map",
  "regex",
+ "self_cell",
  "serde",
  "serde_json",
  "slog",
@@ -579,29 +573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "ouroboros"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8234affc3c31a8b744cc236fd3dc7443f57c6370cbb7d61f41f9c7dcc6c2530"
-dependencies = [
- "ouroboros_macro",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3633332cd8c0b6a865e2e0e705fad9cde25fe458cd0c693629b58a7b15e4d852"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,30 +657,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -843,6 +790,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "self_cell"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ec62a5f46d5d25d0e0da6a57d8ef944a08ed25c770852ce664d5055ce813ab"
 
 [[package]]
 name = "semver"
@@ -1036,12 +989,6 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "str-macro"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -56,7 +56,7 @@ cbindgen = "0.19"
 sloggers = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ouroboros = "0.9"
+self_cell = "0.7.1"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["console"] }
 


### PR DESCRIPTION
Before:

$ cargo build --target wasm32-unknown-unknown
... 161 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 1m 53s

After:

$ cargo build --target wasm32-unknown-unknown
... 152 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 1m 33s

That's 22% faster in this very rough test. But the 9 fewer dependencies make this seem plausible.

There are still some proc macro dependencies like syn left, but they have nothing to do with `self_cell` as it has 0 dependencies and doesn't use proc macros.

Disclaimer I'm the author of `self_cell`.

I would have like to run the tests before and after, but I don't know how to do that for wasm. Please check this works like before. That said. the heavy lifting is done in the type system here and I expect no runtime problems.