### PR TITLE
[WJ-573] Remove _ concatenation

### DIFF
--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -54,9 +54,8 @@ pub fn substitute(log: &Logger, text: &mut String) {
     // Strip lines with only whitespace
     regex_replace(log, text, &*WHITESPACE, "");
 
-    // Join concatenated lines (ending with '\' or '_')
+    // Join concatenated lines (ending with '\')
     str_replace(log, text, "\\\n", "");
-    str_replace(log, text, " _\n", " ");
 
     // Tabs to spaces
     str_replace(log, text, "\t", "    ");
@@ -103,7 +102,7 @@ fn regex_replace(log: &Logger, text: &mut String, regex: &Regex, replacement: &s
 }
 
 #[cfg(test)]
-const TEST_CASES: [(&str, &str); 8] = [
+const TEST_CASES: [(&str, &str); 6] = [
     (
         "\tapple\n\tbanana\tcherry\n",
         "    apple\n    banana    cherry",
@@ -123,14 +122,6 @@ const TEST_CASES: [(&str, &str); 8] = [
     (
         "concat:\napple banana \\\nCherry\\\nPineapple \\ grape\nblueberry\n",
         "concat:\napple banana CherryPineapple \\ grape\nblueberry",
-    ),
-    (
-        "concat:\napple banana _\nCherry _\nPineapple _ grape\nblueberry\n",
-        "concat:\napple banana CherryPineapple _ grape\nblueberry",
-    ),
-    (
-        "concat:\napple banana \\\nCherry _\nPineapple _ grape\nblueberry\n",
-        "concat:\napple banana CherryPineapple _ grape\nblueberry",
     ),
     ("<\n        \n      \n  \n      \n>", "<\n\n>"),
 ];

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -44,7 +44,6 @@ lazy_static! {
     };
     static ref LEADING_NEWLINES: Regex = Regex::new(r"^\n+").unwrap();
     static ref TRAILING_NEWLINES: Regex = Regex::new(r"\n+$").unwrap();
-    static ref CONCAT_LINES: Regex = Regex::new(r"(?:\\| _)\n").unwrap();
 }
 
 pub fn substitute(log: &Logger, text: &mut String) {
@@ -56,7 +55,8 @@ pub fn substitute(log: &Logger, text: &mut String) {
     regex_replace(log, text, &*WHITESPACE, "");
 
     // Join concatenated lines (ending with '\' or '_')
-    regex_replace(log, text, &*CONCAT_LINES, "");
+    str_replace(log, text, "\\\n", "");
+    str_replace(log, text, " _\n", " ");
 
     // Tabs to spaces
     str_replace(log, text, "\t", "    ");
@@ -140,7 +140,6 @@ fn regexes() {
     let _ = &*WHITESPACE;
     let _ = &*LEADING_NEWLINES;
     let _ = &*TRAILING_NEWLINES;
-    let _ = &*CONCAT_LINES;
 }
 
 #[test]

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -44,7 +44,7 @@ lazy_static! {
     };
     static ref LEADING_NEWLINES: Regex = Regex::new(r"^\n+").unwrap();
     static ref TRAILING_NEWLINES: Regex = Regex::new(r"\n+$").unwrap();
-    static ref CONCAT_LINES: Regex = Regex::new(r"[\\_]\n").unwrap();
+    static ref CONCAT_LINES: Regex = Regex::new(r"(?:\\| _)\n").unwrap();
 }
 
 pub fn substitute(log: &Logger, text: &mut String) {
@@ -125,11 +125,11 @@ const TEST_CASES: [(&str, &str); 8] = [
         "concat:\napple banana CherryPineapple \\ grape\nblueberry",
     ),
     (
-        "concat:\napple banana _\nCherry_\nPineapple _ grape\nblueberry\n",
+        "concat:\napple banana _\nCherry _\nPineapple _ grape\nblueberry\n",
         "concat:\napple banana CherryPineapple _ grape\nblueberry",
     ),
     (
-        "concat:\napple banana \\\nCherry_\nPineapple _ grape\nblueberry\n",
+        "concat:\napple banana \\\nCherry _\nPineapple _ grape\nblueberry\n",
         "concat:\napple banana CherryPineapple _ grape\nblueberry",
     ),
     ("<\n        \n      \n  \n      \n>", "<\n\n>"),


### PR DESCRIPTION
In preparation for [WJ-573](https://scuttle.atlassian.net/browse/WJ-573) eventually adding actual support for soft line breaks, we should just remove the `_` concatenation for now to avoid regressions.