### PR TITLE
[ftml] Rename "html" to "body"

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/ffi/html.rs
+++ b/ftml/src/ffi/html.rs
@@ -71,7 +71,7 @@ impl From<HtmlMeta> for ftml_html_meta {
 #[repr(C)]
 #[derive(Debug)]
 pub struct ftml_html_output {
-    pub html: *mut c_char,
+    pub body: *mut c_char,
     pub styles_list: *mut *mut c_char,
     pub styles_len: usize,
     pub meta_list: *mut ftml_html_meta,
@@ -82,7 +82,7 @@ pub struct ftml_html_output {
 
 impl ftml_html_output {
     pub fn write_from(&mut self, output: HtmlOutput, warnings: &[ParseWarning]) {
-        self.html = string_to_cstr(output.html);
+        self.body = string_to_cstr(output.body);
 
         let c_styles = output.styles.into_iter().map(string_to_cstr).collect();
         let (styles_ptr, styles_len) = vec_to_cptr(c_styles);
@@ -107,7 +107,7 @@ impl ftml_html_output {
 pub unsafe extern "C" fn ftml_destroy_html_output(ptr: *mut ftml_html_output) {
     let this = &mut *ptr;
 
-    drop_cstr(this.html);
+    drop_cstr(this.body);
     drop_cptr(this.styles_list, this.styles_len, |style| drop_cstr(style));
     drop_cptr(this.meta_list, this.meta_len, |item| {
         drop_cstr(item.name);

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -23,13 +23,13 @@ use super::escape::escape;
 use super::meta::{HtmlMeta, HtmlMetaType};
 use super::output::HtmlOutput;
 use crate::render::Handle;
-use crate::PageInfo;
+use crate::{info, PageInfo};
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
 
 #[derive(Debug)]
 pub struct HtmlContext<'i, 'h> {
-    html: String,
+    body: String,
     styles: Vec<String>,
     meta: Vec<HtmlMeta>,
     info: &'i PageInfo<'i>,
@@ -43,7 +43,7 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
     #[inline]
     pub fn new(info: &'i PageInfo<'i>, handle: &'h Handle) -> Self {
         HtmlContext {
-            html: String::new(),
+            body: String::new(),
             styles: Vec::new(),
             meta: Self::initial_metadata(&info),
             info,
@@ -107,7 +107,7 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
     // Buffer management
     #[inline]
     pub fn buffer(&mut self) -> &mut String {
-        &mut self.html
+        &mut self.body
     }
 
     #[inline]
@@ -140,10 +140,10 @@ impl<'i, 'h> From<HtmlContext<'i, 'h>> for HtmlOutput {
     #[inline]
     fn from(ctx: HtmlContext<'i, 'h>) -> HtmlOutput {
         let HtmlContext {
-            html, styles, meta, ..
+            body, styles, meta, ..
         } = ctx;
 
-        HtmlOutput { html, styles, meta }
+        HtmlOutput { body, styles, meta }
     }
 }
 

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -64,7 +64,7 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
             HtmlMeta {
                 tag_type: HtmlMetaType::Name,
                 name: str!("generator"),
-                value: format!("ftml {}", env!("CARGO_PKG_VERSION")),
+                value: info::VERSION.clone(),
             },
             HtmlMeta {
                 tag_type: HtmlMetaType::Name,

--- a/ftml/src/render/html/output.rs
+++ b/ftml/src/render/html/output.rs
@@ -22,7 +22,7 @@ use super::meta::HtmlMeta;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct HtmlOutput {
-    pub html: String,
+    pub body: String,
     pub styles: Vec<String>,
     pub meta: Vec<HtmlMeta>,
 }

--- a/ftml/src/test.rs
+++ b/ftml/src/test.rs
@@ -215,13 +215,13 @@ impl Test<'_> {
             );
         }
 
-        if html_output.html != self.html {
+        if html_output.body != self.html {
             panic!(
                 "Running test '{}' failed! HTML does not match:\nExpected: {:?}\nActual: {:?}\n\n{}\n\nTree (correct): {:#?}",
                 self.name,
                 self.html,
-                html_output.html,
-                html_output.html,
+                html_output.body,
+                html_output.body,
                 &tree,
             );
         }

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 const TS_APPEND_CONTENT: &str = r#"
 
 export interface IHtmlOutput {
-    html: string;
+    body: string;
     style: string;
     meta: IHtmlMeta[];
 }
@@ -163,8 +163,8 @@ impl HtmlOutput {
     }
 
     #[wasm_bindgen]
-    pub fn html(&self) -> String {
-        self.inner.html.clone()
+    pub fn body(&self) -> String {
+        self.inner.body.clone()
     }
 
     #[wasm_bindgen(typescript_type = "IStyleArray")]

--- a/web/app/Services/Wikitext/HtmlOutput.php
+++ b/web/app/Services/Wikitext/HtmlOutput.php
@@ -11,13 +11,13 @@ use \FFI;
  */
 class HtmlOutput
 {
-    public string $html;
+    public string $body;
     public array $styles;
     public array $meta;
     public array $warnings;
 
     public function __construct(FFI\CData $c_data) {
-        $this->html = FFI::string($c_data->html);
+        $this->body = FFI::string($c_data->body);
         $this->styles = self::stylesFromArray($c_data->styles_list, $c_data->styles_len);
         $this->meta = HtmlMeta::fromArray($c_data->meta_list, $c_data->meta_len);
         $this->warnings = ParseWarning::fromArray($c_data->warning_list, $c_data->warning_len);


### PR DESCRIPTION
This is a more accurate way of describing which part of the HTML document is being produced.

It also has a minor change that uses a more complete crate version in the generated HTML meta fields.