### PR TITLE
Make View Source and Backlinks Function

### DIFF
--- a/web/php/Modules/Backlinks/BacklinksModule.php
+++ b/web/php/Modules/Backlinks/BacklinksModule.php
@@ -12,7 +12,7 @@ class BacklinksModule extends SmartyModule
     public function build($runData)
     {
 
-        $pageId = $runData->getParameterList()->getParameterValue("page_id");
+        $pageId = $runData->getParameterList()->getParameterValue("pageId");
 
         if (!$pageId || !is_numeric($pageId)) {
             throw new ProcessException(_("The page cannot be found or does not exist."), "no_page");

--- a/web/php/Modules/ViewSource/ViewSourceModule.php
+++ b/web/php/Modules/ViewSource/ViewSourceModule.php
@@ -11,8 +11,9 @@ class ViewSourceModule extends SmartyModule
 {
     public function build($runData)
     {
+
         $site = $runData->getTemp("site");
-        $pageId = $runData->getParameterList()->getParameterValue("page_id");
+        $pageId = $runData->getParameterList()->getParameterValue("pageId");
 
         $raw = $runData->getParameterList()->getParameterValue("raw");
 

--- a/web/templates/modules/ViewSource/ViewSourceModule.tpl
+++ b/web/templates/modules/ViewSource/ViewSourceModule.tpl
@@ -1,7 +1,5 @@
 {if $raw}{$source}{else}
 <h1>{t}Page source{/t}</h1>
 
-<textarea class="page-source" readonly>
-	{$source|escape|semipre}
-</textarea>
+<pre><textarea class="page-source" readonly>{$source|escape}</textarea></pre>
 {/if}

--- a/web/web/files--common/theme/base/css/style.css
+++ b/web/web/files--common/theme/base/css/style.css
@@ -742,12 +742,13 @@ table.page-compare td, table.page-compare th{
 	border: 1px solid #CCC;
 }
 
-.page-source{
-	border: 1px dashed #AAA;
-	padding: 1em 2em;
-	/*overflow: auto;*/
-	/*white-space: pre-wrap;*/
-
+.page-source {
+    border: 1px dashed #AAA;
+    padding: 1em 2em;
+    white-space: pre-wrap;
+    overflow: auto;
+    width: 90%;
+    height: 40em;
 }
 
 .page-source pre{
@@ -1494,5 +1495,3 @@ version: 2.3.1
     border:1px solid #808080; /* content border */
     border-bottom-color:#243356; /* different border color */
 }
-
-


### PR DESCRIPTION
There was a bug present in our build of wikijump where attempting to view the source or backlinks resulted in an exception. This was the result of a mismatched case between the javascript and php. Additionally, @ammongit also styled the View Source so that it was a fixed height and easily viewable.

![image](https://user-images.githubusercontent.com/86030912/122868428-c9327800-d2df-11eb-8dc1-6e618b3ab453.png)
