### PR TITLE
Add carryforward flags to codecov configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,15 @@
 comment:
-  layout: 'reach,diff,footer'
+  layout: "reach, diff, flags, files"
+  show_carryforward_flags: true
+
+flags:
+  clientmonorepo:
+    carryforward: true
+    paths:
+      - client/
+
+  # PHP backend and legacy frontend
+  unittests:
+    carryforward: true
+    paths:
+      - web/

--- a/client/modules/wj-util/src/index.ts
+++ b/client/modules/wj-util/src/index.ts
@@ -96,7 +96,10 @@ export function escapeRegExp(str: string) {
 
 /**
  * Checks if a string has any of the provided sigils.
- * (e.g. `hasSigil('!string', '!') -> true`)
+ * @example
+ * ```
+ * hasSigil("!string", "!") // true
+ * ```
  */
 export function hasSigil<T extends string = string>(
   str: unknown,

--- a/web/.styleci.yml
+++ b/web/.styleci.yml
@@ -10,4 +10,5 @@ js:
   finder:
     not-name:
       - webpack.mix.js
+
 css: true


### PR DESCRIPTION
Fixes wacky code coverage reports, hopefully. Causes Codecov to "carry forward" the previous coverage reports if the coverage report uploaded is not flagged as being relevant for the files affected.