### PR TITLE
Looser acceptance for emails

### DIFF
--- a/ftml/src/parsing/lexer.pest
+++ b/ftml/src/parsing/lexer.pest
@@ -111,11 +111,11 @@ token = _{
 identifier = @{ (ASCII_ALPHANUMERIC | ASCII_DIGIT)+ }
 
 email = @{
-    (ASCII_ALPHANUMERIC | "-" | ".")+ ~
+    (!(" " | "\t" | NEWLINE) ~ ANY)+ ~
     "@" ~
-    (ASCII_ALPHANUMERIC | "-")+ ~
+    (!(" " | "\t" | NEWLINE) ~ ANY)+ ~
     "." ~
-    (ASCII_ALPHANUMERIC | ".")+
+    (!(" " | "\t" | NEWLINE) ~ ANY)+ ~
 }
 
 url = @{

--- a/ftml/src/parsing/lexer.pest
+++ b/ftml/src/parsing/lexer.pest
@@ -115,7 +115,7 @@ email = @{
     "@" ~
     (!(" " | "\t" | NEWLINE) ~ ANY)+ ~
     "." ~
-    (!(" " | "\t" | NEWLINE) ~ ANY)+ ~
+    (!(" " | "\t" | NEWLINE) ~ ANY)+
 }
 
 url = @{


### PR DESCRIPTION
I'm not sure why I did a naive pattern for emails. It excludes plenty of common valid ones. This pattern is much more generous and simply assumes there is a `@` and then a `.` somewhere in the string.