### PR TITLE
[WJ-581] Bump ftml to v1.0.0

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "0.12.0"
+version = "1.0.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -36,12 +36,14 @@ $ cargo build --release
 You can use this as a dependency by adding the following to your `Cargo.toml`:
 
 ```toml
-ftml = "0.10"
+ftml = "1"
 ```
 
-The library comes with two default features, `log` and `ffi`.
+The library comes with three default features, `css`, `log` and `ffi`.
 
-The former adds all `slog` logging code, which when removed replaces all of them with no-ops.
+The `css` feature adds a constrant string representing the contents of `misc/ftml-base.css` to the binary.
+
+The `log` feature adds all `slog` logging code, which when removed replaces all of them with no-ops.
 This may be desirable on certain platforms where the performance difference is significant.
 
 The `ffi` feature introduces an FFI interface for ftml, permitting C and C API-compatible code


### PR DESCRIPTION
This bumps ftml to 1.0.0, as all the issues within the [FTML 1.0 (WJ-595)](https://scuttle.atlassian.net/browse/WJ-595) epic are completed.