### PR TITLE
[WJ-570] Output styles as a vec

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/ffi/html.rs
+++ b/ftml/src/ffi/html.rs
@@ -72,7 +72,8 @@ impl From<HtmlMeta> for ftml_html_meta {
 #[derive(Debug)]
 pub struct ftml_html_output {
     pub html: *mut c_char,
-    pub style: *mut c_char,
+    pub styles_list: *mut *mut c_char,
+    pub styles_len: usize,
     pub meta_list: *mut ftml_html_meta,
     pub meta_len: usize,
     pub warning_list: *mut ftml_warning,
@@ -82,7 +83,11 @@ pub struct ftml_html_output {
 impl ftml_html_output {
     pub fn write_from(&mut self, output: HtmlOutput, warnings: &[ParseWarning]) {
         self.html = string_to_cstr(output.html);
-        self.style = string_to_cstr(output.style);
+
+        let c_styles = output.styles.into_iter().map(string_to_cstr).collect();
+        let (styles_ptr, styles_len) = vec_to_cptr(c_styles);
+        self.styles_list = styles_ptr;
+        self.styles_len = styles_len;
 
         let c_meta = output.meta.into_iter().map(ftml_html_meta::from).collect();
         let (meta_ptr, meta_len) = vec_to_cptr(c_meta);
@@ -103,7 +108,7 @@ pub unsafe extern "C" fn ftml_destroy_html_output(ptr: *mut ftml_html_output) {
     let this = &mut *ptr;
 
     drop_cstr(this.html);
-    drop_cstr(this.style);
+    drop_cptr(this.styles_list, this.styles_len, |style| drop_cstr(style));
     drop_cptr(this.meta_list, this.meta_len, |item| {
         drop_cstr(item.name);
         drop_cstr(item.value);

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -30,7 +30,7 @@ use std::num::NonZeroUsize;
 #[derive(Debug)]
 pub struct HtmlContext<'i, 'h> {
     html: String,
-    style: String,
+    styles: Vec<String>,
     meta: Vec<HtmlMeta>,
     info: &'i PageInfo<'i>,
     handle: &'h Handle,
@@ -44,7 +44,7 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
     pub fn new(info: &'i PageInfo<'i>, handle: &'h Handle) -> Self {
         HtmlContext {
             html: String::new(),
-            style: String::new(),
+            styles: Vec::new(),
             meta: Self::initial_metadata(&info),
             info,
             handle,
@@ -111,12 +111,8 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
     }
 
     #[inline]
-    pub fn add_style(&mut self, style: &str) {
-        if !self.style.is_empty() {
-            self.style.push_str("\n/*****/\n");
-        }
-
-        self.style.push_str(style);
+    pub fn add_style(&mut self, style: String) {
+        self.styles.push(style);
     }
 
     #[inline]
@@ -144,10 +140,10 @@ impl<'i, 'h> From<HtmlContext<'i, 'h>> for HtmlOutput {
     #[inline]
     fn from(ctx: HtmlContext<'i, 'h>) -> HtmlOutput {
         let HtmlContext {
-            html, style, meta, ..
+            html, styles, meta, ..
         } = ctx;
 
-        HtmlOutput { html, style, meta }
+        HtmlOutput { html, styles, meta }
     }
 }
 

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -70,7 +70,7 @@ impl Render for HtmlRender {
 
         // Add styles
         for style in &tree.styles {
-            ctx.add_style(style);
+            ctx.add_style(str!(style));
         }
 
         // Crawl through elements and generate HTML

--- a/ftml/src/render/html/output.rs
+++ b/ftml/src/render/html/output.rs
@@ -23,6 +23,6 @@ use super::meta::HtmlMeta;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HtmlOutput {
     pub html: String,
-    pub style: String,
+    pub styles: Vec<String>,
     pub meta: Vec<HtmlMeta>,
 }

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -60,6 +60,9 @@ export interface IPageInfo {
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(typescript_type = "string[]")]
+    pub type IStyleArray;
+
     #[wasm_bindgen(typescript_type = "IHtmlMeta[]")]
     pub type IHtmlMetaArray;
 
@@ -164,9 +167,9 @@ impl HtmlOutput {
         self.inner.html.clone()
     }
 
-    #[wasm_bindgen]
-    pub fn style(&self) -> String {
-        self.inner.style.clone()
+    #[wasm_bindgen(typescript_type = "IStyleArray")]
+    pub fn styles(&self) -> Result<IStyleArray, JsValue> {
+        rust_to_js!(self.inner.styles)
     }
 
     #[wasm_bindgen(typescript_type = "IHtmlMetaArray")]

--- a/web/app/Services/Wikitext/HtmlOutput.php
+++ b/web/app/Services/Wikitext/HtmlOutput.php
@@ -12,18 +12,26 @@ use \FFI;
 class HtmlOutput
 {
     public string $html;
-    public string $style;
+    public array $styles;
     public array $meta;
     public array $warnings;
 
     public function __construct(FFI\CData $c_data) {
         $this->html = FFI::string($c_data->html);
-        $this->style = FFI::string($c_data->style);
+        $this->styles = self::stylesFromArray($c_data->styles_list, $c_data->styles_len);
         $this->meta = HtmlMeta::fromArray($c_data->meta_list, $c_data->meta_len);
         $this->warnings = ParseWarning::fromArray($c_data->warning_list, $c_data->warning_len);
 
         // Free original C data
         FtmlFfi::freeHtmlOutput($c_data);
         FFI::free($c_data);
+    }
+
+    public static function stylesFromArray(FFI\CData $pointer, int $length): array {
+        return FtmlFfi::pointerToList(
+            $pointer,
+            $length,
+            fn(FFI\CData $c_data) => FFI::string($c_data),
+        );
     }
 }


### PR DESCRIPTION
This modifies `HtmlOutput` such that `styles` is now a `Vec<String>` rather than a `String`. This also modifies the WASM and FFI usages of ftml.