### PR TITLE
Hotfix: block rule mapping

### DIFF
--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -22,7 +22,7 @@ use super::{blocks::*, BlockRule};
 use std::collections::HashMap;
 use unicase::UniCase;
 
-pub const BLOCK_RULES: [BlockRule; 37] = [
+pub const BLOCK_RULES: [BlockRule; 38] = [
     BLOCK_ALIGN_CENTER,
     BLOCK_ALIGN_JUSTIFY,
     BLOCK_ALIGN_LEFT,


### PR DESCRIPTION
The merge on this file didn't produce a conflict, even though both PRs edit it and increase the count by 1. It's supposed to be increased by 2 because two blocks were added in two PRs.