### PR TITLE
Fix clippy build

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
 name = "atty"
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 dependencies = [
  "jobserver",
 ]
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
 dependencies = [
  "bitflags",
  "libc",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.21+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
 dependencies = [
  "cc",
  "libc",
@@ -660,9 +660,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"


### PR DESCRIPTION
The clippy lint check was failing with the following:

```rust
   Compiling git2 v0.13.19
error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
  --> /home/ammon/.cargo/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:74:15
   |
74 |         match (self, other) {
   |               ^^^^^^^^^^^^^
   |
note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 73:26...
  --> /home/ammon/.cargo/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:73:26
   |
73 |     fn eq(&self, other: &AttrValue<'_>) -> bool {
   |                          ^^^^^^^^^^^^^
note: ...so that the types are compatible
  --> /home/ammon/.cargo/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:74:15
   |
74 |         match (self, other) {
   |               ^^^^^^^^^^^^^
   = note: expected `(&AttrValue<'_>, &AttrValue<'_>)`
              found `(&AttrValue<'_>, &AttrValue<'_>)`
note: but, the lifetime must be valid for the lifetime `'_` as defined on the impl at 72:30...
  --> /home/ammon/.cargo/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:72:30
   |
72 | impl PartialEq for AttrValue<'_> {
   |                              ^^
note: ...so that the types are compatible
  --> /home/ammon/.cargo/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:79:16
   |
79 |             | (Self::Bytes(bytes), AttrValue::String(string)) => string.as_bytes() == *bytes,
   |                ^^^^^^^^^^^^^^^^^^
   = note: expected `AttrValue<'_>`
              found `AttrValue<'_>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0495`.
error: could not compile `git2`
```

On the latest cargo clippy version.

Updating the `git2` dependency fixes this issue.