### PR TITLE
Add missing CSS class prefixes

### DIFF
--- a/ftml/misc/ftml-base.css
+++ b/ftml/misc/ftml-base.css
@@ -4,11 +4,11 @@
     padding: 1em;
 }
 
-.email {
+.wj-email {
     white-space: nowrap;
 }
 
-.raw {
+.wj-raw {
     white-space: pre-wrap;
 }
 


### PR DESCRIPTION
All standard CSS classes are prefixed with `wj-`. For some reason these two classes didn't have it.