### PR TITLE
Fix invalid method call in UserInfoWinModule template

### DIFF
--- a/web/templates/modules/Users/UserInfoWinModule.tpl
+++ b/web/templates/modules/Users/UserInfoWinModule.tpl
@@ -9,7 +9,7 @@
         {if $user->real_name}
             {t}Real name{/t}: {$user->real_name}<br/>
         {/if}
-        {if $user->pronouns()}
+        {if $user->pronouns}
             {t}Pronouns{/t}: {$user->pronouns}<br/>
         {/if}
         {if $user->dob}


### PR DESCRIPTION
Brain fart on a conditional causes the info panel to fail to load. Fix is tested working.