### PR TITLE
Remove profiles from recommended hosts entries

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -25,14 +25,12 @@ Add the following lines to your HOSTS file:
 127.0.0.1          wikijump.test               Wikijump
 127.0.0.1          www.wikijump.test           Wikijump
 127.0.0.1          wjfiles.test                Wikijump
-127.0.0.1          profiles.wikijump.test      Wikijump
 127.0.0.1          template-en.wikijump.test   Wikijump
 127.0.0.1          sandbox.wikijump.test       Wikijump
 127.0.0.1          scp-wiki.wikijump.test      Wikijump
 ::1                wikijump.test               Wikijump
 ::1                www.wikijump.test           Wikijump
 ::1                wjfiles.test                Wikijump
-::1                profiles.wikijump.test      Wikijump
 ::1                template-en.wikijump.test   Wikijump
 ::1                sandbox.wikijump.test       Wikijump
 ::1                scp-wiki.wikijump.test      Wikijump


### PR DESCRIPTION
Because we have removed the profiles site, we don't need those hosts entries anymore.