### PR TITLE
[WJ-39] Hide forum delete button if unable to delete forums.

### DIFF
--- a/web/php/Modules/Forum/ForumViewThreadModule.php
+++ b/web/php/Modules/Forum/ForumViewThreadModule.php
@@ -168,6 +168,8 @@ class ForumViewThreadModule extends SmartyModule
         $runData->contextAdd("thread", $thread);
         $runData->contextAdd("category", $category);
         $runData->contextAdd("posts", $posts);
+        
+        $runData->contextAdd("canDelete", WDPermissionManager::instance()->hasForumPermission('moderate_forum', $runData->getUser(), $category));
 
         $page = $GLOBALS['page'];
     }

--- a/web/php/Modules/Forum/ForumViewThreadModule.php
+++ b/web/php/Modules/Forum/ForumViewThreadModule.php
@@ -169,7 +169,8 @@ class ForumViewThreadModule extends SmartyModule
         $runData->contextAdd("category", $category);
         $runData->contextAdd("posts", $posts);
         
-        $runData->contextAdd("canDelete", WDPermissionManager::instance()->hasForumPermission('moderate_forum', $runData->getUser(), $category));
+        $canDelete = WDPermissionManager::instance()->hasForumPermission('moderate_forum', $runData->getUser(), $category);
+        $runData->contextAdd("canDelete", $canDelete);
 
         $page = $GLOBALS['page'];
     }

--- a/web/templates/modules/Forum/ForumViewThreadModule.tpl
+++ b/web/templates/modules/Forum/ForumViewThreadModule.tpl
@@ -103,8 +103,10 @@
 
 	<div style="display:none" id="post-options-template">
 			<a href="javascript:;" onclick="Wikijump.modules.ForumViewThreadModule.listeners.showPermalink(event,'%POST_ID%')">{t}permanent link{/t}</a> |
-			<a href="javascript:;" onclick="Wikijump.modules.ForumViewThreadModule.listeners.editPost(event,'%POST_ID%')">{t}edit{/t}</a> |
-			<a href="javascript:;" onclick="Wikijump.modules.ForumViewThreadModule.listeners.deletePost(event,'%POST_ID%')">{t}delete{/t}</a>
+			<a href="javascript:;" onclick="Wikijump.modules.ForumViewThreadModule.listeners.editPost(event,'%POST_ID%')">{t}edit{/t}</a> 
+            {if $canDelete}
+                 | <a href="javascript:;" onclick="Wikijump.modules.ForumViewThreadModule.listeners.deletePost(event,'%POST_ID%')">{t}delete{/t}</a>
+            {/if}
 	</div>
 
 	<div style="display:none" id="post-options-permalink-template">{$tUrl}#post-</div>


### PR DESCRIPTION
**[WJ-39 ("Hide the "delete" button on forum posts if it's not permitted")](https://scuttle.atlassian.net/browse/WJ-39?atlOrigin=eyJpIjoiZGM2Njc2OTQ5ODk1NDQwZWI4YzRjYTcyMjRkOTNiMzMiLCJwIjoiaiJ9)**

Previously, users could see "delete" on every forum post even if they did not have permissions. WJ-39 was created to change this. This PR attempts to tackle that particular issue.