### PR TITLE
[WJ-704] Allow specifying wikis in triple-bracket links

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "sloggers"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7071b1119e436e93157c2e9e134138d9d8716dfe5e2f472500119bcbe4f45a4e"
+checksum = "1ffcb984e952de7fdb085aa7bebcd4575e9d0c79630640a359a38578f0c18fd3"
 dependencies = [
  "chrono",
  "libc",

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "block-buffer"
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -473,9 +473,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libflate"
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",
@@ -553,9 +553,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "ref-map"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703281d31f29412a41ce63af76576f2f9db5628731414ca4c06b4c454b93ea5d"
+checksum = "d22b73985e369f260445a5e08ad470117b30e522c91b4820585baa2e0cbf7075"
 
 [[package]]
 name = "regex"
@@ -1240,12 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/data/backlinks.rs
+++ b/ftml/src/data/backlinks.rs
@@ -18,13 +18,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::data::PageRef;
+use crate::tree::LinkLocation;
 use std::borrow::Cow;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Backlinks<'a> {
-    pub included_pages: Vec<Cow<'a, str>>,
-    pub internal_links: Vec<Cow<'a, str>>,
+    pub included_pages: Vec<PageRef<'a>>,
+    pub internal_links: Vec<LinkLocation<'a>>,
     pub external_links: Vec<Cow<'a, str>>,
 }
 

--- a/ftml/src/data/mod.rs
+++ b/ftml/src/data/mod.rs
@@ -20,8 +20,10 @@
 
 mod backlinks;
 mod page_info;
+mod page_ref;
 mod user_info;
 
 pub use self::backlinks::Backlinks;
 pub use self::page_info::PageInfo;
+pub use self::page_ref::PageRef;
 pub use self::user_info::UserInfo;

--- a/ftml/src/data/mod.rs
+++ b/ftml/src/data/mod.rs
@@ -25,5 +25,5 @@ mod user_info;
 
 pub use self::backlinks::Backlinks;
 pub use self::page_info::PageInfo;
-pub use self::page_ref::PageRef;
+pub use self::page_ref::{PageRef, PageRefParseError};
 pub use self::user_info::UserInfo;

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -77,6 +77,11 @@ impl<'t> PageRef<'t> {
         self.page.as_ref()
     }
 
+    #[inline]
+    pub fn fields(&self) -> (Option<&str>, &str) {
+        (self.site(), self.page())
+    }
+
     pub fn parse(s: &'t str) -> Result<PageRef<'t>, PageRefParseError> {
         let s = s.trim();
         if s.is_empty() {

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -1,5 +1,5 @@
 /*
- * includes/object.rs
+ * data/page_ref.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Wikijump Team
@@ -20,7 +20,6 @@
 
 use ref_map::*;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fmt::{self, Display};
 
 /// Represents a reference to a page on the wiki, as used by includes.
@@ -134,58 +133,6 @@ impl Display for PageRef<'_> {
     }
 }
 
-pub type IncludeVariables<'t> = HashMap<Cow<'t, str>, Cow<'t, str>>;
-
-/// Represents an include block.
-///
-/// It contains the page being included, as well as the arguments
-/// to be passed to it when doing the substitution.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub struct IncludeRef<'t> {
-    page_ref: PageRef<'t>,
-    variables: IncludeVariables<'t>,
-}
-
-impl<'t> IncludeRef<'t> {
-    #[inline]
-    pub fn new(page_ref: PageRef<'t>, variables: IncludeVariables<'t>) -> Self {
-        IncludeRef {
-            page_ref,
-            variables,
-        }
-    }
-
-    #[inline]
-    pub fn page_only(page_ref: PageRef<'t>) -> Self {
-        IncludeRef::new(page_ref, HashMap::new())
-    }
-
-    #[inline]
-    pub fn page_ref(&self) -> &PageRef<'t> {
-        &self.page_ref
-    }
-
-    #[inline]
-    pub fn variables(&self) -> &IncludeVariables<'t> {
-        &self.variables
-    }
-}
-
-impl<'t> From<IncludeRef<'t>> for (PageRef<'t>, IncludeVariables<'t>) {
-    #[inline]
-    fn from(include: IncludeRef<'t>) -> (PageRef<'t>, IncludeVariables<'t>) {
-        let IncludeRef {
-            page_ref,
-            variables,
-        } = include;
-
-        (page_ref, variables)
-    }
-}
-
-// Tests
-
 #[test]
 fn page_ref() {
     macro_rules! test {
@@ -224,24 +171,4 @@ fn page_ref() {
         ":scp-wiki:deleted:secret:fragment:page",
         PageRef::page_and_site("scp-wiki", "deleted:secret:fragment:page"),
     );
-}
-
-#[test]
-fn to_owned() {
-    // Clone PageRef
-    let page_ref_1 = PageRef::page_only("scp-001");
-    let page_ref_2: PageRef<'static> = page_ref_1.to_owned();
-    assert_eq!(page_ref_1, page_ref_2);
-
-    // Clone IncludeRef
-    let include_ref_1 = IncludeRef::new(page_ref_1, HashMap::new());
-    let include_ref_2: IncludeRef<'static> = include_ref_1.to_owned();
-    assert_eq!(include_ref_1, include_ref_2);
-    assert_eq!(include_ref_1.page_ref(), &page_ref_2);
-    assert!(include_ref_1.variables.is_empty());
-
-    // Deconstruct IncludeRef
-    let (page_ref, variables) = include_ref_2.into();
-    assert_eq!(page_ref, page_ref_2);
-    assert!(variables.is_empty());
 }

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -172,3 +172,16 @@ fn page_ref() {
         PageRef::page_and_site("scp-wiki", "deleted:secret:fragment:page"),
     );
 }
+
+#[cfg(test)]
+mod prop {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn page_ref_prop(s in r"[a-zA-Z_:.]*") {
+            let _ = PageRef::parse(&s);
+        }
+    }
+}

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -41,20 +41,15 @@ pub struct PageRef<'t> {
 
 impl<'t> PageRef<'t> {
     #[inline]
-    pub fn new(site: Option<Cow<'t, str>>, page: Cow<'t, str>) -> Self {
-        PageRef { site, page }
-    }
-
-    #[inline]
     pub fn page_and_site<S1, S2>(site: S1, page: S2) -> Self
     where
         S1: Into<Cow<'t, str>>,
         S2: Into<Cow<'t, str>>,
     {
-        let site = site.into();
-        let page = page.into();
-
-        PageRef::new(Some(site), page)
+        PageRef {
+            site: Some(site.into()),
+            page: page.into(),
+        }
     }
 
     #[inline]
@@ -62,9 +57,10 @@ impl<'t> PageRef<'t> {
     where
         S: Into<Cow<'t, str>>,
     {
-        let page = page.into();
-
-        PageRef::new(None, page)
+        PageRef {
+            site: None,
+            page: page.into(),
+        }
     }
 
     #[inline]
@@ -138,7 +134,7 @@ impl Display for PageRef<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PageRefParseError;
 
 #[test]
@@ -154,11 +150,13 @@ fn page_ref() {
 
         ($input:expr => $expected:expr) => {{
             let actual = PageRef::parse($input);
+            let expected = $expected.ok_or(PageRefParseError);
+
             println!("Input: {:?}", $input);
             println!("Output: {:?}", actual);
             println!();
 
-            assert_eq!(actual, $expected, "Actual parse results don't match expected");
+            assert_eq!(actual, expected, "Actual parse results don't match expected");
         }};
     }
 

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -77,10 +77,10 @@ impl<'t> PageRef<'t> {
         self.page.as_ref()
     }
 
-    pub fn parse(s: &'t str) -> Option<PageRef<'t>> {
+    pub fn parse(s: &'t str) -> Result<PageRef<'t>, PageRefParseError> {
         let s = s.trim();
         if s.is_empty() {
-            return None;
+            return Err(PageRefParseError);
         }
 
         let result = match s.find(':') {
@@ -89,7 +89,7 @@ impl<'t> PageRef<'t> {
                 // Find the second colon
                 let idx = match s[1..].find(':') {
                     Some(idx) => idx + 1,
-                    None => return None,
+                    None => return Err(PageRefParseError),
                 };
 
                 // Get site and page slices
@@ -106,7 +106,7 @@ impl<'t> PageRef<'t> {
             None => PageRef::page_only(s),
         };
 
-        Some(result)
+        Ok(result)
     }
 
     pub fn to_owned(&self) -> PageRef<'static> {
@@ -132,6 +132,9 @@ impl Display for PageRef<'_> {
         write!(f, "{}", &self.page)
     }
 }
+
+#[derive(Debug)]
+pub struct PageRefParseError;
 
 #[test]
 fn page_ref() {

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -89,8 +89,12 @@ impl<'t> PageRef<'t> {
             Some(0) => {
                 // Find the second colon
                 let idx = match s[1..].find(':') {
+                    // Empty site name, e.g. "::something"
+                    // or no second colon, e.g. ":something"
+                    Some(0) | None => return Err(PageRefParseError),
+
+                    // Slice off the rest
                     Some(idx) => idx + 1,
-                    None => return Err(PageRefParseError),
                 };
 
                 // Get site and page slices
@@ -162,6 +166,7 @@ fn page_ref() {
 
     test!("");
     test!(":page");
+    test!("::page");
     test!("page", PageRef::page_only("page"));
     test!("component:page", PageRef::page_only("component:page"));
     test!(

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -98,8 +98,8 @@ impl<'t> PageRef<'t> {
                 };
 
                 // Get site and page slices
-                let site = &s[1..idx];
-                let page = &s[idx + 1..];
+                let site = s[1..idx].trim();
+                let page = s[idx + 1..].trim();
 
                 PageRef::page_and_site(site, page)
             }

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -22,7 +22,7 @@ use ref_map::*;
 use std::borrow::Cow;
 use std::fmt::{self, Display};
 
-/// Represents a reference to a page on the wiki, as used by includes.
+/// Represents a reference to a page on the wiki, as used by include notation.
 ///
 /// It tracks whether it refers to a page on this wiki, or some other,
 /// and what the names of these are.
@@ -35,8 +35,8 @@ use std::fmt::{self, Display};
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PageRef<'t> {
-    site: Option<Cow<'t, str>>,
-    page: Cow<'t, str>,
+    pub site: Option<Cow<'t, str>>,
+    pub page: Cow<'t, str>,
 }
 
 impl<'t> PageRef<'t> {

--- a/ftml/src/ffi/backlinks.rs
+++ b/ftml/src/ffi/backlinks.rs
@@ -42,7 +42,7 @@ impl From<Backlinks<'_>> for ftml_backlinks {
     fn from(backlinks: Backlinks) -> ftml_backlinks {
         macro_rules! convert_vec {
             ($list:expr, $convert:expr) => {{
-                let owned_vec = $list.into_iter().map(|obj| $convert(obj)).collect();
+                let owned_vec = $list.into_iter().map($convert).collect();
 
                 vec_to_cptr(owned_vec)
             }};

--- a/ftml/src/ffi/backlinks.rs
+++ b/ftml/src/ffi/backlinks.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::page_ref::ftml_page_ref;
 use super::prelude::*;
 use crate::data::Backlinks;
 
@@ -25,39 +26,36 @@ use crate::data::Backlinks;
 #[derive(Debug)]
 pub struct ftml_backlinks {
     // Included pages
-    included_pages_list: *mut *mut c_char,
-    included_pages_len: usize,
+    pub included_pages_list: *mut ftml_page_ref,
+    pub included_pages_len: usize,
 
     // Internal links
-    internal_links_list: *mut *mut c_char,
-    internal_links_len: usize,
+    pub internal_links_list: *mut ftml_page_ref,
+    pub internal_links_len: usize,
 
     // External links
-    external_links_list: *mut *mut c_char,
-    external_links_len: usize,
+    pub external_links_list: *mut *mut c_char,
+    pub external_links_len: usize,
 }
 
 impl From<Backlinks<'_>> for ftml_backlinks {
     fn from(backlinks: Backlinks) -> ftml_backlinks {
-        macro_rules! convert_cstr_vec {
-            ($list:expr) => {{
-                let owned_vec = $list
-                    .into_iter()
-                    .map(|cow| string_to_cstr(cow.into_owned()))
-                    .collect();
+        macro_rules! convert_vec {
+            ($list:expr, $convert:expr) => {{
+                let owned_vec = $list.into_iter().map(|obj| $convert(obj)).collect();
 
                 vec_to_cptr(owned_vec)
             }};
         }
 
         let (included_pages_list, included_pages_len) =
-            convert_cstr_vec!(backlinks.included_pages);
+            convert_vec!(backlinks.included_pages, ftml_page_ref::from);
 
         let (internal_links_list, internal_links_len) =
-            convert_cstr_vec!(backlinks.internal_links);
+            convert_vec!(backlinks.internal_links, ftml_page_ref::from);
 
         let (external_links_list, external_links_len) =
-            convert_cstr_vec!(backlinks.external_links);
+            convert_vec!(backlinks.external_links, cow_to_cstr);
 
         // Produce final struct
         ftml_backlinks {
@@ -73,13 +71,23 @@ impl From<Backlinks<'_>> for ftml_backlinks {
 
 impl ftml_backlinks {
     pub unsafe fn drop_c(&mut self) {
-        drop_cptr(self.included_pages_list, self.included_pages_len, |s| {
-            drop_cstr(s)
-        });
+        drop_cptr(
+            self.included_pages_list,
+            self.included_pages_len,
+            |page_ref| {
+                drop_cstr(page_ref.site);
+                drop_cstr(page_ref.page);
+            },
+        );
 
-        drop_cptr(self.internal_links_list, self.internal_links_len, |s| {
-            drop_cstr(s)
-        });
+        drop_cptr(
+            self.internal_links_list,
+            self.internal_links_len,
+            |page_ref| {
+                drop_cstr(page_ref.site);
+                drop_cstr(page_ref.page);
+            },
+        );
 
         drop_cptr(self.external_links_list, self.external_links_len, |s| {
             drop_cstr(s)

--- a/ftml/src/ffi/css.rs
+++ b/ftml/src/ffi/css.rs
@@ -20,13 +20,26 @@
 
 use super::prelude::*;
 
+#[inline]
+#[cfg(feature = "css")]
+fn css_const() -> &'static str {
+    crate::FTML_BASE_CSS
+}
+
+#[inline]
+#[cfg(not(feature = "css"))]
+fn css_const() -> &'static str {
+    ""
+}
+
 lazy_static! {
-    static ref FTML_BASE_CSS: CString = CString::new(crate::FTML_BASE_CSS).unwrap();
+    static ref FTML_BASE_CSS: CString = CString::new(css_const()).unwrap();
 }
 
 /// Outputs a copy of the ftml base CSS.
 ///
 /// This string data is immutable and should not be modified.
+/// This function only produces output if it was built with the "css" feature enabled.
 #[no_mangle]
 pub extern "C" fn ftml_base_css() -> *const c_char {
     FTML_BASE_CSS.as_ptr()

--- a/ftml/src/ffi/mod.rs
+++ b/ftml/src/ffi/mod.rs
@@ -37,10 +37,8 @@ mod prelude {
     pub use std::{mem, ptr};
 }
 
-#[cfg(feature = "css")]
-mod css;
-
 mod backlinks;
+mod css;
 mod exports;
 mod html;
 mod log;

--- a/ftml/src/ffi/mod.rs
+++ b/ftml/src/ffi/mod.rs
@@ -33,8 +33,8 @@ mod prelude {
     pub use super::string::*;
     pub use super::vec::*;
     pub use std::ffi::{CStr, CString};
-    pub use std::mem;
     pub use std::os::raw::c_char;
+    pub use std::{mem, ptr};
 }
 
 #[cfg(feature = "css")]
@@ -46,6 +46,7 @@ mod html;
 mod log;
 mod misc;
 mod page_info;
+mod page_ref;
 mod pool;
 mod string;
 mod text;

--- a/ftml/src/ffi/page_ref.rs
+++ b/ftml/src/ffi/page_ref.rs
@@ -1,5 +1,5 @@
 /*
- * render/backlinks.rs
+ * ffi/page_ref.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2021 Wikijump Team
@@ -18,20 +18,23 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::prelude::*;
 use crate::data::PageRef;
-use std::borrow::Cow;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq, Default)]
-#[serde(rename_all = "kebab-case")]
-pub struct Backlinks<'a> {
-    pub included_pages: Vec<PageRef<'a>>,
-    pub internal_links: Vec<PageRef<'a>>,
-    pub external_links: Vec<Cow<'a, str>>,
+#[repr(C)]
+#[derive(Debug)]
+pub struct ftml_page_ref {
+    pub site: *mut c_char,
+    pub page: *mut c_char,
 }
 
-impl<'a> Backlinks<'a> {
-    #[inline]
-    pub fn new() -> Self {
-        Backlinks::default()
+impl From<PageRef<'_>> for ftml_page_ref {
+    fn from(page_ref: PageRef) -> ftml_page_ref {
+        let PageRef { site, page } = page_ref;
+
+        ftml_page_ref {
+            site: cow_to_cstr_null(site),
+            page: cow_to_cstr(page),
+        }
     }
 }

--- a/ftml/src/ffi/string.rs
+++ b/ftml/src/ffi/string.rs
@@ -53,12 +53,32 @@ pub fn string_to_cstr(string: String) -> *mut c_char {
 }
 
 #[inline]
+pub fn string_to_cstr_null(string: Option<String>) -> *mut c_char {
+    match string {
+        Some(string) => string_to_cstr(string),
+        None => ptr::null_mut(),
+    }
+}
+
+#[inline]
+pub fn cow_to_cstr(cow: Cow<str>) -> *mut c_char {
+    string_to_cstr(cow.into_owned())
+}
+
+#[inline]
+pub fn cow_to_cstr_null(cow: Option<Cow<str>>) -> *mut c_char {
+    string_to_cstr_null(cow.map(|cow| cow.into_owned()))
+}
+
+#[inline]
 pub unsafe fn drop_cstr(ptr: *mut c_char) {
-    mem::drop(CString::from_raw(ptr));
+    if !ptr.is_null() {
+        mem::drop(CString::from_raw(ptr));
+    }
 }
 
 #[test]
-fn str() {
+fn ffi_string() {
     let cstr = string_to_cstr(str!("test"));
     unsafe { drop_cstr(cstr) };
 }

--- a/ftml/src/includes/include_ref.rs
+++ b/ftml/src/includes/include_ref.rs
@@ -1,0 +1,95 @@
+/*
+ * includes/include_ref.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::data::PageRef;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+pub type IncludeVariables<'t> = HashMap<Cow<'t, str>, Cow<'t, str>>;
+
+/// Represents an include block.
+///
+/// It contains the page being included, as well as the arguments
+/// to be passed to it when doing the substitution.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct IncludeRef<'t> {
+    page_ref: PageRef<'t>,
+    variables: IncludeVariables<'t>,
+}
+
+impl<'t> IncludeRef<'t> {
+    #[inline]
+    pub fn new(page_ref: PageRef<'t>, variables: IncludeVariables<'t>) -> Self {
+        IncludeRef {
+            page_ref,
+            variables,
+        }
+    }
+
+    #[inline]
+    pub fn page_only(page_ref: PageRef<'t>) -> Self {
+        IncludeRef::new(page_ref, HashMap::new())
+    }
+
+    #[inline]
+    pub fn page_ref(&self) -> &PageRef<'t> {
+        &self.page_ref
+    }
+
+    #[inline]
+    pub fn variables(&self) -> &IncludeVariables<'t> {
+        &self.variables
+    }
+}
+
+impl<'t> From<IncludeRef<'t>> for (PageRef<'t>, IncludeVariables<'t>) {
+    #[inline]
+    fn from(include: IncludeRef<'t>) -> (PageRef<'t>, IncludeVariables<'t>) {
+        let IncludeRef {
+            page_ref,
+            variables,
+        } = include;
+
+        (page_ref, variables)
+    }
+}
+
+// Tests
+
+#[test]
+fn to_owned() {
+    // Clone PageRef
+    let page_ref_1 = PageRef::page_only("scp-001");
+    let page_ref_2: PageRef<'static> = page_ref_1.to_owned();
+    assert_eq!(page_ref_1, page_ref_2);
+
+    // Clone IncludeRef
+    let include_ref_1 = IncludeRef::new(page_ref_1, HashMap::new());
+    let include_ref_2: IncludeRef<'static> = include_ref_1.to_owned();
+    assert_eq!(include_ref_1, include_ref_2);
+    assert_eq!(include_ref_1.page_ref(), &page_ref_2);
+    assert!(include_ref_1.variables.is_empty());
+
+    // Deconstruct IncludeRef
+    let (page_ref, variables) = include_ref_2.into();
+    assert_eq!(page_ref, page_ref_2);
+    assert!(variables.is_empty());
+}

--- a/ftml/src/includes/includer/mod.rs
+++ b/ftml/src/includes/includer/mod.rs
@@ -22,7 +22,8 @@ mod debug;
 mod null;
 
 mod prelude {
-    pub use crate::includes::{FetchedPage, IncludeRef, Includer, PageRef};
+    pub use crate::data::PageRef;
+    pub use crate::includes::{FetchedPage, IncludeRef, Includer};
     pub use std::borrow::Cow;
     pub use std::collections::HashMap;
 }

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -21,14 +21,15 @@
 #[cfg(test)]
 mod test;
 
+mod include_ref;
 mod includer;
-mod object;
 mod parse;
 
+pub use self::include_ref::{IncludeRef, IncludeVariables};
 pub use self::includer::{DebugIncluder, FetchedPage, Includer, NullIncluder};
-pub use self::object::{IncludeRef, IncludeVariables, PageRef};
 
 use self::parse::parse_include_block;
+use crate::data::PageRef;
 use crate::log::prelude::*;
 use regex::{Regex, RegexBuilder};
 

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -81,11 +81,11 @@ where
         );
 
         match parse_include_block(log, &input[start..], start) {
-            None => debug!(log, "Unable to parse include regex match"),
-            Some((include, end)) => {
+            Ok((include, end)) => {
                 ranges.push(start..end);
                 includes.push(include);
             }
+            Err(_) => debug!(log, "Unable to parse include regex match"),
         }
     }
 

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -18,7 +18,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::{IncludeRef, PageRef};
+use super::IncludeRef;
+use crate::data::PageRef;
 use crate::log::prelude::*;
 use pest::iterators::Pairs;
 use pest::Parser;

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -19,7 +19,7 @@
  */
 
 use super::IncludeRef;
-use crate::data::PageRef;
+use crate::data::{PageRef, PageRefParseError};
 use crate::log::prelude::*;
 use pest::iterators::Pairs;
 use pest::Parser;
@@ -34,7 +34,7 @@ pub fn parse_include_block<'t>(
     log: &Logger,
     text: &'t str,
     start: usize,
-) -> Option<(IncludeRef<'t>, usize)> {
+) -> Result<(IncludeRef<'t>, usize), IncludeParseError> {
     match IncludeParser::parse(Rule::include, text) {
         Ok(mut pairs) => {
             // Extract inner pairs
@@ -50,13 +50,10 @@ pub fn parse_include_block<'t>(
             );
 
             // Convert into an IncludeRef
-            let include = match process_pairs(log, first.into_inner()) {
-                Some(include) => include,
-                None => return None,
-            };
+            let include = process_pairs(log, first.into_inner())?;
 
             // Adjust offset and return
-            Some((include, start + span.end()))
+            Ok((include, start + span.end()))
         }
         Err(error) => {
             debug!(
@@ -67,21 +64,17 @@ pub fn parse_include_block<'t>(
                 "slice" => text,
             );
 
-            None
+            Err(IncludeParseError)
         }
     }
 }
 
-fn process_pairs<'t>(log: &Logger, mut pairs: Pairs<'t, Rule>) -> Option<IncludeRef<'t>> {
-    let page_raw = match pairs.next() {
-        Some(pair) => pair.as_str(),
-        None => return None,
-    };
-
-    let page_ref = match PageRef::parse(page_raw) {
-        Some(page_ref) => page_ref,
-        None => return None,
-    };
+fn process_pairs<'t>(
+    log: &Logger,
+    mut pairs: Pairs<'t, Rule>,
+) -> Result<IncludeRef<'t>, IncludeParseError> {
+    let page_raw = pairs.next().ok_or(IncludeParseError)?.as_str();
+    let page_ref = PageRef::parse(page_raw)?;
 
     trace!(
         log,
@@ -120,5 +113,15 @@ fn process_pairs<'t>(log: &Logger, mut pairs: Pairs<'t, Rule>) -> Option<Include
         arguments.insert(Cow::Borrowed(key), Cow::Borrowed(value));
     }
 
-    Some(IncludeRef::new(page_ref, arguments))
+    Ok(IncludeRef::new(page_ref, arguments))
+}
+
+#[derive(Debug)]
+pub struct IncludeParseError;
+
+impl From<PageRefParseError> for IncludeParseError {
+    #[inline]
+    fn from(_: PageRefParseError) -> Self {
+        IncludeParseError
+    }
 }

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -116,7 +116,7 @@ fn process_pairs<'t>(
     Ok(IncludeRef::new(page_ref, arguments))
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct IncludeParseError;
 
 impl From<PageRefParseError> for IncludeParseError {

--- a/ftml/src/macros.rs
+++ b/ftml/src/macros.rs
@@ -47,3 +47,12 @@ macro_rules! str_write {
         write!($dest, $($arg)*).expect("Writing to string failed");
     }};
 }
+
+/// Borrow from a Cow<T> to create a copy that can be passed.
+macro_rules! cow_borrow {
+    ($cow:expr) => {{
+        use std::borrow::Cow;
+
+        Cow::Borrowed($cow.as_ref())
+    }};
+}

--- a/ftml/src/macros.rs
+++ b/ftml/src/macros.rs
@@ -47,12 +47,3 @@ macro_rules! str_write {
         write!($dest, $($arg)*).expect("Writing to string failed");
     }};
 }
-
-/// Borrow from a Cow<T> to create a copy that can be passed.
-macro_rules! cow_borrow {
-    ($cow:expr) => {{
-        use std::borrow::Cow;
-
-        Cow::Borrowed($cow.as_ref())
-    }};
-}

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -182,7 +182,7 @@ fn build_toc_list_element(
         DepthItem::Item(name) => {
             let anchor = format!("#toc{}", incr.next());
             let link = Element::Link {
-                url: LinkLocation::Url(Cow::Owned(anchor)),
+                link: LinkLocation::Url(Cow::Owned(anchor)),
                 label: LinkLabel::Text(Cow::Owned(name)),
                 target: None,
             };

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -56,7 +56,9 @@ use self::strip::strip_newlines;
 use crate::log::prelude::*;
 use crate::next_index::{NextIndex, TableOfContentsIndex};
 use crate::tokenizer::Tokenization;
-use crate::tree::{AttributeMap, Element, LinkLabel, ListItem, ListType, SyntaxTree};
+use crate::tree::{
+    AttributeMap, Element, LinkLabel, LinkLocation, ListItem, ListType, SyntaxTree,
+};
 use std::borrow::Cow;
 
 pub use self::boolean::{parse_boolean, NonBooleanValue};
@@ -180,7 +182,7 @@ fn build_toc_list_element(
         DepthItem::Item(name) => {
             let anchor = format!("#toc{}", incr.next());
             let link = Element::Link {
-                url: Cow::Owned(anchor),
+                url: LinkLocation::Url(Cow::Owned(anchor)),
                 label: LinkLabel::Text(Cow::Owned(name)),
                 target: None,
             };

--- a/ftml/src/parsing/rule/impls/block/blocks/image.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/image.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::tree::{FloatAlignment, ImageSource};
+use crate::tree::{FloatAlignment, ImageSource, LinkLocation};
 
 pub const BLOCK_IMAGE: BlockRule = BlockRule {
     name: "block-image",
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_IMAGE, name);
 
     let (source, mut arguments) = parser.get_head_name_map(&BLOCK_IMAGE, in_head)?;
-    let link = arguments.get("link");
+    let link = arguments.get("link").map(LinkLocation::parse);
     let alignment = FloatAlignment::parse(name);
 
     // Parse the image source based on format

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -91,7 +91,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url: LinkLocation::Url(url),
+        link: LinkLocation::Url(url),
         label: LinkLabel::Text(cow!(label)),
         target: None,
     };

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -24,7 +24,7 @@
 //! or is a fake link.
 
 use super::prelude::*;
-use crate::tree::LinkLabel;
+use crate::tree::{LinkLabel, LinkLocation};
 use std::borrow::Cow;
 use wikidot_normalize::normalize;
 
@@ -91,7 +91,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url,
+        url: LinkLocation::Url(url),
         label: LinkLabel::Text(cow!(label)),
         target: None,
     };

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -25,7 +25,7 @@
 //! Its syntax is `[https://example.com/ Label text]`.
 
 use super::prelude::*;
-use crate::tree::{AnchorTarget, LinkLabel};
+use crate::tree::{AnchorTarget, LinkLabel, LinkLocation};
 use crate::url::is_url;
 
 pub const RULE_LINK_SINGLE: Rule = Rule {
@@ -126,7 +126,7 @@ fn try_consume_link<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url: cow!(url),
+        url: LinkLocation::Url(cow!(url)),
         label: LinkLabel::Text(cow!(label)),
         target,
     };

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -126,7 +126,7 @@ fn try_consume_link<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url: LinkLocation::Url(cow!(url)),
+        link: LinkLocation::Url(cow!(url)),
         label: LinkLabel::Text(cow!(label)),
         target,
     };

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -29,6 +29,7 @@
 //! Its syntax is `[[[page-name | Label text]`.
 
 use super::prelude::*;
+use crate::data::PageRef;
 use crate::tree::{AnchorTarget, LinkLabel};
 use std::borrow::Cow;
 

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -275,7 +275,10 @@ fn test_strip_category() {
     check!(":scp-wiki:scp-001", Some("scp-001"));
     check!(":scp-wiki : SCP-001", Some("SCP-001"));
     check!(":scp-wiki:system:recent-changes", Some("recent-changes"));
-    check!(":scp-wiki : system : Recent Changes", Some("Recent Changes"));
+    check!(
+        ":scp-wiki : system : Recent Changes",
+        Some("Recent Changes"),
+    );
     check!(": snippets : redirect", Some("redirect"));
     check!(":", None);
 }

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -29,8 +29,7 @@
 //! Its syntax is `[[[page-name | Label text]`.
 
 use super::prelude::*;
-use crate::data::PageRef;
-use crate::tree::{AnchorTarget, LinkLabel};
+use crate::tree::{AnchorTarget, LinkLabel, LinkLocation};
 use std::borrow::Cow;
 
 pub const RULE_LINK_TRIPLE: Rule = Rule {
@@ -145,7 +144,7 @@ fn build_same<'p, 'r, 't>(
 
     // Build and return element
     let element = Element::Link {
-        url: cow!(url),
+        url: LinkLocation::parse(cow!(url)),
         label: LinkLabel::Url(label),
         target,
     };
@@ -200,7 +199,7 @@ fn build_separate<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url: cow!(url),
+        url: LinkLocation::parse(cow!(url)),
         label,
         target,
     };
@@ -223,7 +222,7 @@ fn strip_category(url: &str) -> Option<&str> {
         Some(0) => strip_category(&url[1..]),
 
         // Link with category but no site, e.g. theme:sigma-9.
-        Some(idx) => url[idx + 1..].trim_start(),
+        Some(idx) => Some(url[idx + 1..].trim_start()),
 
         // No stripping necessary
         None => None,

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -144,7 +144,7 @@ fn build_same<'p, 'r, 't>(
 
     // Build and return element
     let element = Element::Link {
-        url: LinkLocation::parse(cow!(url)),
+        link: LinkLocation::parse(cow!(url)),
         label: LinkLabel::Url(label),
         target,
     };
@@ -199,7 +199,7 @@ fn build_separate<'p, 'r, 't>(
 
     // Build link element
     let element = Element::Link {
-        url: LinkLocation::parse(cow!(url)),
+        link: LinkLocation::parse(cow!(url)),
         label,
         target,
     };

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::tree::LinkLabel;
+use crate::tree::{LinkLabel, LinkLocation};
 
 pub const RULE_URL: Rule = Rule {
     name: "url",
@@ -32,8 +32,11 @@ fn try_consume_fn<'p, 'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     debug!(log, "Consuming token as a URL");
 
+    let token = parser.current();
+    let url = cow!(token.slice);
+
     let element = Element::Link {
-        url: cow!(parser.current().slice),
+        url: LinkLocation::Url(url),
         label: LinkLabel::Url(None),
         target: None,
     };

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -36,7 +36,7 @@ fn try_consume_fn<'p, 'r, 't>(
     let url = cow!(token.slice);
 
     let element = Element::Link {
-        url: LinkLocation::Url(url),
+        link: LinkLocation::Url(url),
         label: LinkLabel::Url(None),
         target: None,
     };

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -20,6 +20,7 @@
 
 use crate::log::prelude::*;
 use crate::tree::{ImageSource, LinkLabel, Module};
+use crate::url::BuildSiteUrl;
 use crate::{PageInfo, UserInfo};
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
@@ -29,18 +30,6 @@ use strum_macros::IntoStaticStr;
 pub struct Handle;
 
 impl Handle {
-    pub fn get_url(&self, log: &Logger, site_slug: &str) -> String {
-        // TODO make this a parser setting
-        debug!(
-            log,
-            "Getting URL of this Wikijump instance";
-            "site" => site_slug,
-        );
-
-        // TODO
-        format!("https://{}.wikijump.com/", site_slug)
-    }
-
     pub fn render_module(
         &self,
         log: &Logger,
@@ -168,6 +157,16 @@ impl Handle {
         );
 
         // TODO
+    }
+}
+
+impl BuildSiteUrl for Handle {
+    fn build_url(&self, site: &str, path: &str) -> String {
+        // TODO make this a parser setting
+        // get url of wikijump instance here
+
+        // TODO
+        format!("https://{}.wikijump.com/{}", site, path)
     }
 }
 

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -19,12 +19,13 @@
  */
 
 use crate::log::prelude::*;
-use crate::tree::{ImageSource, LinkLabel, Module};
+use crate::tree::{ImageSource, LinkLabel, Module, LinkLocation};
 use crate::url::BuildSiteUrl;
 use crate::{PageInfo, UserInfo};
 use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use strum_macros::IntoStaticStr;
+use wikidot_normalize::normalize;
 
 #[derive(Debug)]
 pub struct Handle;
@@ -54,11 +55,11 @@ impl Handle {
         }
     }
 
-    pub fn get_page_title(&self, log: &Logger, page_slug: &str) -> String {
-        debug!(log, "Fetching page title"; "page" => page_slug);
+    pub fn get_page_title(&self, log: &Logger, link: &LinkLocation) -> String {
+        debug!(log, "Fetching page title"; "link" => link);
 
         // TODO
-        format!("TODO: actual title ({})", page_slug)
+        format!("TODO: actual title ({:?})", link)
     }
 
     pub fn get_user_info<'a>(&self, log: &Logger, name: &'a str) -> Option<UserInfo<'a>> {
@@ -93,7 +94,7 @@ impl Handle {
         ))
     }
 
-    pub fn get_link_label<F>(&self, log: &Logger, url: &str, label: &LinkLabel, f: F)
+    pub fn get_link_label<F>(&self, log: &Logger, link: &LinkLocation, label: &LinkLabel, f: F)
     where
         F: FnOnce(&str),
     {
@@ -101,9 +102,12 @@ impl Handle {
         let label_text = match *label {
             LinkLabel::Text(ref text) => text,
             LinkLabel::Url(Some(ref text)) => text,
-            LinkLabel::Url(None) => url,
+            LinkLabel::Url(None) => match link {
+                LinkLocation::Url(url) => url,
+                LinkLocation::Page(page_ref) => page_ref.page(),
+            }
             LinkLabel::Page => {
-                page_title = self.get_page_title(log, url);
+                page_title = self.get_page_title(log, link);
                 &page_title
             }
         };
@@ -164,6 +168,12 @@ impl BuildSiteUrl for Handle {
     fn build_url(&self, site: &str, path: &str) -> String {
         // TODO make this a parser setting
         // get url of wikijump instance here
+
+        let path = {
+            let mut path = str!(path);
+            normalize(&mut path);
+            path
+        };
 
         // TODO
         format!("https://{}.wikijump.com/{}", site, path)

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -19,7 +19,7 @@
  */
 
 use crate::log::prelude::*;
-use crate::tree::{ImageSource, LinkLabel, Module, LinkLocation};
+use crate::tree::{ImageSource, LinkLabel, LinkLocation, Module};
 use crate::url::BuildSiteUrl;
 use crate::{PageInfo, UserInfo};
 use std::borrow::Cow;
@@ -94,8 +94,13 @@ impl Handle {
         ))
     }
 
-    pub fn get_link_label<F>(&self, log: &Logger, link: &LinkLocation, label: &LinkLabel, f: F)
-    where
+    pub fn get_link_label<F>(
+        &self,
+        log: &Logger,
+        link: &LinkLocation,
+        label: &LinkLabel,
+        f: F,
+    ) where
         F: FnOnce(&str),
     {
         let page_title;
@@ -105,7 +110,7 @@ impl Handle {
             LinkLabel::Url(None) => match link {
                 LinkLocation::Url(url) => url,
                 LinkLocation::Page(page_ref) => page_ref.page(),
-            }
+            },
             LinkLabel::Page => {
                 page_title = self.get_page_title(log, link);
                 &page_title

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -30,6 +30,7 @@ pub struct Handle;
 
 impl Handle {
     pub fn get_url(&self, log: &Logger, site_slug: &str) -> String {
+        // TODO make this a parser setting
         debug!(
             log,
             "Getting URL of this Wikijump instance";

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -28,6 +28,7 @@ use crate::render::Handle;
 use crate::tree::{Element, LinkLocation};
 use crate::url::is_url;
 use crate::{info, Backlinks, PageInfo};
+use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
 
@@ -174,9 +175,8 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
                     let page_ref = PageRef::page_only(cow!(link));
                     self.backlinks.included_pages.push(page_ref.to_owned());
                 } else {
-                    let link = cow!(link).to_owned();
-                    let link_location = LinkLocation::Url(link).to_owned();
-                    self.backlinks.internal_links.push(link_location);
+                    let link = Cow::Owned(str!(link));
+                    self.backlinks.external_links.push(link);
                 }
             }
         }

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -159,7 +159,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
                 self.backlinks.included_pages.push(page.to_owned());
             }
             LinkLocation::Url(link) => {
-                let mut link: &str = &link;
+                let mut link: &str = link;
 
                 if link == "javascript:;" {
                     return;

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -173,7 +173,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
 
                 if is_url(link) {
                     let page_ref = PageRef::page_only(cow!(link));
-                    self.backlinks.included_pages.push(page_ref.to_owned());
+                    self.backlinks.internal_links.push(page_ref.to_owned());
                 } else {
                     let link = Cow::Owned(str!(link));
                     self.backlinks.external_links.push(link);

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -22,12 +22,12 @@ use super::builder::HtmlBuilder;
 use super::escape::escape;
 use super::meta::{HtmlMeta, HtmlMetaType};
 use super::output::HtmlOutput;
+use crate::data::PageRef;
 use crate::next_index::{NextIndex, TableOfContentsIndex};
 use crate::render::Handle;
-use crate::tree::Element;
+use crate::tree::{Element, LinkLocation};
 use crate::url::is_url;
 use crate::{info, Backlinks, PageInfo};
-use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
 
@@ -149,33 +149,44 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
 
     // Backlinks
     #[inline]
-    pub fn add_link(&mut self, mut link: &str) {
+    pub fn add_link(&mut self, link: &LinkLocation) {
         // TODO: set to internal link if domain matches site
         // See https://scuttle.atlassian.net/browse/WJ-24
 
-        // Also support [ links pointing to local pages.
-        // e.g. [/scp-001 SCP-001] in addition to [[[SCP-001]]].
-        if link.starts_with('/') {
-            link = &link[1..];
-        }
+        match link {
+            LinkLocation::Page(page) => {
+                self.backlinks.included_pages.push(page.to_owned());
+            }
+            LinkLocation::Url(link) => {
+                let mut link: &str = &link;
 
-        // Add to appropriate list
-        let link_owned = Cow::Owned(str!(link));
+                if link == "javascript:;" {
+                    return;
+                }
 
-        if is_url(link) {
-            self.backlinks.external_links.push(link_owned);
-        } else if link != "javascript:;" {
-            self.backlinks.internal_links.push(link_owned);
+                // Also support [ links pointing to local pages.
+                // e.g. [/scp-001 SCP-001] in addition to [[[SCP-001]]].
+                if link.starts_with('/') {
+                    link = &link[1..];
+                }
+
+                if is_url(link) {
+                    let page_ref = PageRef::page_only(cow!(link));
+                    self.backlinks.included_pages.push(page_ref.to_owned());
+                } else {
+                    let link = cow!(link).to_owned();
+                    let link_location = LinkLocation::Url(link).to_owned();
+                    self.backlinks.internal_links.push(link_location);
+                }
+            }
         }
     }
 
     // TODO
     #[allow(dead_code)]
     #[inline]
-    pub fn add_include(&mut self, page: &str) {
-        let page_owned = Cow::Owned(str!(page));
-
-        self.backlinks.included_pages.push(page_owned);
+    pub fn add_include(&mut self, page: PageRef) {
+        self.backlinks.included_pages.push(page.to_owned());
     }
 
     // Buffer management

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -19,14 +19,14 @@
  */
 
 use super::prelude::*;
-use crate::tree::{AttributeMap, FloatAlignment, ImageSource};
-use crate::url::normalize_url;
+use crate::tree::{AttributeMap, FloatAlignment, ImageSource, LinkLocation};
+use crate::url::normalize_link;
 
 pub fn render_image(
     log: &Logger,
     ctx: &mut HtmlContext,
     source: &ImageSource,
-    link: Option<&str>,
+    link: &Option<LinkLocation>,
     alignment: Option<FloatAlignment>,
     attributes: &AttributeMap,
 ) {
@@ -34,7 +34,7 @@ pub fn render_image(
         log,
         "Rendering image element";
         "source" => source.name(),
-        "link" => link.unwrap_or("<none>"),
+        "link" => link.unwrap_or(LinkLocation::Url(cow!("<none>"))),
         "alignment" => match alignment {
             Some(image) => image.align.name(),
             None => "<default>",
@@ -65,8 +65,8 @@ pub fn render_image(
             };
 
             match link {
-                Some(url) => {
-                    let url = normalize_url(url);
+                Some(link) => {
+                    let url = normalize_link(link, ctx.handle());
                     ctx.html().a().attr("href", &[&url]).contents(build_image);
                 }
                 None => build_image(ctx),

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -34,7 +34,10 @@ pub fn render_image(
         log,
         "Rendering image element";
         "source" => source.name(),
-        "link" => link.unwrap_or(LinkLocation::Url(cow!("<none>"))),
+        "link" => match link {
+            Some(link) => format!("{:?}", link),
+            None => str!("<none>"),
+        },
         "alignment" => match alignment {
             Some(image) => image.align.name(),
             None => "<default>",

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -69,7 +69,7 @@ pub fn render_image(
 
             match link {
                 Some(link) => {
-                    let url = normalize_link(link, false, ctx.info(), ctx.handle());
+                    let url = normalize_link(link, ctx.handle());
                     ctx.html().a().attr("href", &[&url]).contents(build_image);
                 }
                 None => build_image(ctx),

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -69,7 +69,7 @@ pub fn render_image(
 
             match link {
                 Some(link) => {
-                    let url = normalize_link(link, ctx.handle());
+                    let url = normalize_link(link, false, ctx.info(), ctx.handle());
                     ctx.html().a().attr("href", &[&url]).contents(build_image);
                 }
                 None => build_image(ctx),

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -67,7 +67,7 @@ pub fn render_link(
     // Add to backlinks
     ctx.add_link(link);
 
-    let url = normalize_link(link, false, ctx.info(), ctx.handle());
+    let url = normalize_link(link, ctx.handle());
 
     // Create <a> and set attributes
     let mut tag = ctx.html().a();
@@ -78,7 +78,7 @@ pub fn render_link(
     }
 
     // Add <a> internals, i.e. the link name
-    handle.get_link_label(log, &url, label, |label| {
+    handle.get_link_label(log, link, label, |label| {
         tag.inner(log, &label);
     });
 }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -67,7 +67,7 @@ pub fn render_link(
     // Add to backlinks
     ctx.add_link(link);
 
-    let url = normalize_link(link, handle);
+    let url = normalize_link(link, false, ctx.info(), ctx.handle());
 
     // Create <a> and set attributes
     let mut tag = ctx.html().a();

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -19,8 +19,8 @@
  */
 
 use super::prelude::*;
-use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel};
-use crate::url::normalize_url;
+use crate::tree::{AnchorTarget, AttributeMap, Element, LinkLabel, LinkLocation};
+use crate::url::normalize_link;
 
 pub fn render_anchor(
     log: &Logger,
@@ -51,32 +51,34 @@ pub fn render_anchor(
 pub fn render_link(
     log: &Logger,
     ctx: &mut HtmlContext,
-    url: &str,
+    link: &LinkLocation,
     label: &LinkLabel,
     target: Option<AnchorTarget>,
 ) {
     debug!(
         log,
         "Rendering link";
-        "url" => url,
+        "link" => link,
         "target" => target_str(target),
     );
 
     let handle = ctx.handle();
 
     // Add to backlinks
-    ctx.add_link(url);
+    ctx.add_link(link);
+
+    let url = normalize_link(link, handle);
 
     // Create <a> and set attributes
     let mut tag = ctx.html().a();
-    tag.attr("href", &[&normalize_url(url)]);
+    tag.attr("href", &[&url]);
 
     if let Some(target) = target {
         tag.attr("target", &[target.html_attr()]);
     }
 
     // Add <a> internals, i.e. the link name
-    handle.get_link_label(log, url, label, |label| {
+    handle.get_link_label(log, &url, label, |label| {
         tag.inner(log, &label);
     });
 }

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -86,9 +86,11 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
             attributes,
             target,
         } => render_anchor(log, ctx, elements, attributes, *target),
-        Element::Link { link, label, target } => {
-            render_link(log, ctx, link, label, *target)
-        }
+        Element::Link {
+            link,
+            label,
+            target,
+        } => render_link(log, ctx, link, label, *target),
         Element::Image {
             source,
             link,

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -53,7 +53,7 @@ use super::HtmlContext;
 use crate::log::prelude::*;
 use crate::render::ModuleRenderMode;
 use crate::tree::Element;
-use ref_map::OptionRefMap;
+use ref_map::*;
 
 pub fn render_elements(log: &Logger, ctx: &mut HtmlContext, elements: &[Element]) {
     debug!(log, "Rendering elements"; "elements-len" => elements.len());

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -86,8 +86,8 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
             attributes,
             target,
         } => render_anchor(log, ctx, elements, attributes, *target),
-        Element::Link { url, label, target } => {
-            render_link(log, ctx, url, label, *target)
+        Element::Link { link, label, target } => {
+            render_link(log, ctx, link, label, *target)
         }
         Element::Image {
             source,

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -94,7 +94,7 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
             link,
             alignment,
             attributes,
-        } => render_image(log, ctx, source, ref_cow!(link), *alignment, attributes),
+        } => render_image(log, ctx, source, link, *alignment, attributes),
         Element::List {
             ltype,
             items,

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -109,21 +109,17 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
             if let Some(href) = attributes.get().get("href") {
                 let link = LinkLocation::parse(cow!(href));
                 let url = get_url_from_link(ctx, &link);
-                println!("href {:?}, link {:?}, url {:?}", href, link, url);
 
-                if href != &url {
-                    str_write!(ctx, " [{}]", url);
-                }
+                str_write!(ctx, " [{}]", url);
             }
         }
-        Element::Link { url, label, .. } => {
-            let url = get_url_from_link(ctx, &url);
+        Element::Link { link, label, .. } => {
+            let url = get_url_from_link(ctx, link);
 
-            ctx.handle().get_link_label(log, &url, label, |label| {
+            ctx.handle().get_link_label(log, link, label, |label| {
                 ctx.push_str(label);
 
                 // Don't show URL if it's a name link, or an anchor
-                println!("url {:?}, label {:?}", url, label);
                 if url != label && !url.starts_with('#') {
                     str_write!(ctx, " [{}]", url);
                 }
@@ -304,7 +300,7 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
 }
 
 fn get_url_from_link<'a>(ctx: &TextContext, link: &'a LinkLocation<'a>) -> Cow<'a, str> {
-    let url = normalize_link(link, true, ctx.info(), ctx.handle());
+    let url = normalize_link(link, ctx.handle());
 
     // TODO: when we remove inline javascript stuff
     if url.as_ref() == "javascript:;" {

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -24,8 +24,8 @@ use super::super::condition::{check_ifcategory, check_iftags};
 use super::TextContext;
 use crate::log::prelude::*;
 use crate::render::ModuleRenderMode;
-use crate::tree::{ContainerType, Element, ListItem, ListType};
-use crate::url::{is_url, normalize_url};
+use crate::tree::{ContainerType, Element, LinkLocation, ListItem, ListType};
+use crate::url::{normalize_href, normalize_link};
 use std::borrow::Cow;
 
 pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]) {
@@ -106,18 +106,18 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
         } => {
             render_elements(log, ctx, elements);
 
-            if let Some(href) = attributes.get().get("href") {
-                let url = get_full_url(log, ctx, href);
-                if &url != href {
-                    str_write!(ctx, " [{}]", url);
+            if let Some(original_href) = attributes.get().get("href") {
+                let href = normalize_href(original_href);
+                if &href != original_href {
+                    str_write!(ctx, " [{}]", href);
                 }
             }
         }
         Element::Link { url, label, .. } => {
-            ctx.handle().get_link_label(log, url, label, |label| {
-                ctx.push_str(label);
+            let url = get_url_from_link(ctx, url);
 
-                let url = get_full_url(log, ctx, url);
+            ctx.handle().get_link_label(log, &url, label, |label| {
+                ctx.push_str(label);
 
                 // Don't show URL if it's a name link, or an anchor
                 if url != label && !url.starts_with('#') {
@@ -140,8 +140,8 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
                 str_write!(ctx, " [Align: {}{}]", image.align.name(), float);
             }
 
-            if let Some(url) = link {
-                str_write!(ctx, " [Link: {}]", get_full_url(log, ctx, url));
+            if let Some(link) = link {
+                str_write!(ctx, " [Link: {}]", get_url_from_link(ctx, link));
             }
 
             if let Some(alt_text) = attributes.get().get("alt") {
@@ -299,36 +299,13 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
     }
 }
 
-fn get_full_url<'a>(log: &Logger, ctx: &TextContext, url: &'a str) -> Cow<'a, str> {
-    debug!(log, "Building full URL"; "url" => url);
+fn get_url_from_link<'a>(ctx: &TextContext, link: &'a LinkLocation<'a>) -> Cow<'a, str> {
+    let url = normalize_link(link, ctx.handle());
 
     // TODO: when we remove inline javascript stuff
-    if url == "javascript:;" {
+    if url.as_ref() == "javascript:;" {
         return Cow::Borrowed("#");
     }
 
-    // Anchor links should just be returned as-is
-    if url.starts_with('#') {
-        return Cow::Borrowed(url);
-    }
-
-    // If it's a URL with a scheme, just return this
-    if is_url(url) {
-        return Cow::Borrowed(url);
-    }
-
-    // Let's build a full URL.
-    // First, normalize:
-    let url = normalize_url(url);
-
-    let site = &ctx.info().site;
-    let mut full_url = ctx.handle().get_url(log, site);
-
-    // Ensure there is exactly one slash
-    if full_url.ends_with('/') {
-        full_url.pop();
-    }
-
-    full_url.push_str(&url);
-    Cow::Owned(full_url)
+    url
 }

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -208,7 +208,7 @@ impl Test<'_> {
 
         if tree != self.tree {
             panic!(
-                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nWarnings: {:#?}",
+                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual:   {:#?}\n{}\nWarnings: {:#?}",
                 self.name,
                 self.tree,
                 tree,
@@ -219,7 +219,7 @@ impl Test<'_> {
 
         if warnings != self.warnings {
             panic!(
-                "Running test '{}' failed! Warnings did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nTree (correct): {:#?}",
+                "Running test '{}' failed! Warnings did not match:\nExpected: {:#?}\nActual:   {:#?}\n{}\nTree (correct): {:#?}",
                 self.name,
                 self.warnings,
                 warnings,
@@ -230,7 +230,7 @@ impl Test<'_> {
 
         if html_output.body != self.html {
             panic!(
-                "Running test '{}' failed! HTML does not match:\nExpected: {:?}\nActual: {:?}\n\n{}\n\nTree (correct): {:#?}",
+                "Running test '{}' failed! HTML does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
                 self.name,
                 self.html,
                 html_output.body,
@@ -241,7 +241,7 @@ impl Test<'_> {
 
         if text_output != self.text {
             panic!(
-                "Running test '{}' failed! Text output does not match:\nExpected: {:?}\nActual: {:?}\n\n{}\n\nTree (correct): {:#?}",
+                "Running test '{}' failed! Text output does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
                 self.name,
                 self.text,
                 text_output,

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -208,7 +208,7 @@ impl Test<'_> {
 
         if tree != self.tree {
             panic!(
-                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual:   {:#?}\n{}\nWarnings: {:#?}",
+                "Running test '{}' failed! AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nWarnings: {:#?}",
                 self.name,
                 self.tree,
                 tree,

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -138,8 +138,13 @@ fn arb_link_element() -> impl Strategy<Value = Element<'static>> {
         Just(LinkLabel::Page),
     ];
 
-    (arb_link_location(), label, arb_target())
-        .prop_map(|(link, label, target)| Element::Link { link, label, target })
+    (arb_link_location(), label, arb_target()).prop_map(|(link, label, target)| {
+        Element::Link {
+            link,
+            label,
+            target,
+        }
+    })
 }
 
 fn arb_image() -> impl Strategy<Value = Element<'static>> {

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -139,7 +139,7 @@ fn arb_link_element() -> impl Strategy<Value = Element<'static>> {
     ];
 
     (arb_link_location(), label, arb_target())
-        .prop_map(|(url, label, target)| Element::Link { url, label, target })
+        .prop_map(|(link, label, target)| Element::Link { link, label, target })
 }
 
 fn arb_image() -> impl Strategy<Value = Element<'static>> {

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -18,13 +18,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::data::PageInfo;
+use crate::data::{PageInfo, PageRef};
 use crate::render::{html::HtmlRender, text::TextRender, Render};
 use crate::tree::attribute::SAFE_ATTRIBUTES;
 use crate::tree::{
     Alignment, AnchorTarget, AttributeMap, Container, ContainerType, Element,
-    FloatAlignment, Heading, HeadingLevel, ImageSource, LinkLabel, ListItem, ListType,
-    Module, SyntaxTree,
+    FloatAlignment, Heading, HeadingLevel, ImageSource, LinkLabel, LinkLocation,
+    ListItem, ListType, Module, SyntaxTree,
 };
 use proptest::option;
 use proptest::prelude::*;
@@ -117,18 +117,29 @@ fn arb_target() -> impl Strategy<Value = Option<AnchorTarget>> {
     ]))
 }
 
-fn arb_link() -> impl Strategy<Value = Element<'static>> {
+fn arb_page_ref() -> impl Strategy<Value = PageRef<'static>> {
+    let site = option::of(cow!(r"[a-z0-9\-]+"));
+    let page = cow!(r"[a-z0-9\-_:]+");
+
+    (site, page).prop_map(|(site, page)| PageRef { site, page })
+}
+
+fn arb_link_location() -> impl Strategy<Value = LinkLocation<'static>> {
+    prop_oneof![
+        arb_page_ref().prop_map(LinkLocation::Page),
+        cow!(".+").prop_map(LinkLocation::Url),
+    ]
+}
+
+fn arb_link_element() -> impl Strategy<Value = Element<'static>> {
     let label = prop_oneof![
         cow!(".*").prop_map(LinkLabel::Text),
         option::of(cow!(SIMPLE_URL_REGEX)).prop_map(LinkLabel::Url),
         Just(LinkLabel::Page),
     ];
 
-    (cow!(".+"), label, arb_target()).prop_map(|(url, label, target)| Element::Link {
-        url,
-        label,
-        target,
-    })
+    (arb_link_location(), label, arb_target())
+        .prop_map(|(url, label, target)| Element::Link { url, label, target })
 }
 
 fn arb_image() -> impl Strategy<Value = Element<'static>> {
@@ -155,7 +166,7 @@ fn arb_image() -> impl Strategy<Value = Element<'static>> {
 
     (
         source,
-        arb_optional_str(),
+        option::of(arb_link_location()),
         image_alignment,
         arb_attribute_map(),
     )
@@ -310,7 +321,7 @@ fn arb_element_leaf() -> impl Strategy<Value = Element<'static>> {
         cow!(".*").prop_map(Element::Raw),
         cow!(SIMPLE_EMAIL_REGEX).prop_map(Element::Email),
         arb_module(),
-        arb_link(),
+        arb_link_element(),
         arb_image(),
         // TODO: Element::RadioButton
         arb_checkbox(),

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -31,7 +31,7 @@
 
 use super::element::Element;
 use super::list::ListItem;
-use ref_map::OptionRefMap;
+use ref_map::*;
 use std::borrow::Cow;
 
 #[inline]

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -23,7 +23,7 @@ use super::clone::{
 };
 use super::{
     Alignment, AnchorTarget, AttributeMap, Container, ElementCondition, FloatAlignment,
-    ImageSource, LinkLabel, ListItem, ListType, Module,
+    ImageSource, LinkLabel, LinkLocation, ListItem, ListType, Module,
 };
 use std::borrow::Cow;
 use std::num::NonZeroU32;
@@ -79,7 +79,7 @@ pub enum Element<'t> {
     ///
     /// The "url" field is either a page name (relative URL) or full URL.
     Link {
-        url: Cow<'t, str>,
+        url: LinkLocation<'t>,
         label: LinkLabel<'t>,
         target: Option<AnchorTarget>,
     },
@@ -91,7 +91,7 @@ pub enum Element<'t> {
     /// The "link" field is what the `<a>` points to, when the user clicks on the image.
     Image {
         source: ImageSource<'t>,
-        link: Option<Cow<'t, str>>,
+        link: Option<LinkLocation<'t>>,
         alignment: Option<FloatAlignment>,
         attributes: AttributeMap<'t>,
     },
@@ -311,7 +311,7 @@ impl Element<'_> {
                 target: *target,
             },
             Element::Link { url, label, target } => Element::Link {
-                url: string_to_owned(url),
+                url: url.to_owned(),
                 label: label.to_owned(),
                 target: *target,
             },
@@ -336,7 +336,7 @@ impl Element<'_> {
                 attributes,
             } => Element::Image {
                 source: source.to_owned(),
-                link: option_string_to_owned(link),
+                link: link.map(|link| link.to_owned()),
                 alignment: *alignment,
                 attributes: attributes.to_owned(),
             },

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -25,6 +25,7 @@ use super::{
     Alignment, AnchorTarget, AttributeMap, Container, ElementCondition, FloatAlignment,
     ImageSource, LinkLabel, LinkLocation, ListItem, ListType, Module,
 };
+use ref_map::*;
 use std::borrow::Cow;
 use std::num::NonZeroU32;
 use std::slice;
@@ -336,7 +337,7 @@ impl Element<'_> {
                 attributes,
             } => Element::Image {
                 source: source.to_owned(),
-                link: link.map(|link| link.to_owned()),
+                link: link.ref_map(|link| link.to_owned()),
                 alignment: *alignment,
                 attributes: attributes.to_owned(),
             },

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -78,9 +78,9 @@ pub enum Element<'t> {
     /// The "label" field is an optional field denoting what the link should
     /// display.
     ///
-    /// The "url" field is either a page name (relative URL) or full URL.
+    /// The "link" field is either a page reference (relative URL) or full URL.
     Link {
-        url: LinkLocation<'t>,
+        link: LinkLocation<'t>,
         label: LinkLabel<'t>,
         target: Option<AnchorTarget>,
     },
@@ -311,8 +311,8 @@ impl Element<'_> {
                 attributes: attributes.to_owned(),
                 target: *target,
             },
-            Element::Link { url, label, target } => Element::Link {
-                url: url.to_owned(),
+            Element::Link { link, label, target } => Element::Link {
+                link: link.to_owned(),
                 label: label.to_owned(),
                 target: *target,
             },

--- a/ftml/src/tree/element.rs
+++ b/ftml/src/tree/element.rs
@@ -311,7 +311,11 @@ impl Element<'_> {
                 attributes: attributes.to_owned(),
                 target: *target,
             },
-            Element::Link { link, label, target } => Element::Link {
+            Element::Link {
+                link,
+                label,
+                target,
+            } => Element::Link {
                 link: link.to_owned(),
                 label: label.to_owned(),
                 target: *target,

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -74,7 +74,7 @@ impl slog::Value for LinkLocation<'_> {
         serializer.emit_str(
             key,
             match self {
-                LinkLocation::Url(url) => &url,
+                LinkLocation::Url(url) => url,
                 LinkLocation::Page(page) => {
                     string = str!(page);
                     &string

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -42,8 +42,8 @@ impl<'a> LinkLocation<'a> {
         }
 
         match PageRef::parse(link_str) {
-            Ok(page_ref) => LinkLocation::Page(page_ref),
             Err(_) => LinkLocation::Url(link),
+            Ok(page_ref) => LinkLocation::Page(page_ref.to_owned()),
         }
     }
 
@@ -79,11 +79,16 @@ impl slog::Value for LinkLocation<'_> {
         key: slog::Key,
         serializer: &mut dyn slog::Serializer,
     ) -> slog::Result {
+        let string;
+
         serializer.emit_str(
             key,
             match self {
-                LinkLocation::Page(page) => &str!(page),
                 LinkLocation::Url(url) => &url,
+                LinkLocation::Page(page) => {
+                    string = str!(page);
+                    &string
+                }
             },
         )
     }

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -53,22 +53,6 @@ impl<'a> LinkLocation<'a> {
         }
     }
 
-    pub fn url(&self, domain: &str) -> Cow<str> {
-        match self {
-            LinkLocation::Url(url) => cow_borrow!(url),
-            LinkLocation::Page(page_ref) => {
-                let page = page_ref.page();
-
-                match page_ref.site() {
-                    Some(site) => {
-                        Cow::Owned(format!("https://{}.{}/{}", site, domain, page))
-                    }
-                    None => cow_borrow!(page),
-                }
-            }
-        }
-    }
-
     pub fn to_owned(&self) -> LinkLocation<'static> {
         match self {
             LinkLocation::Page(page) => LinkLocation::Page(page.to_owned()),

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -35,10 +35,16 @@ pub enum LinkLocation<'a> {
 
 impl<'a> LinkLocation<'a> {
     pub fn parse(link: Cow<'a, str>) -> Self {
-        let link_str = link.as_ref();
+        let mut link_str = link.as_ref();
 
+        // Check for direct URLs or anchor links
         if is_url(link_str) || link_str.starts_with('#') {
             return LinkLocation::Url(link);
+        }
+
+        // Check for local links starting with '/'
+        if link_str.starts_with('/') {
+            link_str = &link_str[1..];
         }
 
         match PageRef::parse(link_str) {

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::data::PageInfo;
 use crate::tree::LinkLocation;
 use std::borrow::Cow;
 use wikidot_normalize::normalize;
@@ -58,6 +59,8 @@ pub fn is_url(url: &str) -> bool {
 
 pub fn normalize_link<'a>(
     link: &'a LinkLocation<'a>,
+    full_url: bool,
+    page_info: &PageInfo,
     helper: &dyn BuildSiteUrl,
 ) -> Cow<'a, str> {
     match link {
@@ -67,7 +70,15 @@ pub fn normalize_link<'a>(
 
             match site {
                 Some(site) => Cow::Owned(helper.build_url(site, page)),
-                None => normalize_href(page),
+                None => {
+                    if full_url {
+                        let current_site = &page_info.site;
+
+                        Cow::Owned(helper.build_url(current_site, page))
+                    } else {
+                        normalize_href(page)
+                    }
+                }
             }
         }
     }

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -18,7 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::data::PageInfo;
 use crate::tree::LinkLocation;
 use std::borrow::Cow;
 use wikidot_normalize::normalize;
@@ -59,8 +58,6 @@ pub fn is_url(url: &str) -> bool {
 
 pub fn normalize_link<'a>(
     link: &'a LinkLocation<'a>,
-    full_url: bool,
-    page_info: &PageInfo,
     helper: &dyn BuildSiteUrl,
 ) -> Cow<'a, str> {
     match link {
@@ -70,15 +67,7 @@ pub fn normalize_link<'a>(
 
             match site {
                 Some(site) => Cow::Owned(helper.build_url(site, page)),
-                None => {
-                    if full_url {
-                        let current_site = &page_info.site;
-
-                        Cow::Owned(helper.build_url(current_site, page))
-                    } else {
-                        normalize_href(page)
-                    }
-                }
+                None => normalize_href(page),
             }
         }
     }

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -25,7 +25,7 @@ use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use crate::render::text::TextRender;
 use crate::render::Render;
 use crate::PageInfo as RustPageInfo;
-use ref_map::OptionRefMap;
+use ref_map::*;
 use std::sync::Arc;
 
 // Typescript declarations

--- a/ftml/test/anchor-alias-star.txt
+++ b/ftml/test/anchor-alias-star.txt
@@ -1,1 +1,1 @@
-My link
+My link [http://example.com]

--- a/ftml/test/anchor-alias.txt
+++ b/ftml/test/anchor-alias.txt
@@ -1,1 +1,1 @@
-My link [https://test.wikijump.com/some-page]
+My link [/some-page]

--- a/ftml/test/anchor-star.txt
+++ b/ftml/test/anchor-star.txt
@@ -1,1 +1,1 @@
-My link
+My link [https://example.com]

--- a/ftml/test/anchor.txt
+++ b/ftml/test/anchor.txt
@@ -1,1 +1,1 @@
-My link [https://test.wikijump.com/some-page]
+My link [/some-page]

--- a/ftml/test/anchor2-alias-star.txt
+++ b/ftml/test/anchor2-alias-star.txt
@@ -1,1 +1,1 @@
-My link
+My link [http://example.com]

--- a/ftml/test/anchor2-alias.txt
+++ b/ftml/test/anchor2-alias.txt
@@ -1,1 +1,1 @@
-My link [https://test.wikijump.com/some-page]
+My link [/some-page]

--- a/ftml/test/anchor2-star.txt
+++ b/ftml/test/anchor2-star.txt
@@ -1,1 +1,1 @@
-My link
+My link [https://example.com]

--- a/ftml/test/anchor2.txt
+++ b/ftml/test/anchor2.txt
@@ -1,1 +1,1 @@
-My link [https://test.wikijump.com/some-page]
+My link [/some-page]

--- a/ftml/test/heading-1.json
+++ b/ftml/test/heading-1.json
@@ -51,7 +51,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "My header"
                                     },

--- a/ftml/test/heading-2.json
+++ b/ftml/test/heading-2.json
@@ -70,7 +70,7 @@
                                         {
                                             "element": "link",
                                             "data": {
-                                                "url": "#toc0",
+                                                "link": "#toc0",
                                                 "label": {
                                                     "text": "My header"
                                                 },

--- a/ftml/test/heading-3-toc.json
+++ b/ftml/test/heading-3-toc.json
@@ -64,7 +64,7 @@
                                                     {
                                                         "element": "link",
                                                         "data": {
-                                                            "url": "#toc0",
+                                                            "link": "#toc0",
                                                             "label": {
                                                                 "text": "toc"
                                                             },

--- a/ftml/test/heading-3.json
+++ b/ftml/test/heading-3.json
@@ -67,7 +67,7 @@
                                                     {
                                                         "element": "link",
                                                         "data": {
-                                                            "url": "#toc0",
+                                                            "link": "#toc0",
                                                             "label": {
                                                                 "text": "Banana Cherry"
                                                             },

--- a/ftml/test/heading-4.json
+++ b/ftml/test/heading-4.json
@@ -71,7 +71,7 @@
                                                                 {
                                                                     "element": "link",
                                                                     "data": {
-                                                                        "url": "#toc0",
+                                                                        "link": "#toc0",
                                                                         "label": {
                                                                             "text": "Small heading"
                                                                         },

--- a/ftml/test/heading-5-toc.json
+++ b/ftml/test/heading-5-toc.json
@@ -168,7 +168,7 @@
                                                                             {
                                                                                 "element": "link",
                                                                                 "data": {
-                                                                                    "url": "#toc0",
+                                                                                    "link": "#toc0",
                                                                                     "label": {
                                                                                         "text": "H5"
                                                                                     },
@@ -192,7 +192,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc1",
+                                    "link": "#toc1",
                                     "label": {
                                         "text": "H1"
                                     },
@@ -210,7 +210,7 @@
                                         {
                                             "element": "link",
                                             "data": {
-                                                "url": "#toc2",
+                                                "link": "#toc2",
                                                 "label": {
                                                     "text": "H2 ++"
                                                 },

--- a/ftml/test/heading-5.json
+++ b/ftml/test/heading-5.json
@@ -92,7 +92,7 @@
                                                                             {
                                                                                 "element": "link",
                                                                                 "data": {
-                                                                                    "url": "#toc0",
+                                                                                    "link": "#toc0",
                                                                                     "label": {
                                                                                         "text": "Header Five"
                                                                                     },

--- a/ftml/test/heading-6-toc.json
+++ b/ftml/test/heading-6-toc.json
@@ -82,7 +82,7 @@
                                                                                         {
                                                                                             "element": "link",
                                                                                             "data": {
-                                                                                                "url": "#toc0",
+                                                                                                "link": "#toc0",
                                                                                                 "label": {
                                                                                                     "text": "toc"
                                                                                                 },

--- a/ftml/test/heading-6.json
+++ b/ftml/test/heading-6.json
@@ -72,7 +72,7 @@
                                                                                         {
                                                                                             "element": "link",
                                                                                             "data": {
-                                                                                                "url": "#toc0",
+                                                                                                "link": "#toc0",
                                                                                                 "label": {
                                                                                                     "text": "SCP-6969"
                                                                                                 },

--- a/ftml/test/heading-multiple.json
+++ b/ftml/test/heading-multiple.json
@@ -124,7 +124,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "H1"
                                     },
@@ -142,7 +142,7 @@
                                         {
                                             "element": "link",
                                             "data": {
-                                                "url": "#toc1",
+                                                "link": "#toc1",
                                                 "label": {
                                                     "text": "H2"
                                                 },
@@ -166,7 +166,7 @@
                                                                 {
                                                                     "element": "link",
                                                                     "data": {
-                                                                        "url": "#toc2",
+                                                                        "link": "#toc2",
                                                                         "label": {
                                                                             "text": "H4"
                                                                         },
@@ -190,7 +190,7 @@
                                                                                         {
                                                                                             "element": "link",
                                                                                             "data": {
-                                                                                                "url": "#toc3",
+                                                                                                "link": "#toc3",
                                                                                                 "label": {
                                                                                                     "text": "H6"
                                                                                                 },
@@ -211,7 +211,7 @@
                                                     {
                                                         "element": "link",
                                                         "data": {
-                                                            "url": "#toc4",
+                                                            "link": "#toc4",
                                                             "label": {
                                                                 "text": "H3"
                                                             },
@@ -229,7 +229,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc5",
+                                    "link": "#toc5",
                                     "label": {
                                         "text": "H1"
                                     },

--- a/ftml/test/iframe-fail.json
+++ b/ftml/test/iframe-fail.json
@@ -23,7 +23,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com",
+                                "link": "https://example.com",
                                 "label": {
                                     "url": null
                                 },

--- a/ftml/test/image-link-page.json
+++ b/ftml/test/image-link-page.json
@@ -25,7 +25,10 @@
                                         "file": "filename.png"
                                     }
                                 },
-                                "link": "SCP-001",
+                                "link": {
+                                    "site": null,
+                                    "page": "SCP-001"
+                                },
                                 "alignment": null,
                                 "attributes": {}
                             }

--- a/ftml/test/image-link-page.txt
+++ b/ftml/test/image-link-page.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-link-page/filename.png [Link: https://test.wikijump.com/scp-001] B
+A Image: https://test.wjfiles.com/local--files/page-image-link-page/filename.png [Link: /scp-001] B

--- a/ftml/test/link-anchor-fake.json
+++ b/ftml/test/link-anchor-fake.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "javascript:;",
+                                "link": "javascript:;",
                                 "label": {
                                     "text": "Fake link"
                                 },

--- a/ftml/test/link-anchor.json
+++ b/ftml/test/link-anchor.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "#apple",
+                                "link": "#apple",
                                 "label": {
                                     "text": "Some link"
                                 },

--- a/ftml/test/link-single-fail-newline.json
+++ b/ftml/test/link-single-fail-newline.json
@@ -15,7 +15,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com/",
+                                "link": "https://example.com/",
                                 "label": {
                                     "url": null
                                 },

--- a/ftml/test/link-single-new-tab.json
+++ b/ftml/test/link-single-new-tab.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "http://scp-sandbox-3.wikidot.com/system:recent-changes",
+                                "link": "http://scp-sandbox-3.wikidot.com/system:recent-changes",
                                 "label": {
                                     "text": "Sandbox: Recent Changes"
                                 },

--- a/ftml/test/link-single-url.json
+++ b/ftml/test/link-single-url.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "/page",
+                                "link": "/page",
                                 "label": {
                                     "text": "Some page"
                                 },

--- a/ftml/test/link-single-url.txt
+++ b/ftml/test/link-single-url.txt
@@ -1,1 +1,1 @@
-Some page [https://test.wikijump.com/page]
+Some page [/page]

--- a/ftml/test/link-single.json
+++ b/ftml/test/link-single.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com/",
+                                "link": "https://example.com/",
                                 "label": {
                                     "text": "Some link"
                                 },

--- a/ftml/test/link-triple-category-new-tab.html
+++ b/ftml/test/link-triple-category-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="/system:recent-pages" target="_blank">Recent Pages</a></p>
+<p><a href="/system:recent-changes" target="_blank">Recent Changes</a></p>

--- a/ftml/test/link-triple-category-new-tab.json
+++ b/ftml/test/link-triple-category-new-tab.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "system:Recent Pages",
+                                "link": {
+                                    "site": null,
+                                    "page": "system:Recent Pages"
+                                },
                                 "label": {
                                     "url": "Recent Pages"
                                 },

--- a/ftml/test/link-triple-category-new-tab.json
+++ b/ftml/test/link-triple-category-new-tab.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[[*system:Recent Pages]]]",
+    "input": "[[[*system:Recent Changes]]]",
     "tree": {
         "elements": [
             {
@@ -13,10 +13,10 @@
                             "data": {
                                 "link": {
                                     "site": null,
-                                    "page": "system:Recent Pages"
+                                    "page": "system:Recent Changes"
                                 },
                                 "label": {
-                                    "url": "Recent Pages"
+                                    "url": "Recent Changes"
                                 },
                                 "target": "new-tab"
                             }

--- a/ftml/test/link-triple-category-new-tab.txt
+++ b/ftml/test/link-triple-category-new-tab.txt
@@ -1,1 +1,1 @@
-Recent Pages [/system:recent-pages]
+Recent Changes [/system:recent-changes]

--- a/ftml/test/link-triple-category-new-tab.txt
+++ b/ftml/test/link-triple-category-new-tab.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://test.wikijump.com/system:recent-pages]
+Recent Pages [/system:recent-pages]

--- a/ftml/test/link-triple-category-spaces.html
+++ b/ftml/test/link-triple-category-spaces.html
@@ -1,1 +1,1 @@
-<p><a href="/system:recent-pages">Recent Pages</a></p>
+<p><a href="/system:recent-changes">Recent Changes</a></p>

--- a/ftml/test/link-triple-category-spaces.json
+++ b/ftml/test/link-triple-category-spaces.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[[system: Recent Pages]]]",
+    "input": "[[[system: Recent Changes]]]",
     "tree": {
         "elements": [
             {
@@ -13,10 +13,10 @@
                             "data": {
                                 "link": {
                                     "site": null,
-                                    "page": "system: Recent Pages"
+                                    "page": "system: Recent Changes"
                                 },
                                 "label": {
-                                    "url": "Recent Pages"
+                                    "url": "Recent Changes"
                                 },
                                 "target": null
                             }

--- a/ftml/test/link-triple-category-spaces.json
+++ b/ftml/test/link-triple-category-spaces.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "system: Recent Pages",
+                                "link": {
+                                    "site": null,
+                                    "page": "system: Recent Pages"
+                                },
                                 "label": {
                                     "url": "Recent Pages"
                                 },

--- a/ftml/test/link-triple-category-spaces.txt
+++ b/ftml/test/link-triple-category-spaces.txt
@@ -1,1 +1,1 @@
-Recent Pages [/system:recent-pages]
+Recent Changes [/system:recent-changes]

--- a/ftml/test/link-triple-category-spaces.txt
+++ b/ftml/test/link-triple-category-spaces.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://test.wikijump.com/system:recent-pages]
+Recent Pages [/system:recent-pages]

--- a/ftml/test/link-triple-category.html
+++ b/ftml/test/link-triple-category.html
@@ -1,1 +1,1 @@
-<p><a href="/system:recent-pages">Recent Pages</a></p>
+<p><a href="/system:recent-changes">Recent Changes</a></p>

--- a/ftml/test/link-triple-category.json
+++ b/ftml/test/link-triple-category.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "system:Recent Pages",
+                                "link": {
+                                    "site": null,
+                                    "page": "system:Recent Pages"
+                                },
                                 "label": {
                                     "url": "Recent Pages"
                                 },

--- a/ftml/test/link-triple-category.json
+++ b/ftml/test/link-triple-category.json
@@ -1,5 +1,5 @@
 {
-    "input": "[[[system:Recent Pages]]]",
+    "input": "[[[system:Recent Changes]]]",
     "tree": {
         "elements": [
             {
@@ -13,10 +13,10 @@
                             "data": {
                                 "link": {
                                     "site": null,
-                                    "page": "system:Recent Pages"
+                                    "page": "system:Recent Changes"
                                 },
                                 "label": {
-                                    "url": "Recent Pages"
+                                    "url": "Recent Changes"
                                 },
                                 "target": null
                             }

--- a/ftml/test/link-triple-category.txt
+++ b/ftml/test/link-triple-category.txt
@@ -1,1 +1,1 @@
-Recent Pages [/system:recent-pages]
+Recent Changes [/system:recent-changes]

--- a/ftml/test/link-triple-category.txt
+++ b/ftml/test/link-triple-category.txt
@@ -1,1 +1,1 @@
-Recent Pages [https://test.wikijump.com/system:recent-pages]
+Recent Pages [/system:recent-pages]

--- a/ftml/test/link-triple-label-new-tab.json
+++ b/ftml/test/link-triple-label-new-tab.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": {
                                     "text": "Label"
                                 },

--- a/ftml/test/link-triple-label-new-tab.txt
+++ b/ftml/test/link-triple-label-new-tab.txt
@@ -1,1 +1,1 @@
-Label [https://test.wikijump.com/some-page]
+Label [/some-page]

--- a/ftml/test/link-triple-label.json
+++ b/ftml/test/link-triple-label.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": {
                                     "text": "My label"
                                 },

--- a/ftml/test/link-triple-label.txt
+++ b/ftml/test/link-triple-label.txt
@@ -1,1 +1,1 @@
-My label [https://test.wikijump.com/some-page]
+My label [/some-page]

--- a/ftml/test/link-triple-new-tab.json
+++ b/ftml/test/link-triple-new-tab.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "SCP-001",
+                                "link": {
+                                    "site": null,
+                                    "page": "SCP-001"
+                                },
                                 "label": {
                                     "url": null
                                 },

--- a/ftml/test/link-triple-new-tab.txt
+++ b/ftml/test/link-triple-new-tab.txt
@@ -1,1 +1,1 @@
-SCP-001 [https://test.wikijump.com/scp-001]
+SCP-001 [/scp-001]

--- a/ftml/test/link-triple-site-category.html
+++ b/ftml/test/link-triple-site-category.html
@@ -1,0 +1,1 @@
+<p><a href="https://scp-wiki.wikijump.com/component:theme">Sigma-9 Theme</a></p>

--- a/ftml/test/link-triple-site-category.json
+++ b/ftml/test/link-triple-site-category.json
@@ -1,0 +1,37 @@
+{
+    "input": "[[[:scp-wiki:component:theme|Sigma-9 Theme]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "link": {
+                                    "site": "scp-wiki",
+                                    "page": "component:theme"
+                                },
+                                "label": {
+                                    "text": "Sigma-9 Theme"
+                                },
+                                "target": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-site-category.txt
+++ b/ftml/test/link-triple-site-category.txt
@@ -1,0 +1,1 @@
+Sigma-9 Theme [https://scp-wiki.wikijump.com/component:theme]

--- a/ftml/test/link-triple-site-name.html
+++ b/ftml/test/link-triple-site-name.html
@@ -1,0 +1,1 @@
+<p><a href="https://scp-wiki.wikijump.com/system:recent-changes">Recent Changes</a></p>

--- a/ftml/test/link-triple-site-name.json
+++ b/ftml/test/link-triple-site-name.json
@@ -1,0 +1,37 @@
+{
+    "input": "[[[:scp-wiki : system : Recent Changes]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "link": {
+                                    "site": "scp-wiki",
+                                    "page": "system : Recent Changes"
+                                },
+                                "label": {
+                                    "url": "Recent Changes"
+                                },
+                                "target": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-site-name.txt
+++ b/ftml/test/link-triple-site-name.txt
@@ -1,0 +1,1 @@
+Recent Changes [https://scp-wiki.wikijump.com/system:recent-changes]

--- a/ftml/test/link-triple-site-title.html
+++ b/ftml/test/link-triple-site-title.html
@@ -1,0 +1,1 @@
+<p><a href="https://scp-wiki.wikijump.com/scp-series">TODO: actual title (Page(PageRef { site: Some(&quot;scp-wiki&quot;), page: &quot;scp-series&quot; }))</a></p>

--- a/ftml/test/link-triple-site-title.json
+++ b/ftml/test/link-triple-site-title.json
@@ -1,0 +1,35 @@
+{
+    "input": "[[[:scp-wiki:scp-series|]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "link": {
+                                    "site": "scp-wiki",
+                                    "page": "scp-series"
+                                },
+                                "label": "page",
+                                "target": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-site-title.txt
+++ b/ftml/test/link-triple-site-title.txt
@@ -1,0 +1,1 @@
+TODO: actual title (Page(PageRef { site: Some("scp-wiki"), page: "scp-series" })) [https://scp-wiki.wikijump.com/scp-series]

--- a/ftml/test/link-triple-site.html
+++ b/ftml/test/link-triple-site.html
@@ -1,0 +1,1 @@
+<p><a href="https://scp-wiki.wikijump.com/scp-1000">Children of the Night</a></p>

--- a/ftml/test/link-triple-site.json
+++ b/ftml/test/link-triple-site.json
@@ -1,0 +1,37 @@
+{
+    "input": "[[[:scp-wiki:scp-1000|Children of the Night]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "link": {
+                                    "site": "scp-wiki",
+                                    "page": "scp-1000"
+                                },
+                                "label": {
+                                    "text": "Children of the Night"
+                                },
+                                "target": null
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-site.txt
+++ b/ftml/test/link-triple-site.txt
@@ -1,0 +1,1 @@
+Children of the Night [https://scp-wiki.wikijump.com/scp-1000]

--- a/ftml/test/link-triple-title-new-tab.html
+++ b/ftml/test/link-triple-title-new-tab.html
@@ -1,1 +1,1 @@
-<p><a href="/some-page" target="_blank">TODO: actual title (some-page)</a></p>
+<p><a href="/some-page" target="_blank">TODO: actual title (Page(PageRef { site: None, page: &quot;some-page&quot; }))</a></p>

--- a/ftml/test/link-triple-title-new-tab.json
+++ b/ftml/test/link-triple-title-new-tab.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": "page",
                                 "target": "new-tab"
                             }

--- a/ftml/test/link-triple-title-new-tab.txt
+++ b/ftml/test/link-triple-title-new-tab.txt
@@ -1,1 +1,1 @@
-TODO: actual title (some-page) [https://test.wikijump.com/some-page]
+TODO: actual title (Page(PageRef { site: None, page: "some-page" })) [/some-page]

--- a/ftml/test/link-triple-title.html
+++ b/ftml/test/link-triple-title.html
@@ -1,1 +1,1 @@
-<p><a href="/some-page">TODO: actual title (some-page)</a></p>
+<p><a href="/some-page">TODO: actual title (Page(PageRef { site: None, page: &quot;some-page&quot; }))</a></p>

--- a/ftml/test/link-triple-title.json
+++ b/ftml/test/link-triple-title.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": "page",
                                 "target": null
                             }

--- a/ftml/test/link-triple-title.txt
+++ b/ftml/test/link-triple-title.txt
@@ -1,1 +1,1 @@
-TODO: actual title (some-page) [https://test.wikijump.com/some-page]
+TODO: actual title (Page(PageRef { site: None, page: "some-page" })) [/some-page]

--- a/ftml/test/link-triple-url-whitespace.json
+++ b/ftml/test/link-triple-url-whitespace.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com/",
+                                "link": "https://example.com/",
                                 "label": {
                                     "text": "Example"
                                 },

--- a/ftml/test/link-triple-url.json
+++ b/ftml/test/link-triple-url.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com/",
+                                "link": "https://example.com/",
                                 "label": {
                                     "text": "Example"
                                 },

--- a/ftml/test/link-triple-whitespace-new-tab.json
+++ b/ftml/test/link-triple-whitespace-new-tab.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": {
                                     "text": "My label"
                                 },

--- a/ftml/test/link-triple-whitespace-new-tab.txt
+++ b/ftml/test/link-triple-whitespace-new-tab.txt
@@ -1,1 +1,1 @@
-My label [https://test.wikijump.com/some-page]
+My label [/some-page]

--- a/ftml/test/link-triple-whitespace.json
+++ b/ftml/test/link-triple-whitespace.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "some-page",
+                                "link": {
+                                    "site": null,
+                                    "page": "some-page"
+                                },
                                 "label": {
                                     "text": "My label"
                                 },

--- a/ftml/test/link-triple-whitespace.txt
+++ b/ftml/test/link-triple-whitespace.txt
@@ -1,1 +1,1 @@
-My label [https://test.wikijump.com/some-page]
+My label [/some-page]

--- a/ftml/test/link-triple.json
+++ b/ftml/test/link-triple.json
@@ -11,7 +11,10 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "SCP-001",
+                                "link": {
+                                    "site": null,
+                                    "page": "SCP-001"
+                                },
                                 "label": {
                                     "url": null
                                 },

--- a/ftml/test/link-triple.txt
+++ b/ftml/test/link-triple.txt
@@ -1,1 +1,1 @@
-SCP-001 [https://test.wikijump.com/scp-001]
+SCP-001 [/scp-001]

--- a/ftml/test/link-url.json
+++ b/ftml/test/link-url.json
@@ -11,7 +11,7 @@
                         {
                             "element": "link",
                             "data": {
-                                "url": "https://example.com/directory",
+                                "link": "https://example.com/directory",
                                 "label": {
                                     "url": null
                                 },

--- a/ftml/test/toc-attributes.json
+++ b/ftml/test/toc-attributes.json
@@ -61,7 +61,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "A"
                                     },

--- a/ftml/test/toc-fail.json
+++ b/ftml/test/toc-fail.json
@@ -59,7 +59,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "A"
                                     },

--- a/ftml/test/toc-float.json
+++ b/ftml/test/toc-float.json
@@ -55,7 +55,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "A"
                                     },

--- a/ftml/test/toc.json
+++ b/ftml/test/toc.json
@@ -72,7 +72,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc0",
+                                    "link": "#toc0",
                                     "label": {
                                         "text": "A"
                                     },
@@ -84,7 +84,7 @@
                             {
                                 "element": "link",
                                 "data": {
-                                    "url": "#toc1",
+                                    "link": "#toc1",
                                     "label": {
                                         "text": "B"
                                     },

--- a/web/app/Services/Wikitext/Backlinks.php
+++ b/web/app/Services/Wikitext/Backlinks.php
@@ -41,6 +41,7 @@ class Backlinks
     {
         return array_unique($items, SORT_STRING);
     }
+
     public static function fromWikiObject(Text_Wiki &$wiki): Backlinks
     {
         $inclusionsPresent = $wiki->vars['inclusions'] ?? [];

--- a/web/app/Services/Wikitext/Backlinks.php
+++ b/web/app/Services/Wikitext/Backlinks.php
@@ -32,16 +32,16 @@ class Backlinks
         $this->externalLinks = self::dedupeStrings($externalLinks);
     }
 
-    private static function dedupeIds(array $items): array
+    private static function dedupeIds(array &$items): array
     {
         return array_unique($items, SORT_NUMERIC);
     }
 
-    private static function dedupeStrings(array $items): array
+    private static function dedupeStrings(array &$items): array
     {
         return array_unique($items, SORT_STRING);
     }
-    public static function fromWikiObject(Text_Wiki $wiki): Backlinks
+    public static function fromWikiObject(Text_Wiki &$wiki): Backlinks
     {
         $inclusionsPresent = $wiki->vars['inclusions'] ?? [];
         $inclusionsAbsent = $wiki->vars['inclusionsNotExist'] ?? [];

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -66,7 +66,7 @@ final class FtmlFfi
     }
 
     // ftml export methods
-    public static function renderHtml(string $wikitext, Wikitext\PageInfo $pageInfo): HtmlOutput
+    public static function renderHtml(string $wikitext, Wikitext\PageInfo &$pageInfo): HtmlOutput
     {
         $siteId = self::getSiteId($pageInfo->site);
         if ($siteId === null) {
@@ -85,7 +85,7 @@ final class FtmlFfi
         return OutputConversion::makeHtmlOutput($siteId, $output);
     }
 
-    public static function renderText(string $wikitext, Wikitext\PageInfo $pageInfo): TextOutput
+    public static function renderText(string $wikitext, Wikitext\PageInfo &$pageInfo): TextOutput
     {
         $c_pageInfo = new PageInfo($pageInfo);
         $output = self::make(self::$FTML_TEXT_OUTPUT);
@@ -93,14 +93,14 @@ final class FtmlFfi
         return OutputConversion::makeTextOutput($output);
     }
 
-    public static function freeHtmlOutput(FFI\CData $c_data)
+    public static function freeHtmlOutput(FFI\CData &$data)
     {
-        self::$ffi->ftml_destroy_html_output(FFI::addr($c_data));
+        self::$ffi->ftml_destroy_html_output(FFI::addr($data));
     }
 
-    public static function freeTextOutput(FFI\CData $c_data)
+    public static function freeTextOutput(FFI\CData &$data)
     {
-        self::$ffi->ftml_destroy_text_output(FFI::addr($c_data));
+        self::$ffi->ftml_destroy_text_output(FFI::addr($data));
     }
 
     public static function version(): string
@@ -119,7 +119,7 @@ final class FtmlFfi
      * @param FFI\CType $ctype
      * @return FFI\CData
      */
-    public static function make(FFI\CType $ctype): ?FFI\CData
+    public static function make(FFI\CType &$ctype): ?FFI\CData
     {
         // Handle zero-width types
         if (FFI::sizeof($ctype) === 0) {
@@ -145,12 +145,12 @@ final class FtmlFfi
      * Converts a FFI C string into a nullable PHP string.
      * That is, it handles C NULL properly.
      */
-    public static function nullableString(FFI\CData &$c_data): ?string
+    public static function nullableString(FFI\CData &$data): ?string
     {
-        if (FFI::isNull($c_data)) {
+        if (FFI::isNull($data)) {
             return null;
         } else {
-            return FFI::string($c_data);
+            return FFI::string($data);
         }
     }
 
@@ -164,7 +164,7 @@ final class FtmlFfi
      * @param array $dimensions
      * @return FFI\CType
      */
-    public static function arrayType(FFI\CType $ctype, array $dimensions): FFI\CType
+    public static function arrayType(FFI\CType &$ctype, array $dimensions): FFI\CType
     {
         return FFI::arrayType($ctype, $dimensions);
     }
@@ -215,7 +215,7 @@ final class FtmlFfi
      * @param callable $convertFn Converts a PHP item to its C equivalent
      * @returns array with keys "pointer" and "length"
      */
-    public static function listToPointer(FFI\CType $type, array $list, callable $convertFn): array
+    public static function listToPointer(FFI\CType $type, array &$list, callable $convertFn): array
     {
         // Allocate heap array
         $length = count($list);
@@ -242,7 +242,7 @@ final class FtmlFfi
      * @param int $length The length of this array, in items
      * @param callable $freeFn The function used to free the item
      */
-    public static function freePointer(?FFI\CData $pointer, int $length, callable $freeFn)
+    public static function freePointer(?FFI\CData &$pointer, int $length, callable $freeFn)
     {
         if ($pointer === null) {
             // Nothing to free, empty array
@@ -262,7 +262,7 @@ final class FtmlFfi
      *
      * @returns array with the converted objects
      */
-    public static function pointerToList(FFI\CData $pointer, int $length, callable $convertFn): array
+    public static function pointerToList(FFI\CData &$pointer, int $length, callable $convertFn): array
     {
         $list = [];
 

--- a/web/app/Services/Wikitext/FFI/OutputConversion.php
+++ b/web/app/Services/Wikitext/FFI/OutputConversion.php
@@ -117,8 +117,7 @@ final class OutputConversion
         $inclusions = self::splitLinks(
             $data->included_pages_list,
             $data->included_pages_len,
-            fn(FFI\CData $data) => self::makePageRef($data),
-            fn(PageRef $pageRef) => self::getPageId($siteId, $pageRef),
+            $siteId,
         );
         $inclusionsPresent = $inclusions['present'];
         $inclusionsAbsent = $inclusions['absent'];
@@ -126,8 +125,7 @@ final class OutputConversion
         $internalLinks = self::splitLinks(
             $data->internal_links_list,
             $data->internal_links_len,
-            fn(FFI\CData $data) => self::makePageRef($data),
-            fn(PageRef $pageRef) => self::getPageId($siteId, $pageRef),
+            $siteId,
         );
         $internalLinksPresent = $internalLinks['present'];
         $internalLinksAbsent = $internalLinks['absent'];
@@ -158,21 +156,20 @@ final class OutputConversion
     private static function splitLinks(
         FFI\CData &$pointer,
         int $length,
-        callable $convertFn,
-        callable $checkItemFn
+        string $siteId
     ): array {
         $present = [];
         $absent = [];
 
         // Convert items, placing in the appropriate list
         for ($i = 0; $i < $length; $i++) {
-            $originalItem = $convertFn($pointer[$i]);
-            $foundItem = $checkItemFn($originalItem);
+            $pageRef = self::makePageRef($pointer[$i]);
+            $pageId = self::getPageId($siteId, $pageRef);
 
-            if ($foundItem === null) {
-                array_push($absent, $originalItem);
+            if ($pageId === null) {
+                array_push($absent, $pageRef->pathRepr());
             } else {
-                array_push($present, $foundItem);
+                array_push($present, $pageId);
             }
         }
 

--- a/web/app/Services/Wikitext/FFI/OutputConversion.php
+++ b/web/app/Services/Wikitext/FFI/OutputConversion.php
@@ -21,26 +21,26 @@ final class OutputConversion
     private function __construct() {}
 
     // HtmlMeta
-    public static function makeHtmlMetaArray(FFI\CData $pointer, int $length): array
+    public static function makeHtmlMetaArray(FFI\CData &$pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
             $length,
-            fn(FFI\CData $c_data) => self::makeHtmlMeta($c_data),
+            fn(FFI\CData &$data) => self::makeHtmlMeta($data),
         );
     }
 
-    public static function makeHtmlMeta(FFI\CData $c_data): HtmlMeta
+    public static function makeHtmlMeta(FFI\CData &$data): HtmlMeta
     {
-        $tagType = self::getTagType($c_data->tag_type);
-        $name = FFI::string($c_data->name);
-        $value = FFI::string($c_data->value);
+        $tagType = self::getTagType($data->tag_type);
+        $name = FFI::string($data->name);
+        $value = FFI::string($data->value);
         return new HtmlMeta($tagType, $name, $value);
     }
 
-    private static function getTagType(int $c_tag): string
+    private static function getTagType(int $tag): string
     {
-        switch ($c_tag) {
+        switch ($tag) {
             case FtmlFfi::$META_NAME:
                 return HtmlMetaType::NAME;
             case FtmlFfi::$META_HTTP_EQUIV:
@@ -48,94 +48,94 @@ final class OutputConversion
             case FtmlFfi::$META_PROPERTY:
                 return HtmlMetaType::PROPERTY;
             default:
-                throw new Error("Invalid HTML meta tag type C enum value: $c_tag");
+                throw new Error("Invalid HTML meta tag type C enum value: $tag");
         }
     }
 
     // HtmlOutput
-    public static function makeHtmlOutput(string $siteId, FFI\CData $c_data): HtmlOutput
+    public static function makeHtmlOutput(string $siteId, FFI\CData &$data): HtmlOutput
     {
-        $body = FFI::string($c_data->body);
-        $styles = self::makeStylesArray($c_data->styles_list, $c_data->styles_len);
-        $meta = self::makeHtmlMetaArray($c_data->meta_list, $c_data->meta_len);
-        $warnings = self::makeParseWarningArray($c_data->warning_list, $c_data->warning_len);
-        $backlinks = self::makeBacklinks($siteId, $c_data->backlinks);
+        $body = FFI::string($data->body);
+        $styles = self::makeStylesArray($data->styles_list, $data->styles_len);
+        $meta = self::makeHtmlMetaArray($data->meta_list, $data->meta_len);
+        $warnings = self::makeParseWarningArray($data->warning_list, $data->warning_len);
+        $backlinks = self::makeBacklinks($siteId, $data->backlinks);
 
         // Free original C data
-        FtmlFfi::freeHtmlOutput($c_data);
-        FFI::free($c_data);
+        FtmlFfi::freeHtmlOutput($data);
+        FFI::free($data);
 
         // Return object
         return new HtmlOutput($body, $styles, $meta, $warnings, $backlinks);
     }
 
-    private static function makeStylesArray(FFI\CData $pointer, int $length): array {
+    private static function makeStylesArray(FFI\CData &$pointer, int $length): array {
         return FtmlFfi::pointerToList(
             $pointer,
             $length,
-            fn(FFI\CData $c_data) => FFI::string($c_data),
+            fn(FFI\CData $data) => FFI::string($data),
         );
     }
 
     // TextOutput
-    public static function makeTextOutput(FFI\CData $c_data): TextOutput
+    public static function makeTextOutput(FFI\CData &$data): TextOutput
     {
-        $text = FFI::string($c_data->text);
-        $warnings = self::makeParseWarningArray($c_data->warning_list, $c_data->warning_len);
+        $text = FFI::string($data->text);
+        $warnings = self::makeParseWarningArray($data->warning_list, $data->warning_len);
 
         // Free original C data
-        FtmlFfi::freeTextOutput($c_data);
-        FFI::free($c_data);
+        FtmlFfi::freeTextOutput($data);
+        FFI::free($data);
 
         // Return object
         return new TextOutput($text, $warnings);
     }
 
     // ParseWarning
-    public static function makeParseWarningArray(FFI\CData $pointer, int $length): array
+    public static function makeParseWarningArray(FFI\CData &$pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
             $length,
-            fn(FFI\CData $c_data) => self::makeParseWarning($c_data),
+            fn(FFI\CData $data) => self::makeParseWarning($data),
         );
     }
 
-    public static function makeParseWarning(FFI\CData $c_data): ParseWarning
+    public static function makeParseWarning(FFI\CData &$data): ParseWarning
     {
-        $token = FFI::string($c_data->token);
-        $rule = FFI::string($c_data->rule);
-        $spanStart = $c_data->span_start;
-        $spanEnd = $c_data->span_end;
-        $kind = FFI::string($c_data->kind);
+        $token = FFI::string($data->token);
+        $rule = FFI::string($data->rule);
+        $spanStart = $data->span_start;
+        $spanEnd = $data->span_end;
+        $kind = FFI::string($data->kind);
         return new ParseWarning($token, $rule, $spanStart, $spanEnd, $kind);
     }
 
     // Backlinks
-    public static function makeBacklinks(string $siteId, FFI\CData $c_data): Backlinks
+    public static function makeBacklinks(string $siteId, FFI\CData &$data): Backlinks
     {
         $inclusions = self::splitLinks(
-            $c_data->included_pages_list,
-            $c_data->included_pages_len,
-            fn(FFI\CData $c_data) => self::makePageRef($c_data),
+            $data->included_pages_list,
+            $data->included_pages_len,
+            fn(FFI\CData $data) => self::makePageRef($data),
             fn(PageRef $pageRef) => self::getPageId($siteId, $pageRef),
         );
         $inclusionsPresent = $inclusions['present'];
         $inclusionsAbsent = $inclusions['absent'];
 
         $internalLinks = self::splitLinks(
-            $c_data->internal_links_list,
-            $c_data->internal_links_len,
-            fn(FFI\CData $c_data) => self::makePageRef($c_data),
+            $data->internal_links_list,
+            $data->internal_links_len,
+            fn(FFI\CData $data) => self::makePageRef($data),
             fn(PageRef $pageRef) => self::getPageId($siteId, $pageRef),
         );
         $internalLinksPresent = $internalLinks['present'];
         $internalLinksAbsent = $internalLinks['absent'];
 
         $externalLinks = FtmlFfi::pointerToList(
-            $c_data->external_links_list,
-            $c_data->external_links_len,
-            fn(FFI\CData $c_data) => FFI::string($c_data),
+            $data->external_links_list,
+            $data->external_links_len,
+            fn(FFI\CData $data) => FFI::string($data),
         );
 
         return new Backlinks(
@@ -147,16 +147,16 @@ final class OutputConversion
         );
     }
 
-    private static function makePageRef(FFI\CData $c_data): PageRef
+    private static function makePageRef(FFI\CData &$data): PageRef
     {
-        $site = FtmlFfi::nullableString($c_data->site);
-        $page = FFI::string($c_data->page);
+        $site = FtmlFfi::nullableString($data->site);
+        $page = FFI::string($data->page);
 
         return new PageRef($site, $page);
     }
 
     private static function splitLinks(
-        FFI\CData $pointer,
+        FFI\CData &$pointer,
         int $length,
         callable $convertFn,
         callable $checkItemFn

--- a/web/app/Services/Wikitext/FtmlBackend.php
+++ b/web/app/Services/Wikitext/FtmlBackend.php
@@ -13,7 +13,7 @@ class FtmlBackend extends WikitextBackend
 {
     private PageInfo $pageInfo;
 
-    public function __construct(int $mode, ?PageInfo $pageInfo)
+    public function __construct(int $mode, ?PageInfo &$pageInfo)
     {
         // TODO mode
         $this->pageInfo = $pageInfo ?? self::defaultPageInfo();

--- a/web/app/Services/Wikitext/FtmlBackend.php
+++ b/web/app/Services/Wikitext/FtmlBackend.php
@@ -37,6 +37,6 @@ class FtmlBackend extends WikitextBackend
 
     private static function defaultPageInfo(): PageInfo
     {
-        return new PageInfo('_anonymous', null, 'www', '_anonymous', null, [], 'C');
+        return new PageInfo('_anonymous', null, 'test', '_anonymous', null, [], 'default');
     }
 }

--- a/web/app/Services/Wikitext/PageRef.php
+++ b/web/app/Services/Wikitext/PageRef.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Wikijump\Services\Wikitext;
 

--- a/web/app/Services/Wikitext/PageRef.php
+++ b/web/app/Services/Wikitext/PageRef.php
@@ -16,4 +16,15 @@ class PageRef
         $this->site = $site;
         $this->page = $page;
     }
+
+    public function pathRepr(): string
+    {
+        if ($this->site === null) {
+            $site = '';
+        } else {
+            $site = ":$this->site:";
+        }
+
+        return $site . $this->page;
+    }
 }

--- a/web/app/Services/Wikitext/PageRef.php
+++ b/web/app/Services/Wikitext/PageRef.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Wikijump\Services\Wikitext;
+
+/**
+ * Class PageRef, refers to a particular page by slug. If the site is null, then the current site is used.
+ * @package Wikijump\Services\Wikitext
+ */
+class PageRef
+{
+    public ?string $site;
+    public string $page;
+
+    public function __construct(?string $site, string $page)
+    {
+        $this->site = $site;
+        $this->page = $page;
+    }
+}

--- a/web/app/Services/Wikitext/TextWikiBackend.php
+++ b/web/app/Services/Wikitext/TextWikiBackend.php
@@ -14,7 +14,7 @@ class TextWikiBackend extends WikitextBackend
 {
     private WikiTransformation $wt;
 
-    public function __construct(int $mode, ?PageInfo $pageInfo)
+    public function __construct(int $mode, ?PageInfo &$pageInfo)
     {
         $this->wt = new WikiTransformation();
 

--- a/web/app/Services/Wikitext/WikitextBackend.php
+++ b/web/app/Services/Wikitext/WikitextBackend.php
@@ -26,7 +26,7 @@ abstract class WikitextBackend
      *
      * @throws Exception if the feature flag value is invalid
      */
-    public static function make(int $mode, ?PageInfo $pageInfo): WikitextBackend
+    public static function make(int $mode, ?PageInfo &$pageInfo): WikitextBackend
     {
         switch (GlobalProperties::$FEATURE_WIKITEXT_BACKEND) {
             case 'text_wiki':


### PR DESCRIPTION
Wikidot allows you to `[[include]]` pages off-site using `:wiki-name:page-name` syntax (e.g. `:scp-wiki:theme:black-highlighter-theme`). This PR extends triple-bracket link syntax to be able to do the same. That is, you can already do `[[[Page Name Here]]]` to link to `/page-name-here`, and now you can do `[[[:scp-wiki:SCP-1000]]]` to link to a page on a different wiki.

This adds `LinkLocation` as a data type which either allows freeform string URLs like before, or pointing to a specific page via `PageRef`. This also changes backlinks to store a list of `PageRef`s rather than string slugs. These two necessitated changes to the AST tests and to the PHP FFI interface.