### PR TITLE
Add enum abstract class

### DIFF
--- a/web/app/Common/Enum.php
+++ b/web/app/Common/Enum.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Wikijump\Common;
+
+use http\Exception\RuntimeException;
+
+/**
+ * Implements an enumeration abstract class for the creation of enums within PHP.
+ *
+ * Children should make a final class that extends Enum, and then add all the
+ * variants as constants for enum values.
+ *
+ * The static methods values() and isValue() are available for use.
+ *
+ * See https://stackoverflow.com/questions/254514/enumerations-on-php/17045081#17045081
+ *
+ * @package Wikijump\Common
+ */
+abstract class Enum
+{
+    final private function __construct()
+    {
+        throw new RuntimeException("You may not create Enum class instances");
+    }
+
+    final private function __clone()
+    {
+        throw new RuntimeException("You may not clone Enum class instances");
+    }
+
+    final public static function values(): array
+    {
+        $class = new ReflectionClass(static::class);
+        return $class->getConstants();
+    }
+
+    final public static function isValue($value): bool
+    {
+        return in_array($value, static::values());
+    }
+}

--- a/web/app/Common/Enum.php
+++ b/web/app/Common/Enum.php
@@ -34,7 +34,7 @@ abstract class Enum
         return $class->getConstants();
     }
 
-    final public static function isValue($value): bool
+    final public static function isValue(mixed $value): bool
     {
         return in_array($value, static::values());
     }

--- a/web/app/Common/Enum.php
+++ b/web/app/Common/Enum.php
@@ -28,13 +28,24 @@ abstract class Enum
         throw new RuntimeException("You may not clone Enum class instances");
     }
 
+    /**
+     * Gets the list of member values in this enum.
+     *
+     * @return array List of values in this enum.
+     */
     final public static function values(): array
     {
         $class = new ReflectionClass(static::class);
         return $class->getConstants();
     }
 
-    final public static function isValue(mixed $value): bool
+    /**
+     * Determines if a value is a member of this enum.
+     *
+     * @param mixed $value The value to check
+     * @return bool Is an enum member
+     */
+    final public static function isValue($value): bool
     {
         return in_array($value, static::values());
     }


### PR DESCRIPTION
Based on the solution [here](https://stackoverflow.com/questions/254514/enumerations-on-php/17045081#17045081), it will allow us to make enums in PHP using class constants.

An example enumeration using this code:

```php
use \Wikijump\Common\Enum;

final class ResponseStatusCode extends Enum
{
    const OK                         = 200;
    const CREATED                    = 201;
    const ACCEPTED                   = 202;
    // ...
    const SERVICE_UNAVAILABLE        = 503;
    const GATEWAY_TIME_OUT           = 504;
    const HTTP_VERSION_NOT_SUPPORTED = 505;
}
```