### PR TITLE
Update Rust version

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -200,11 +200,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -362,9 +361,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -451,9 +450,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libflate"
@@ -562,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -678,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -690,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -700,27 +699,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -793,15 +792,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "self_cell"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c924e8e521faa453317ab6887122657f1855e9c46f0fb5e6b4bdc3be845353"
+checksum = "6b35f48c688bec6aef5b874a1b4ff19a6b3213eeae481d7976522b133ab22f3f"
 
 [[package]]
 name = "semver"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 dependencies = [
  "serde",
 ]
@@ -957,12 +956,14 @@ dependencies = [
 
 [[package]]
 name = "sloggers"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01d37507aa6f37490cfa08d71e2639b16906e84c285ae4b9f7ec7ca35756d69"
+checksum = "92ee08a52260ed355f96069884bf8873f2439231f8754cbd545291d647ebbd75"
 dependencies = [
  "chrono",
+ "libc",
  "libflate",
+ "once_cell",
  "regex",
  "serde",
  "slog",
@@ -994,15 +995,15 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1012,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1162,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -1201,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -41,8 +41,8 @@ serde_json = "1"
 slog = { version = "2.7", features = ["max_level_trace"], optional = true }
 slog-mock = "0.4"
 str-macro = "1"
-strum = "0.20"
-strum_macros = "0.20"
+strum = "0.21"
+strum_macros = "0.21"
 tinyvec = "1"
 unicase = "2"
 void = "1"
@@ -53,10 +53,10 @@ built = { version = "0.5", features = ["chrono", "git2"] }
 cbindgen = "0.19"
 
 [dev-dependencies]
-sloggers = "1"
+sloggers = "2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-self_cell = "0.8"
+self_cell = "0.9"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["console"] }
 

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -27,7 +27,7 @@ The lint `#![deny(unsafe_code)]` is set, and therefore this crate has only safe 
 Available under the terms of the GNU Affero General Public License. See [LICENSE.md](LICENSE.md).
 
 ### Compilation
-This library targets the latest stable Rust. At time of writing, that is `1.51.0`.
+This library targets the latest stable Rust. At time of writing, that is `1.53.0`.
 
 ```sh
 $ cargo build --release

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -151,7 +151,7 @@ impl Replacer {
                     buffer.push_str(mtch.as_str());
                     buffer.push_str(end);
 
-                    text.replace_range(range, &buffer);
+                    text.replace_range(range, buffer);
                 }
             }
         }

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -91,9 +91,9 @@ impl Handle {
 
         let (site, page, file): (&str, &str, &str) = match source {
             ImageSource::Url(url) => return Cow::clone(url),
-            ImageSource::File1 { file } => (&info.site, &info.page, &file),
-            ImageSource::File2 { page, file } => (&info.site, &page, &file),
-            ImageSource::File3 { site, page, file } => (&site, &page, &file),
+            ImageSource::File1 { file } => (&info.site, &info.page, file),
+            ImageSource::File2 { page, file } => (&info.site, page, file),
+            ImageSource::File3 { site, page, file } => (site, page, file),
         };
 
         // TODO

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -180,7 +180,7 @@ impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
 
     pub fn attr_map(&mut self, map: &AttributeMap) -> &mut Self {
         for (key, value) in map.get() {
-            self.attr(&key, &[value]);
+            self.attr(key, &[value]);
         }
 
         self
@@ -197,9 +197,9 @@ impl<'c, 'i, 'h, 't> HtmlBuilderTag<'c, 'i, 'h, 't> {
             // Otherwise, just pass in the value
             if key.eq_ignore_ascii_case(extra_key) {
                 merged = true;
-                self.attr(&key, &[extra_value, " ", value]);
+                self.attr(key, &[extra_value, " ", value]);
             } else {
-                self.attr(&key, &[value]);
+                self.attr(key, &[value]);
             }
         }
 

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -45,7 +45,7 @@ impl<'i, 'h> HtmlContext<'i, 'h> {
         HtmlContext {
             body: String::new(),
             styles: Vec::new(),
-            meta: Self::initial_metadata(&info),
+            meta: Self::initial_metadata(info),
             info,
             handle,
             code_snippet_index: NonZeroUsize::new(1).unwrap(),

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -85,7 +85,7 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
             target,
         } => render_anchor(log, ctx, elements, attributes, *target),
         Element::Link { url, label, target } => {
-            render_link(log, ctx, &url, label, *target)
+            render_link(log, ctx, url, label, *target)
         }
         Element::Image {
             source,
@@ -98,7 +98,7 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
             name,
             checked,
             attributes,
-        } => render_radio_button(log, ctx, &name, *checked, attributes),
+        } => render_radio_button(log, ctx, name, *checked, attributes),
         Element::CheckBox {
             checked,
             attributes,
@@ -140,7 +140,7 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
                 render_elements(log, ctx, elements);
             }
         }
-        Element::User { name, show_avatar } => render_user(log, ctx, &name, *show_avatar),
+        Element::User { name, show_avatar } => render_user(log, ctx, name, *show_avatar),
         Element::Color { color, elements } => render_color(log, ctx, color, elements),
         Element::Code { contents, language } => {
             render_code(log, ctx, ref_cow!(language), contents)

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -27,7 +27,7 @@ pub fn render_wikitext_raw(log: &Logger, ctx: &mut HtmlContext, text: &str) {
         .span()
         .attr("class", &["raw"])
         .attr("style", &["white-space: pre-wrap;"]) // TODO add this to the "raw" class
-        .inner(&log, &text);
+        .inner(log, &text);
 }
 
 pub fn render_email(log: &Logger, ctx: &mut HtmlContext, email: &str) {

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -254,7 +254,7 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
         Element::Color { elements, .. } => render_elements(log, ctx, elements),
         Element::Code { contents, language } => {
             let language = match language {
-                Some(cow) => &cow,
+                Some(language) => language,
                 None => "",
             };
 

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -271,18 +271,18 @@ impl Element<'_> {
                 attributes,
                 target,
             } => Element::Anchor {
-                elements: elements_to_owned(&elements),
+                elements: elements_to_owned(elements),
                 attributes: attributes.to_owned(),
                 target: *target,
             },
             Element::Link { url, label, target } => Element::Link {
-                url: string_to_owned(&url),
+                url: string_to_owned(url),
                 label: label.to_owned(),
                 target: *target,
             },
             Element::List { ltype, items } => Element::List {
                 ltype: *ltype,
-                items: list_items_to_owned(&items),
+                items: list_items_to_owned(items),
             },
             Element::Image {
                 source,
@@ -300,7 +300,7 @@ impl Element<'_> {
                 checked,
                 attributes,
             } => Element::RadioButton {
-                name: string_to_owned(&name),
+                name: string_to_owned(name),
                 checked: *checked,
                 attributes: attributes.to_owned(),
             },
@@ -320,11 +320,11 @@ impl Element<'_> {
                 show_top,
                 show_bottom,
             } => Element::Collapsible {
-                elements: elements_to_owned(&elements),
+                elements: elements_to_owned(elements),
                 attributes: attributes.to_owned(),
                 start_open: *start_open,
-                show_text: option_string_to_owned(&show_text),
-                hide_text: option_string_to_owned(&hide_text),
+                show_text: option_string_to_owned(show_text),
+                hide_text: option_string_to_owned(hide_text),
                 show_top: *show_top,
                 show_bottom: *show_bottom,
             },
@@ -333,32 +333,32 @@ impl Element<'_> {
                 elements,
             } => Element::IfCategory {
                 conditions: conditions.iter().map(|c| c.to_owned()).collect(),
-                elements: elements_to_owned(&elements),
+                elements: elements_to_owned(elements),
             },
             Element::IfTags {
                 conditions,
                 elements,
             } => Element::IfTags {
                 conditions: conditions.iter().map(|c| c.to_owned()).collect(),
-                elements: elements_to_owned(&elements),
+                elements: elements_to_owned(elements),
             },
             Element::User { name, show_avatar } => Element::User {
                 name: string_to_owned(name),
                 show_avatar: *show_avatar,
             },
             Element::Color { color, elements } => Element::Color {
-                color: string_to_owned(&color),
-                elements: elements_to_owned(&elements),
+                color: string_to_owned(color),
+                elements: elements_to_owned(elements),
             },
             Element::Code { contents, language } => Element::Code {
-                contents: string_to_owned(&contents),
-                language: option_string_to_owned(&language),
+                contents: string_to_owned(contents),
+                language: option_string_to_owned(language),
             },
             Element::Html { contents } => Element::Html {
-                contents: string_to_owned(&contents),
+                contents: string_to_owned(contents),
             },
             Element::Iframe { url, attributes } => Element::Iframe {
-                url: string_to_owned(&url),
+                url: string_to_owned(url),
                 attributes: attributes.to_owned(),
             },
             Element::LineBreak => Element::LineBreak,

--- a/ftml/src/tree/list.rs
+++ b/ftml/src/tree/list.rs
@@ -41,7 +41,7 @@ impl ListItem<'_> {
     pub fn to_owned(&self) -> ListItem<'static> {
         match self {
             ListItem::Elements(elements) => {
-                ListItem::Elements(elements_to_owned(&elements))
+                ListItem::Elements(elements_to_owned(elements))
             }
             ListItem::SubList(element) => {
                 ListItem::SubList(element.to_owned()) //

--- a/ftml/src/wasm/tokenizer.rs
+++ b/ftml/src/wasm/tokenizer.rs
@@ -49,7 +49,6 @@ extern "C" {
 
 self_cell!(
     struct TokenizationInner {
-        #[from_fn]
         owner: String,
 
         #[covariant]
@@ -97,7 +96,7 @@ impl Tokenization {
 pub fn tokenize(text: String) -> Tokenization {
     let log = &*LOGGER;
     let inner =
-        TokenizationInner::from_fn(text, |text: &String| crate::tokenize(&log, text));
+        TokenizationInner::new(text, |text: &String| crate::tokenize(&log, text));
 
     Tokenization {
         inner: Arc::new(inner),

--- a/ftml/src/wasm/tokenizer.rs
+++ b/ftml/src/wasm/tokenizer.rs
@@ -95,8 +95,7 @@ impl Tokenization {
 #[wasm_bindgen]
 pub fn tokenize(text: String) -> Tokenization {
     let log = &*LOGGER;
-    let inner =
-        TokenizationInner::new(text, |text: &String| crate::tokenize(&log, text));
+    let inner = TokenizationInner::new(text, |text: &String| crate::tokenize(&log, text));
 
     Tokenization {
         inner: Arc::new(inner),

--- a/ftml/src/wasm/utf16.rs
+++ b/ftml/src/wasm/utf16.rs
@@ -51,9 +51,8 @@ impl Utf16IndexMap {
 
     #[wasm_bindgen(constructor)]
     pub fn new(text: String) -> Utf16IndexMap {
-        let inner = Utf16IndexMapInner::new(text, |text: &String| {
-            RustUtf16IndexMap::new(text)
-        });
+        let inner =
+            Utf16IndexMapInner::new(text, |text: &String| RustUtf16IndexMap::new(text));
 
         Utf16IndexMap {
             inner: Arc::new(inner),

--- a/ftml/src/wasm/utf16.rs
+++ b/ftml/src/wasm/utf16.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 
 self_cell!(
     struct Utf16IndexMapInner {
-        #[from_fn]
         owner: String,
 
         #[covariant]
@@ -52,7 +51,7 @@ impl Utf16IndexMap {
 
     #[wasm_bindgen(constructor)]
     pub fn new(text: String) -> Utf16IndexMap {
-        let inner = Utf16IndexMapInner::from_fn(text, |text: &String| {
+        let inner = Utf16IndexMapInner::new(text, |text: &String| {
             RustUtf16IndexMap::new(text)
         });
 


### PR DESCRIPTION
[Rust 1.53 Announcement Post](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html)

Updates dependencies to their latest versions and fixes lints associated with a new version of [Clippy](https://github.com/rust-lang/rust-clippy).