### PR TITLE
Move coverage generation for client monorepo to a new workflow job

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -56,7 +56,7 @@ jobs:
             ~/.pnpm-store
           key: ${{ runner.OS }}-pnpm-coverage-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.OS }}-pnpm-
+            ${{ runner.OS }}-pnpm-coverage-
             ${{ runner.OS }}-
 
       - name: Install Node

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -23,7 +23,6 @@ jobs:
           key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.OS }}-pnpm-
-            ${{ runner.OS }}-
 
       - name: Install Node
         uses: actions/setup-node@v2
@@ -57,7 +56,6 @@ jobs:
           key: ${{ runner.OS }}-pnpm-coverage-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.OS }}-pnpm-coverage-
-            ${{ runner.OS }}-
 
       - name: Install Node
         uses: actions/setup-node@v2

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           path: |
             ~/.pnpm-store
-          key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.OS }}-pnpm-coverage-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.OS }}-pnpm-
             ${{ runner.OS }}-

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -42,6 +42,37 @@ jobs:
       - name: Validate
         run: cd client && pnpm validate
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: PNPM Store Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.pnpm-store
+          key: ${{ runner.OS }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.OS }}-pnpm-
+            ${{ runner.OS }}-
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+
+      - name: Install PNPM
+        run: curl -f https://get.pnpm.io/v6.js | node - add --global pnpm@6
+
+      - name: Install Dependencies
+        run: cd client && pnpm i
+
+      - name: Coverage
+        run: cd client && pnpm cover
+
       - name: Export Coverage
         uses: codecov/codecov-action@v1
         with:

--- a/client/nabs.yml
+++ b/client/nabs.yml
@@ -15,18 +15,26 @@ test: pnpm test:compile && nyc --use-spawn-wrap npm run test:run
 
 typecheck: tsc
 
+lint:eslint: eslint "./**/*.js" "./**/*.ts"
+lint:stylelint: stylelint "modules/**/*.scss" "web/**/*.scss"
+lint:prettier: prettier --ignore-unknown --check "modules/**" "web/**"
 lint:
-  eslint: eslint "./**/*.js" "./**/*.ts"
-  stylelint: stylelint "modules/**/*.scss" "web/**/*.scss"
-  prettier: prettier --ignore-unknown --check "modules/**" "web/**"
+  - pnpm lint:eslint
+  - pnpm lint:prettier
+  - pnpm lint:stylelint
 
+lint:fix:eslint: eslint "./**/*.js" "./**/*.ts" --fix
+lint:fix:stylelint: stylelint "modules/**/*.scss" "web/**/*.scss" --fix
+lint:fix:prettier: prettier --write --ignore-unknown "modules/**" "web/**"
 lint:fix:
-  eslint: eslint "./**/*.js" "./**/*.ts" --fix
-  stylelint: stylelint "modules/**/*.scss" "web/**/*.scss" --fix
-  prettier: prettier --write --ignore-unknown "modules/**" "web/**"
+  - pnpm lint:fix:eslint
+  - pnpm lint:fix:prettier
+  - pnpm lint:fix:stylelint
 
 # Runs everything in parallel for maximum speed
-validate:cmd: pnpm lint && pnpm typecheck
+validate:cmd:
+  - pnpm lint
+  - pnpm typecheck
 validate: ultra --concurrency 10 validate:cmd
 
 # -- MISC.

--- a/client/nabs.yml
+++ b/client/nabs.yml
@@ -9,7 +9,13 @@ test:compile:
   - trash tests-dist
   - node scripts/build-tests.js
 test:run: uvu ./tests-dist/dist test-megabundle.+js$
-test: pnpm test:compile && nyc --use-spawn-wrap npm run test:run
+test:
+  - pnpm test:compile
+  - pnpm test:run
+
+cover:
+  - pnpm test:compile
+  - nyc --use-spawn-wrap npm run test:run || true
 
 # -- VALIDATION
 

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "ultra -r build",
+    "cover": "pnpm test:compile && nyc --use-spawn-wrap npm run test:run || true",
     "dev:dev-sandbox": "ultra --raw -r --filter \"web/dev-sandbox\" dev",
     "force-build": "ultra --rebuild -r build",
     "lint": "pnpm lint:eslint && pnpm lint:prettier && pnpm lint:stylelint",
@@ -15,7 +16,7 @@
     "lint:fix:stylelint": "stylelint \"modules/**/*.scss\" \"web/**/*.scss\" --fix",
     "lint:prettier": "prettier --ignore-unknown --check \"modules/**\" \"web/**\"",
     "lint:stylelint": "stylelint \"modules/**/*.scss\" \"web/**/*.scss\"",
-    "test": "pnpm test:compile && nyc --use-spawn-wrap npm run test:run",
+    "test": "pnpm test:compile && pnpm test:run",
     "test:compile": "trash tests-dist && node scripts/build-tests.js",
     "test:run": "uvu ./tests-dist/dist test-megabundle.+js$",
     "typecheck": "tsc",

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,6 @@
     "test:compile": "trash tests-dist && node scripts/build-tests.js",
     "test:run": "uvu ./tests-dist/dist test-megabundle.+js$",
     "typecheck": "tsc",
-    "update": "pnpm i && pnpm -r build",
     "validate": "ultra --concurrency 10 validate:cmd",
     "validate:cmd": "pnpm lint && pnpm typecheck",
     "nabs": "nabs"


### PR DESCRIPTION
I noticed that our sunburst on [CodeCov](https://app.codecov.io/gh/scpwiki/wikijump/) only contained files from `ftml/` and `web/` but was missing `client/`.

I think I've managed to track this down to the [`pnpm test`](https://github.com/scpwiki/wikijump/blob/f6f8b6e0ebeb5b4ec42b4373205da2a80f07c946/.github/workflows/client.yaml#L39-L40) step. Tests are currently failing, so that step errors out, which results in subsequent steps not being executed, therefore coverage is never uploaded.

I'm not sure if this PR will fix it or not, but I'm hoping that it might prompt CodeCov to update our report and that might give us a definite answer. If this doesn't work it would probably be a good idea to split coverage generation out into another command (that doesn't fail), and see if that works instead.