### PR TITLE
Add AWS seed files that match local spec

### DIFF
--- a/install/aws/dev/docker/postgres/seed.sql
+++ b/install/aws/dev/docker/postgres/seed.sql
@@ -1,0 +1,23 @@
+SET default_transaction_read_only = off;
+
+CREATE ROLE wikijump;
+ALTER ROLE wikijump WITH INHERIT CREATEDB LOGIN REPLICATION NOBYPASSRLS PASSWORD 'wikijump';
+
+CREATE DATABASE wikijump ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
+
+ALTER DATABASE wikijump OWNER TO wikijump;
+
+\connect wikijump
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+GRANT ALL ON SCHEMA public TO wikijump;

--- a/install/aws/prod/docker/postgres/seed.sql
+++ b/install/aws/prod/docker/postgres/seed.sql
@@ -1,0 +1,23 @@
+SET default_transaction_read_only = off;
+
+CREATE ROLE wikijump;
+ALTER ROLE wikijump WITH INHERIT CREATEDB LOGIN REPLICATION NOBYPASSRLS PASSWORD 'wikijump';
+
+CREATE DATABASE wikijump ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
+
+ALTER DATABASE wikijump OWNER TO wikijump;
+
+\connect wikijump
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+GRANT ALL ON SCHEMA public TO wikijump;


### PR DESCRIPTION
The seed.sql files removed in #367 were the old seed file that also populated the database instead of just creating it and letting Laravel's migration files do the rest. This PR fixes the dev deploy and uses the same known-good config as local builds.