### PR TITLE
Remove the get_span() method from ftml wasm 

### DIFF
--- a/ftml/src/wasm/utf16.rs
+++ b/ftml/src/wasm/utf16.rs
@@ -100,14 +100,4 @@ impl Utf16IndexMap {
         let new_index = self.get().get_index(index);
         Ok(new_index)
     }
-
-    #[wasm_bindgen]
-    pub fn get_span(&self, start: usize, end: usize) -> Result<IIndexSpan, JsValue> {
-        self.check_index(start)?;
-        self.check_index(end)?;
-
-        let new_start = self.get().get_index(start);
-        let new_end = self.get().get_index(end);
-        rust_to_js!(vec![new_start, new_end])
-    }
 }

--- a/ftml/src/wasm/utf16.rs
+++ b/ftml/src/wasm/utf16.rs
@@ -23,14 +23,6 @@ use crate::Utf16IndexMap as RustUtf16IndexMap;
 use ouroboros::self_referencing;
 use std::sync::Arc;
 
-// Typescript declarations
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(typescript_type = "[number, number]")]
-    pub type IIndexSpan;
-}
-
 // Wrapper structures
 
 #[self_referencing]


### PR DESCRIPTION
This method previously existed instead of `get_index_end()` to allow retrieving the start and end of a span in a single function.

However now that `get_index_end()` doesn't exist anymore, and that start and end indices have no special differentiation, we should remove this. Users can just call `get_span()` twice.