### PR TITLE
Mitigation for CVE-2020-28168

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -58,7 +58,7 @@
         "@typescript-eslint/eslint-plugin": "^4.4.1",
         "@typescript-eslint/parser": "^4.4.1",
         "alpinejs": "^3.0.6",
-        "axios": "^0.19",
+        "axios": ">=0.21.1",
         "babel-jest": "^26.6.3",
         "clean-webpack-plugin": "^3.0.0",
         "compress-tag": "^2.0.0",


### PR DESCRIPTION
https://github.com/advisories/GHSA-4w2v-q235-vp99 was fired by Dependabot and requires an update to package.json.