### PR TITLE
[WJ-568] Add _ as line extension

### DIFF
--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -54,8 +54,8 @@ pub fn substitute(log: &Logger, text: &mut String) {
     // Strip lines with only whitespace
     regex_replace(log, text, &*WHITESPACE, "");
 
-    // Join concatenated lines (ending with '\')
-    str_replace(log, text, "\\\n", "");
+    // Join concatenated lines (ending with '\' or '_')
+    str_replace(log, text, "[\\_]\n", "");
 
     // Tabs to spaces
     str_replace(log, text, "\t", "    ");

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -103,7 +103,7 @@ fn regex_replace(log: &Logger, text: &mut String, regex: &Regex, replacement: &s
 }
 
 #[cfg(test)]
-const TEST_CASES: [(&str, &str); 6] = [
+const TEST_CASES: [(&str, &str); 8] = [
     (
         "\tapple\n\tbanana\tcherry\n",
         "    apple\n    banana    cherry",
@@ -123,6 +123,14 @@ const TEST_CASES: [(&str, &str); 6] = [
     (
         "concat:\napple banana \\\nCherry\\\nPineapple \\ grape\nblueberry\n",
         "concat:\napple banana CherryPineapple \\ grape\nblueberry",
+    ),
+    (
+        "concat:\napple banana _\nCherry_\nPineapple _ grape\nblueberry\n",
+        "concat:\napple banana CherryPineapple _ grape\nblueberry",
+    ),
+    (
+        "concat:\napple banana \\\nCherry_\nPineapple _ grape\nblueberry\n",
+        "concat:\napple banana CherryPineapple _ grape\nblueberry",
     ),
     ("<\n        \n      \n  \n      \n>", "<\n\n>"),
 ];

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -44,6 +44,7 @@ lazy_static! {
     };
     static ref LEADING_NEWLINES: Regex = Regex::new(r"^\n+").unwrap();
     static ref TRAILING_NEWLINES: Regex = Regex::new(r"\n+$").unwrap();
+    static ref CONCAT_LINES: Regex = Regex::new(r"[\\_]\n").unwrap();
 }
 
 pub fn substitute(log: &Logger, text: &mut String) {
@@ -55,7 +56,7 @@ pub fn substitute(log: &Logger, text: &mut String) {
     regex_replace(log, text, &*WHITESPACE, "");
 
     // Join concatenated lines (ending with '\' or '_')
-    str_replace(log, text, "[\\_]\n", "");
+    regex_replace(log, text, &*CONCAT_LINES, "");
 
     // Tabs to spaces
     str_replace(log, text, "\t", "    ");
@@ -131,6 +132,7 @@ fn regexes() {
     let _ = &*WHITESPACE;
     let _ = &*LEADING_NEWLINES;
     let _ = &*TRAILING_NEWLINES;
+    let _ = &*CONCAT_LINES;
 }
 
 #[test]


### PR DESCRIPTION
This allows using `_` to extend lines, like `\`:

```
Alpha _
Beta _
Gamma
```
Is interpreted the same as:
```
Alpha Beta Gamma
```