### PR TITLE
Build ftml in php-fpm without logging

### DIFF
--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -23,7 +23,11 @@ RUN git clone \
 
 WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
 
-RUN cargo build --release
+# Build ftml-ffi without logging
+RUN cargo build \
+        --release \
+        --no-default-features \
+        --features ffi
 
 #
 # Main php-fpm container

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -23,7 +23,11 @@ RUN git clone \
 
 WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
 
-RUN cargo build --release
+# Build ftml-ffi without logging
+RUN cargo build \
+        --release \
+        --no-default-features \
+        --features ffi
 
 #
 # Main php-fpm container

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -23,7 +23,11 @@ RUN git clone \
 
 WORKDIR /src/${WIKIJUMP_REPO_DIR}/ftml
 
-RUN cargo build --release
+# Build ftml-ffi without logging
+RUN cargo build \
+        --release \
+        --no-default-features \
+        --features ffi
 
 #
 # Main php-fpm container


### PR DESCRIPTION
I've thought about this for a bit, but because ftml emits _so much_ logging, and this causes the performance on a CPU-bound task to degrade below the WASM implementation (which has no logging), I think it is better that for our production environment, we disable logs.

We can investigate bugs locally by finding the relevant wikitext that failed and running it, inspecting log output.