### PR TITLE
[WJ-705] Allow ARIA attributes in ftml

### DIFF
--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -171,7 +171,7 @@ lazy_static! {
     static ref ATTRIBUTE_SUFFIX_SAFE: Regex = Regex::new(r"[a-zA-z0-9\-]+").unwrap();
 }
 
-pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 1] = ["data-"];
+pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 2] = ["aria-", "data-"];
 
 pub fn is_safe_attribute(attribute: UniCase<&str>) -> bool {
     if SAFE_ATTRIBUTES.contains(&attribute) {

--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -100,6 +100,7 @@ lazy_static! {
             "readonly",
             "required",
             "reversed",
+            "role",
             "rows",
             "rowspan",
             "scope",

--- a/ftml/test/span-style.html
+++ b/ftml/test/span-style.html
@@ -1,1 +1,1 @@
-<p><span class="fruit" data-fruit="!red" id="banana" style="color: yellow;">Banana</span></p>
+<p><span aria-pressed="false" class="fruit" data-fruit="!red" id="banana" role="button" style="color: yellow;">Banana</span></p>

--- a/ftml/test/span-style.json
+++ b/ftml/test/span-style.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[span id=\"banana\" class=\"fruit\" style=\"color: yellow;\" data-fruit=\"!red\"]]Banana[[/span]]",
+    "input": "[[span id=\"banana\" class=\"fruit\" style=\"color: yellow;\" data-fruit=\"!red\" role=\"button\" aria-pressed=\"false\"]]Banana[[/span]]",
     "tree": {
         "elements": [
             {
@@ -16,7 +16,9 @@
                                     "id": "banana",
                                     "class": "fruit",
                                     "style": "color: yellow;",
-                                    "data-fruit": "!red"
+                                    "data-fruit": "!red",
+                                    "role": "button",
+                                    "aria-pressed": "false"
                                 },
                                 "elements": [
                                     {


### PR DESCRIPTION
This adds [ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) attributes as allowed in ftml, which permits power users to improve accessibility on wikitext they create.