### PR TITLE
Removed array type for Kernel::commands

### DIFF
--- a/web/app/Console/Kernel.php
+++ b/web/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      *
      * @var array
      */
-    protected array $commands = [
+    protected $commands = [
         //
     ];
 


### PR DESCRIPTION
The docker build for PHP-FPM failed due to `$commands` being typed when the upstram variable is not. It _was_ defined in my version which might just be a PHPStorm oddity. With any luck this is all that's still blocking the build.