### PR TITLE
Update ForbiddenNames.php

### DIFF
--- a/web/php/Config/ForbiddenNames.php
+++ b/web/php/Config/ForbiddenNames.php
@@ -93,6 +93,13 @@ class ForbiddenNames {
         '/^robot$/',
         '/^O5-\w+$/',
         '/^SCP-\w+$/',
+'/^bauerbach\w+$/',
+      '/^brandonfave\w+$/',  
+'/^bradleya\w+$/',
+     '/^DrAuerbach\w+$/',   
+      '/^Dr Auerbach\w+$/',  
+        '/^ishmonger\w+$/',
+        '/^CFOperator\w+$/',
     ];
 
 }


### PR DESCRIPTION
I think that the usernames of people permabanned from the current site should be included on here unless they appeal. If by any chance it becomes impossible to appeal by the usual means of appealing bans from the site for some reason, then an admin should have an alternate way of doing appeals.

Do you think forbidding new registrations of users permabanned from the current site is a good idea? Or is it only a good idea if they are unable to appeal?

To look at more info on why a user was banned, Google "05command disciplinary [username]", where [username] is replaced with the actual usernazme. Their 05 record (Disciplinary thread) should be the first result.

Also, you can search "+"perma" site:05command.wikidot.com" on Google to quickly see who has been permabanned.