### PR TITLE
[WJ-505] Remove xsend fields from wikijump.ini

### DIFF
--- a/install/aws/dev/docker/php-fpm/wikijump.ini
+++ b/install/aws/dev/docker/php-fpm/wikijump.ini
@@ -395,17 +395,3 @@ modules_css_path = web/files--common/modules/css
 ; GlobalProperties Reference: $MODULES_CSS_URL
 ; Default: "/common--modules/css"
 modules_css_url = /common--modules/css
-
-; [xsendfile]
-; Purpose: Whether or not to use x-sendfile. This needs additional config in Apache, but is on by default in
-;   lighttpd. The nginx equivalent is X_Accel-Redirect. This is used to send files on disk as responses to requests.
-; GlobalProperties Reference: $XSENDFILE_USE
-; Default: false
-xsendfile = false
-
-; [xsendfile_header]
-; Purpose: What header to send with serving a file with x-sendfile. lighttpd 1.4 set X-LIGHTTPD-send-file,
-;   lighttpd 1.5 set X-LIGHTTPD-send-file or X-Sendfile, Apache with mod_xsendfile set X-Sendfile
-; GlobalProperties Reference: $XSENDFILE_HEADER
-; Default: "X-LIGHTTPD-send-file"
-xsendfile_header = X-LIGHTTPD-send-file

--- a/install/aws/prod/docker/php-fpm/wikijump.ini
+++ b/install/aws/prod/docker/php-fpm/wikijump.ini
@@ -395,17 +395,3 @@ modules_css_path = web/files--common/modules/css
 ; GlobalProperties Reference: $MODULES_CSS_URL
 ; Default: "/common--modules/css"
 modules_css_url = /common--modules/css
-
-; [xsendfile]
-; Purpose: Whether or not to use x-sendfile. This needs additional config in Apache, but is on by default in
-;   lighttpd. The nginx equivalent is X_Accel-Redirect. This is used to send files on disk as responses to requests.
-; GlobalProperties Reference: $XSENDFILE_USE
-; Default: false
-xsendfile = false
-
-; [xsendfile_header]
-; Purpose: What header to send with serving a file with x-sendfile. lighttpd 1.4 set X-LIGHTTPD-send-file,
-;   lighttpd 1.5 set X-LIGHTTPD-send-file or X-Sendfile, Apache with mod_xsendfile set X-Sendfile
-; GlobalProperties Reference: $XSENDFILE_HEADER
-; Default: "X-LIGHTTPD-send-file"
-xsendfile_header = X-LIGHTTPD-send-file

--- a/install/local/dev/php-fpm/wikijump.ini
+++ b/install/local/dev/php-fpm/wikijump.ini
@@ -395,17 +395,3 @@ modules_css_path = web/files--common/modules/css
 ; GlobalProperties Reference: $MODULES_CSS_URL
 ; Default: "/common--modules/css"
 modules_css_url = /common--modules/css
-
-; [xsendfile]
-; Purpose: Whether or not to use x-sendfile. This needs additional config in Apache, but is on by default in
-;   lighttpd. The nginx equivalent is X_Accel-Redirect. This is used to send files on disk as responses to requests.
-; GlobalProperties Reference: $XSENDFILE_USE
-; Default: false
-xsendfile = false
-
-; [xsendfile_header]
-; Purpose: What header to send with serving a file with x-sendfile. lighttpd 1.4 set X-LIGHTTPD-send-file,
-;   lighttpd 1.5 set X-LIGHTTPD-send-file or X-Sendfile, Apache with mod_xsendfile set X-Sendfile
-; GlobalProperties Reference: $XSENDFILE_HEADER
-; Default: "X-LIGHTTPD-send-file"
-xsendfile_header = X-LIGHTTPD-send-file

--- a/web/conf/wikijump.ini.example
+++ b/web/conf/wikijump.ini.example
@@ -397,17 +397,3 @@ modules_css_path = web/files--common/modules/css
 ; GlobalProperties Reference: $MODULES_CSS_URL
 ; Default: "/common--modules/css"
 modules_css_url = /common--modules/css
-
-; [xsendfile]
-; Purpose: Whether or not to use x-sendfile. This needs additional config in Apache, but is on by default in
-;   lighttpd. The nginx equivalent is X_Accel-Redirect. This is used to send files on disk as responses to requests.
-; GlobalProperties Reference: $XSENDFILE_USE
-; Default: false
-xsendfile = false
-
-; [xsendfile_header]
-; Purpose: What header to send with serving a file with x-sendfile. lighttpd 1.4 set X-LIGHTTPD-send-file,
-;   lighttpd 1.5 set X-LIGHTTPD-send-file or X-Sendfile, Apache with mod_xsendfile set X-Sendfile
-; GlobalProperties Reference: $XSENDFILE_HEADER
-; Default: "X-LIGHTTPD-send-file"
-xsendfile_header = X-LIGHTTPD-send-file

--- a/web/lib/ozoneframework/php/core/WebFlowController.php
+++ b/web/lib/ozoneframework/php/core/WebFlowController.php
@@ -2,10 +2,6 @@
 
 namespace Ozone\Framework;
 
-
-
-
-
 use Wikidot\Utils\GlobalProperties;
 
 /**
@@ -119,15 +115,11 @@ abstract class WebFlowController {
 	}
 
 	/**
-	 * sends the file to the browser using PHP's readfile or X-Sendfile header
+	 * sends the file to the browser using PHP's readfile
 	 *
 	 * @param mixed $path
 	 */
 	protected function readfile($path) {
-		if (GlobalProperties::$XSENDFILE_USE) {
-			header(GlobalProperties::$XSENDFILE_HEADER . ": $path");
-		} else {
-			readfile($path);
-		}
+		readfile($path);
 	}
 }

--- a/web/php/Utils/GlobalProperties.php
+++ b/web/php/Utils/GlobalProperties.php
@@ -89,8 +89,6 @@ class GlobalProperties
     public static $MODULES_JS_URL;
     public static $MODULES_CSS_PATH;
     public static $MODULES_CSS_URL;
-    public static $XSENDFILE_USE;
-    public static $XSENDFILE_HEADER;
 
     // third-party keys
     public static $FR_CAPTCHA_SITE_KEY;
@@ -242,8 +240,6 @@ class GlobalProperties
         self::$MODULES_JS_URL           = $_ENV["WIKIJUMP_MODULES_JS_URL"] ?? self::fromIni("misc", "modules_js_url", "/common--modules/js");
         self::$MODULES_CSS_PATH         = $_ENV["WIKIJUMP_MODULES_CSS_PATH"] ?? self::fromIni("misc", "modules_css_path", "web/files--common/modules/css");
         self::$MODULES_CSS_URL          = $_ENV["WIKIJUMP_MODULES_CSS_URL"] ?? self::fromIni("misc", "modules_css_url", "/common--modules/css");
-        self::$XSENDFILE_USE            = $_ENV["WIKIJUMP_XSENDFILE_USE"] ?? self::fromIni("misc", "xsendfile", false);
-        self::$XSENDFILE_HEADER         = $_ENV["WIKIJUMP_XSENDFILE_HEADER"] ?? self::fromIni("misc", "xsendfile_header", "X-LIGHTTPD-send-file");
 
         self::$FR_CAPTCHA_SITE_KEY      = $_ENV["WIKIJUMP_FR_CAPTCHA_SITE_KEY"] ?? self::fromIni("keys", "friendlycaptcha-site-key", "");
         self::$FR_CAPTCHA_API_KEY       = $_ENV["WIKIJUMP_FR_CAPTCHA_API_KEY"] ?? self::fromIni("keys", "friendlycaptcha-api-key", "");


### PR DESCRIPTION
We no longer use lighttpd so these headers don't do anything, and they're disabled anyways.