### PR TITLE
Use $SERVICE_NAME in templates

### DIFF
--- a/web/templates/emails/ChangeEmailVerification.tpl
+++ b/web/templates/emails/ChangeEmailVerification.tpl
@@ -10,8 +10,7 @@ email address:		{$email}
 Best regards - {$SERVICE_NAME}
 
 If you have NOT attempted to change your email address associated with
-a Wikijump account or even are not a service user it is possible
+a {$SERVICE_NAME} account or even are not a service user it is possible
 that you have received this email because someone else mistyped their
 own email address. If you however suspect any abuse, please contact
-
 

--- a/web/templates/emails/DigestEmail.tpl
+++ b/web/templates/emails/DigestEmail.tpl
@@ -1,6 +1,6 @@
 Hi, {$user->username|escape}!
 
-{if $count==1}There is one notification{else}There are {$count} notifications{/if} related to your Wikijump account:
+{if $count==1}There is one notification{else}There are {$count} notifications{/if} related to your {$SERVICE_NAME} account:
 To view the full list of notifications visit:
 {$HTTP_SCHEMA}://{$URL_HOST}/account:you/start/notifications
 {foreach from=$notifications item=notification}

--- a/web/templates/modules/Account/AccountNotLoggedInModule.tpl
+++ b/web/templates/modules/Account/AccountNotLoggedInModule.tpl
@@ -1,5 +1,5 @@
 		<p>
-			{t}To access account preferences and settings you should have a valid Wikijump account.{/t}
+			{t}To access account preferences and settings you should have a valid {$SERVICE_NAME} account.{/t}
 		</p>
 		<table style="margin: 1em auto">
 			<tr>
@@ -9,7 +9,7 @@
 							>{t}Log in{/t}</a>
 					</div>
 					<p>
-						{t}if you already have a Wikijump account{/t}
+						{t}if you already have a {$SERVICE_NAME} account{/t}
 					</p>
 				</td>
 				<td style="padding: 1em; font-size: 140%">

--- a/web/templates/modules/Account/AccountSettingsModule.tpl
+++ b/web/templates/modules/Account/AccountSettingsModule.tpl
@@ -20,7 +20,7 @@
 <div>
 	<h3><a href="javascript:;"  onclick="OZONE.ajax.requestModule('Account/Settings/ASNotificationsModule', null, Wikijump.modules.AccountModule.callbacks.menuClick)">{t}Notifications - online &amp; private RSS &amp; email{/t}</a></h3>
 	<p>
-		{t}Configure the way Wikijump informs you about events related to your presence here.{/t}
+		{t}Configure the way {$SERVICE_NAME} informs you about events related to your presence here.{/t}
 	</p>
 </div>
 

--- a/web/templates/modules/Account/PM/PMComposeModule.tpl
+++ b/web/templates/modules/Account/PM/PMComposeModule.tpl
@@ -17,7 +17,7 @@
 					<span id="selected-user-rendered"></span> (<a href="javascript:;" onclick="Wikijump.modules.PMComposeModule.listeners.changeRecipient(event)">{t}change recipient{/t}</a>)
 				</div>
 				<div id="select-user-div">
-					{t}Type the Wikijump User name below or{/t} <a href="javascript:;" onclick="Wikijump.modules.PMComposeModule.listeners.showContactsList(event)">{t}select from your contacts{/t}</a>  <br/>
+					{t}Type the {$SERVICE_NAME} user name below or{/t} <a href="javascript:;" onclick="Wikijump.modules.PMComposeModule.listeners.showContactsList(event)">{t}select from your contacts{/t}</a>  <br/>
 					<div class="autocomplete-container" style="width: 20em; padding-top: 3px;">
 						<input type="text" id="user-lookup" size="30" class="autocomplete-input text"/>
 						<div id="user-lookup-list" class="autocomplete-list"></div>

--- a/web/templates/modules/Account/Profile/APAvatarModule.tpl
+++ b/web/templates/modules/Account/Profile/APAvatarModule.tpl
@@ -109,7 +109,7 @@
 </div>
 
 <div id="avatar-success" style="display: none">
-	<h2>{t}Success!!!{/t}</h2>
+	<h2>{t}Success!{/t}</h2>
 	{t}Your buddy icon has been successfully changed! However due to caching issues you might need to
 	hit "reload" in your browser to see the changes. It might also take max 1 hour for the
 	change to be visible for others depending on their image caching.{/t}

--- a/web/templates/modules/Account/Profile/ChangeScreenNameModule.tpl
+++ b/web/templates/modules/Account/Profile/ChangeScreenNameModule.tpl
@@ -4,7 +4,7 @@
 	Your current screen name is <strong>{$user->username|escape}</strong>.
 </p>
 <p>
-	Each Wikijump User can change their screen name <strong>twice</strong>.
+	Each {$SERVICE_NAME} user can change their screen name <strong>twice</strong>.
 	It looks like you have changed yours <strong style="font-size:120%">{$profile->getChangeScreenNameCount()}</strong> time(s).
 </p>
 <p>

--- a/web/templates/modules/Account/Settings/ASNotificationsModule.tpl
+++ b/web/templates/modules/Account/Settings/ASNotificationsModule.tpl
@@ -107,7 +107,7 @@
 <table class="form">
 	<tr>
 		<td>
-			Receive Wikijump Newsletter?
+			Receive {$SERVICE_NAME} Newsletter?
 		</td>
 		<td>
 			<input type="checkbox" class="checkbox" id="as-receive-newsletter"  {if $settings->getReceiveNewsletter()}checked="checked"{/if}/>

--- a/web/templates/modules/ManageSite/Blocks/ManageSiteUserBlocksModule.tpl
+++ b/web/templates/modules/ManageSite/Blocks/ManageSiteUserBlocksModule.tpl
@@ -42,7 +42,7 @@ there are no blocked users.
 			<td>
 				<div id="select-user-div">
 					<div class="sub">
-						type the Wikijump user name below
+						type the {$SERVICE_NAME} user name below
 					</div>
 					<div class="autocomplete-container" style="width: 20em; padding-top: 3px;">
 						<input type="text" id="user-lookup" size="30" class="autocomplete-input text"/>

--- a/web/templates/modules/ManageSite/ManageSiteCloneModule.tpl
+++ b/web/templates/modules/ManageSite/ManageSiteCloneModule.tpl
@@ -45,7 +45,7 @@
 			<td>
 				<input class="text" type="text" id="new-site-name" name="name" size="30" value="{$site->getName()|escape}" />
 				<div class="sub">
-					{t}Appears on the top-left corner of your Wikijump site.{/t}
+					{t}Appears on the top-left corner of your {$SERVICE_NAME} site.{/t}
 				</div>
 			</td>
 		</tr>

--- a/web/templates/modules/ManageSite/ManageSiteDeleteModule.tpl
+++ b/web/templates/modules/ManageSite/ManageSiteDeleteModule.tpl
@@ -10,7 +10,7 @@
 </p>
 
 <p>
-	We highly discourage anyone from deleting a website at Wikijump especially if:
+	We highly discourage anyone from deleting a website at {$SERVICE_NAME} especially if:
 </p>
 <ul>
 	<li>

--- a/web/templates/modules/ManageSite/ManageSiteForumSettingsModule.tpl
+++ b/web/templates/modules/ManageSite/ManageSiteForumSettingsModule.tpl
@@ -85,7 +85,7 @@ forum:recent-posts</pre></code>
 
 	<p>
 		In order to use forum (and per-page discussions) you must initialize the forum structures in
-		your Wikijump site. When you decide to use the forum additional pages will be created
+		your {$SERVICE_NAME} site. When you decide to use the forum additional pages will be created
 		for you automatically. After that you will be able to create forum categories
 		structure, set permissions etc.
 	</p>
@@ -94,8 +94,8 @@ forum:recent-posts</pre></code>
 	</div>
 
 	<p>
-		<!-- TODO: De-Wikijump.com-ize - change -->
-		For a complete guide on starting a forum look at this <a href="http://community.wikijump.com/howto:forum-step-by-step" target="_blank">Step-by-step Howto</a>.
+		<!-- TODO: De-Wikidot.com-ize - change -->
+		For a complete guide on starting a forum look at this <a href="http://community.wikidot.com/howto:forum-step-by-step" target="_blank">Step-by-step Howto</a>.
 	</p>
 
 {/if}

--- a/web/templates/modules/ManageSite/ManageSiteMembersInviteModule.tpl
+++ b/web/templates/modules/ManageSite/ManageSiteMembersInviteModule.tpl
@@ -2,7 +2,7 @@
 
 <p>
 	You can easily invite new members to this Site. Use this option if you want
-	to invite a particular User (must already have a Wikijump account).
+	to invite a particular user (must already have a {$SERVICE_NAME} account).
 	Do not send "spam invitations".
 </p>
 <p>

--- a/web/templates/modules/NewSite/NewSiteModule.tpl
+++ b/web/templates/modules/NewSite/NewSiteModule.tpl
@@ -13,7 +13,7 @@
 							>{t}Log in{/t}</a>
 					</div>
 					<p>
-						{t}if you already have a Wikijump account{/t}
+						{t}if you already have a {$SERVICE_NAME} account{/t}
 					</p>
 				</td>
 				<td style="padding: 1em; font-size: 140%">
@@ -42,7 +42,7 @@
 					<td>
 						<input class="text" type="text" id="new-site-name" name="name" size="30" value="{$siteName|escape}" />
 						<div class="sub">
-							{t}Appears on the top-left corner of your Wikijump site.{/t}
+							{t}Appears on the top-left corner of your {$SERVICE_NAME} site.{/t}
 						</div>
 					</td>
 				</tr>


### PR DESCRIPTION
This leaves mentions of Wikijump as a service unchanged. It also fixes a broken link to the community Wikidot site.