### PR TITLE
Fix ftml configuration for list blocks

### DIFF
--- a/.github/workflows/ftml-config.yaml
+++ b/.github/workflows/ftml-config.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'ftml/conf/*.toml'
       - 'ftml/scripts/*'
+      - 'ftml/src/parsing/rule/impls/block/blocks/**/*'
       - '.github/workflows/ftml-config.yaml'
 
 jobs:

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38728c31b994e4b849cf59feefb4a8bf26acd299ee0b92c9fb35bd14ad4b8dfa"
+checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
 dependencies = [
  "clap",
  "heck",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "deunicode"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f37775d639f64aa16389eede0cbe6a70f56df4609d50d8b6858690d5d7bf8f2"
+checksum = "f2c9736e15e7df1638a7f6eee92a6511615c738246a052af5ba86f039b65aede"
 
 [[package]]
 name = "digest"
@@ -682,9 +682,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -943,9 +943,9 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
+checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
 dependencies = [
  "crossbeam-channel",
  "slog",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "slog-json"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
+checksum = "52e9b96fb6b5e80e371423b4aca6656eb537661ce8f82c2697e619f8ca85d043"
 dependencies = [
  "chrono",
  "serde",
@@ -1160,12 +1160,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
@@ -1322,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -51,7 +51,7 @@ wikidot-normalize = "0.8"
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }
-cbindgen = "0.19"
+cbindgen = "0.20"
 
 [dev-dependencies]
 proptest = "1"

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -27,7 +27,7 @@ The lint `#![deny(unsafe_code)]` is set, and therefore this crate has only safe 
 Available under the terms of the GNU Affero General Public License. See [LICENSE.md](LICENSE.md).
 
 ### Compilation
-This library targets the latest stable Rust. At time of writing, that is `1.53.0`.
+This library targets the latest stable Rust. At time of writing, that is `1.54.0`.
 
 ```sh
 $ cargo build --release

--- a/ftml/conf/blocks.toml
+++ b/ftml/conf/blocks.toml
@@ -144,6 +144,14 @@ body = "elements"
 html-attributes = true
 html-output = "html,em"
 
+[li]
+head = "map"
+body = "elements"
+accepts-score = true
+accepts-newlines = true
+html-attributes = true
+html-output = "html,li"
+
 [lines]
 aliases = ["newlines"]
 accepts-newlines = true
@@ -172,6 +180,14 @@ head = "map"
 body = "elements"
 html-attributes = true
 html-output = "html,tt"
+
+[ol]
+head = "map"
+body = "elements"
+accepts-score = true
+accepts-newlines = true
+html-attributes = true
+html-output = "html,ol"
 
 [paragraph]
 aliases = ["p"]
@@ -221,6 +237,14 @@ head = "map"
 body = "elements"
 html-attributes = true
 html-output = "html,sup"
+
+[ul]
+head = "map"
+body = "elements"
+accepts-score = true
+accepts-newlines = true
+html-attributes = true
+html-output = "html,ul"
 
 [user]
 accepts-star = true


### PR DESCRIPTION
The CI build didn't fail when the list blocks were added (`[[li]]`, `[[ol]]`, `[[ul]]`) when it should've. This changes the build trigger to activate when any block updates, and adds them to the configuration.

It also updates dependencies and updates the stable Rust version.