### PR TITLE
[WJ-777] Add PageInfo to parsing as well

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/ffi/exports.rs
+++ b/ftml/src/ffi/exports.rs
@@ -47,7 +47,7 @@ fn render<R: Render>(
 
     crate::preprocess(log, &mut text);
     let tokens = crate::tokenize(log, &text);
-    let (tree, warnings) = crate::parse(log, &tokens).into();
+    let (tree, warnings) = crate::parse(log, &page_info, &tokens).into();
     let output = renderer.render(log, &page_info, &tree);
     (output, warnings)
 }

--- a/ftml/src/parsing/check_step.rs
+++ b/ftml/src/parsing/check_step.rs
@@ -45,9 +45,12 @@ pub fn check_step<'r, 't>(
 #[test]
 #[should_panic]
 fn check_step_fail() {
+    use crate::data::PageInfo;
+
     let log = crate::build_logger();
+    let page_info = PageInfo::dummy();
     let tokenization = crate::tokenize(&log, "**Apple** banana");
-    let mut parser = Parser::new(&log, &tokenization);
+    let mut parser = Parser::new(&log, &page_info, &tokenization);
 
     let _ = check_step(&mut parser, Token::Italics);
 }

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -53,6 +53,7 @@ use self::parser::Parser;
 use self::rule::impls::RULE_PAGE;
 use self::string::parse_string;
 use self::strip::strip_newlines;
+use crate::data::PageInfo;
 use crate::log::prelude::*;
 use crate::next_index::{NextIndex, TableOfContentsIndex};
 use crate::tokenizer::Tokenization;
@@ -72,12 +73,13 @@ pub use self::token::{ExtractedToken, Token};
 /// This takes a list of `ExtractedToken` items produced by `tokenize()`.
 pub fn parse<'r, 't>(
     log: &Logger,
+    page_info: &'r PageInfo<'t>,
     tokenization: &'r Tokenization<'t>,
 ) -> ParseOutcome<SyntaxTree<'t>>
 where
     'r: 't,
 {
-    let mut parser = Parser::new(log, tokenization);
+    let mut parser = Parser::new(log, page_info, tokenization);
 
     // Logging setup
     let log = &log.new(slog_o!(

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -38,6 +38,9 @@ pub struct Parser<'r, 't> {
     // Logger instance
     log: Logger,
 
+    // Page information
+    page_info: &'r PageInfo<'t>,
+
     // Parse state
     current: &'r ExtractedToken<'t>,
     remaining: &'r [ExtractedToken<'t>],
@@ -72,7 +75,11 @@ impl<'r, 't> Parser<'r, 't> {
     ///
     /// All other instances should be `.clone()` or `.clone_with_rule()`d from
     /// the main instance used during parsing.
-    pub(crate) fn new(log: &Logger, tokenization: &'r Tokenization<'t>) -> Self {
+    pub(crate) fn new(
+        log: &Logger,
+        page_info: &'r PageInfo<'t>,
+        tokenization: &'r Tokenization<'t>,
+    ) -> Self {
         let log = Logger::clone(log);
         let full_text = tokenization.full_text();
         let (current, remaining) = tokenization
@@ -85,6 +92,7 @@ impl<'r, 't> Parser<'r, 't> {
 
         Parser {
             log,
+            page_info,
             current,
             remaining,
             full_text,
@@ -101,6 +109,11 @@ impl<'r, 't> Parser<'r, 't> {
     #[inline]
     pub fn log(&self) -> Logger {
         Logger::clone(&self.log)
+    }
+
+    #[inline]
+    pub fn page_info(&self) -> &PageInfo<'t> {
+        self.page_info
     }
 
     #[inline]

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -389,11 +389,12 @@ fn make_shared_vec<T>() -> Rc<RefCell<Vec<T>>> {
 #[test]
 fn parser_newline_flag() {
     let log = &crate::build_logger();
+    let page_info = PageInfo::dummy();
 
     macro_rules! check {
         ($input:expr, $expected_steps:expr $(,)?) => {{
             let tokens = crate::tokenize(log, $input);
-            let mut parser = Parser::new(log, &tokens);
+            let mut parser = Parser::new(log, &page_info, &tokens);
             let mut actual_steps = Vec::new();
 
             // Iterate through the tokens.

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -178,23 +178,11 @@ impl<'r, 't> Parser<'r, 't> {
         heading: HeadingLevel,
         name_elements: &[Element],
     ) {
-        // TODO provide real PageInfo
-        let info = PageInfo {
-            page: cow!("table-of-contents"),
-            category: None,
-            site: cow!(""),
-            title: cow!("Table of Contents"),
-            alt_title: None,
-            rating: 0.0,
-            tags: vec![],
-            language: cow!("unknown"),
-        };
-
         // Headings are 1-indexed (e.g. H1), but depth lists are 0-indexed
         let level = usize::from(heading.value()) - 1;
 
         // Render name as text, so it lacks formatting
-        let name = TextRender.render_partial(&self.log, &info, name_elements);
+        let name = TextRender.render_partial(&self.log, self.page_info, name_elements);
 
         self.table_of_contents.borrow_mut().push((level, (), name));
     }

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -190,7 +190,7 @@ impl Test<'_> {
 
         crate::preprocess(log, &mut text);
         let tokens = crate::tokenize(log, &text);
-        let result = crate::parse(log, &tokens);
+        let result = crate::parse(log, &page_info, &tokens);
         let (tree, warnings) = result.into();
         let html_output = HtmlRender.render(log, &page_info, &tree);
         let text_output = TextRender.render(log, &page_info, &tree);

--- a/ftml/src/test/large.rs
+++ b/ftml/src/test/large.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use crate::data::PageInfo;
 use crate::parsing::{ParseWarningKind, Token};
 use crate::tree::{Element, SyntaxTree};
 use std::borrow::Cow;
@@ -30,6 +31,7 @@ use std::borrow::Cow;
 #[test]
 fn recursion_depth() {
     let log = crate::build_logger();
+    let page_info = PageInfo::dummy();
 
     // Build wikitext input
     let mut input = String::new();
@@ -45,7 +47,7 @@ fn recursion_depth() {
     // Run parser steps
     crate::preprocess(&log, &mut input);
     let tokens = crate::tokenize(&log, &input);
-    let (tree, warnings) = crate::parse(&log, &tokens).into();
+    let (tree, warnings) = crate::parse(&log, &page_info, &tokens).into();
 
     // Check outputted warnings
     let warning = warnings.get(0).expect("No warnings produced");
@@ -72,6 +74,7 @@ fn large_payload() {
     const ITERATIONS: usize = 50;
 
     let log = crate::build_logger();
+    let page_info = PageInfo::dummy();
 
     // Build wikitext input
     let mut input = String::new();
@@ -97,7 +100,7 @@ In hac habitasse platea dictumst. Vestibulum fermentum libero nec erat porttitor
     // Run parser steps
     crate::preprocess(&log, &mut input);
     let tokens = crate::tokenize(&log, &input);
-    let (_tree, warnings) = crate::parse(&log, &tokens).into();
+    let (_tree, warnings) = crate::parse(&log, &page_info, &tokens).into();
 
     // Check output
     assert_eq!(warnings.len(), ITERATIONS * 3);

--- a/ftml/src/wasm/mod.rs
+++ b/ftml/src/wasm/mod.rs
@@ -27,6 +27,7 @@ mod css;
 mod error;
 mod log;
 mod misc;
+mod page_info;
 mod parsing;
 mod preproc;
 mod render;

--- a/ftml/src/wasm/page_info.rs
+++ b/ftml/src/wasm/page_info.rs
@@ -1,0 +1,126 @@
+/*
+ * wasm/page_info.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::error::error_to_js;
+use super::prelude::*;
+use crate::PageInfo as RustPageInfo;
+use ref_map::*;
+use std::sync::Arc;
+
+// Typescript declarations
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &str = r#"
+
+export interface IPageInfo {
+    page: string;
+    category: string | null;
+    site: string;
+    title: string;
+    alt_title: string | null;
+    rating: number;
+    tags: string[];
+    language: string;
+}
+
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "IPageInfo")]
+    pub type IPageInfo;
+
+    #[wasm_bindgen(typescript_type = "string[]")]
+    pub type ITags;
+}
+
+// Wrapper structure
+
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub struct PageInfo {
+    inner: Arc<RustPageInfo<'static>>,
+}
+
+#[wasm_bindgen]
+impl PageInfo {
+    #[inline]
+    pub(crate) fn get(&self) -> &RustPageInfo<'static> {
+        &self.inner
+    }
+
+    #[wasm_bindgen]
+    pub fn copy(&self) -> PageInfo {
+        PageInfo {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    #[wasm_bindgen(constructor, typescript_type = "IPageInfo")]
+    pub fn new(object: IPageInfo) -> Result<PageInfo, JsValue> {
+        let rust_page_info = object.into_serde().map_err(error_to_js)?;
+
+        Ok(PageInfo {
+            inner: Arc::new(rust_page_info),
+        })
+    }
+
+    // Getters
+
+    #[wasm_bindgen(method, getter)]
+    pub fn page(&self) -> String {
+        self.inner.page.to_string()
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn category(&self) -> Option<String> {
+        self.inner.category.ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn site(&self) -> String {
+        self.inner.site.to_string()
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn title(&self) -> String {
+        self.inner.title.to_string()
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn alt_title(&self) -> Option<String> {
+        self.inner.alt_title.ref_map(ToString::to_string)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn rating(&self) -> f32 {
+        self.inner.rating
+    }
+
+    #[wasm_bindgen(method, getter, typescript_type = "ITags")]
+    pub fn tags(&self) -> Result<ITags, JsValue> {
+        rust_to_js!(self.inner.tags)
+    }
+
+    #[wasm_bindgen(method, getter)]
+    pub fn language(&self) -> String {
+        self.inner.language.to_string()
+    }
+}

--- a/ftml/src/wasm/parsing.rs
+++ b/ftml/src/wasm/parsing.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::page_info::PageInfo;
 use super::prelude::*;
 use super::tokenizer::Tokenization;
 use crate::parsing::{
@@ -125,12 +126,13 @@ impl SyntaxTree {
 // Exported functions
 
 #[wasm_bindgen]
-pub fn parse(tokens: Tokenization) -> Result<ParseOutcome, JsValue> {
+pub fn parse(page_info: PageInfo, tokens: Tokenization) -> Result<ParseOutcome, JsValue> {
     let log = &*LOGGER;
 
     // Borrow and perform parsing
+    let page_info = page_info.get();
     let tokenization = tokens.get();
-    let (syntax_tree, warnings) = crate::parse(log, tokenization).into();
+    let (syntax_tree, warnings) = crate::parse(log, page_info, tokenization).into();
 
     // Deep-clone AST to make it owned, so it can be safely passed to JS.
     let syntax_tree = syntax_tree.to_owned();

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -18,14 +18,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::error::error_to_js;
+use super::page_info::PageInfo;
 use super::parsing::SyntaxTree;
 use super::prelude::*;
 use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use crate::render::text::TextRender;
 use crate::render::Render;
-use crate::PageInfo as RustPageInfo;
-use ref_map::*;
 use std::sync::Arc;
 
 // Typescript declarations
@@ -51,17 +49,6 @@ export interface IBacklinks {
     external_links: string[];
 }
 
-export interface IPageInfo {
-    page: string;
-    category: string | null;
-    site: string;
-    title: string;
-    alt_title: string | null;
-    rating: number;
-    tags: string[];
-    language: string;
-}
-
 "#;
 
 #[wasm_bindgen]
@@ -74,87 +61,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "IBacklinks")]
     pub type IBacklinks;
-
-    #[wasm_bindgen(typescript_type = "IPageInfo")]
-    pub type IPageInfo;
-
-    #[wasm_bindgen(typescript_type = "string[]")]
-    pub type ITags;
 }
 
 // Wrapper structures
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct PageInfo {
-    inner: Arc<RustPageInfo<'static>>,
-}
-
-#[wasm_bindgen]
-impl PageInfo {
-    #[inline]
-    pub(crate) fn get(&self) -> &RustPageInfo<'static> {
-        &self.inner
-    }
-
-    #[wasm_bindgen]
-    pub fn copy(&self) -> PageInfo {
-        PageInfo {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-
-    #[wasm_bindgen(constructor, typescript_type = "IPageInfo")]
-    pub fn new(object: IPageInfo) -> Result<PageInfo, JsValue> {
-        let rust_page_info = object.into_serde().map_err(error_to_js)?;
-
-        Ok(PageInfo {
-            inner: Arc::new(rust_page_info),
-        })
-    }
-
-    // Getters
-
-    #[wasm_bindgen(method, getter)]
-    pub fn page(&self) -> String {
-        self.inner.page.to_string()
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn category(&self) -> Option<String> {
-        self.inner.category.ref_map(ToString::to_string)
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn site(&self) -> String {
-        self.inner.site.to_string()
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn title(&self) -> String {
-        self.inner.title.to_string()
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn alt_title(&self) -> Option<String> {
-        self.inner.alt_title.ref_map(ToString::to_string)
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn rating(&self) -> f32 {
-        self.inner.rating
-    }
-
-    #[wasm_bindgen(method, getter, typescript_type = "ITags")]
-    pub fn tags(&self) -> Result<ITags, JsValue> {
-        rust_to_js!(self.inner.tags)
-    }
-
-    #[wasm_bindgen(method, getter)]
-    pub fn language(&self) -> String {
-        self.inner.language.to_string()
-    }
-}
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Previously, only the render step required `PageInfo` information. Since parsing and rendering are performed together in the FFI anyways, and we need that information for table of contents generation, I've modified the parser to also require a `PageInfo` like the renderer.