### PR TITLE
[WJ-792] Upgrade ftml to use new wikidot-normalize version

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -224,12 +224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c9736e15e7df1638a7f6eee92a6511615c738246a052af5ba86f039b65aede"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,15 +1384,15 @@ dependencies = [
 
 [[package]]
 name = "wikidot-normalize"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ddf207ff4a92eeab3b84dca52f63abdf697a27d0da5d1f0980d3a70739d081"
+checksum = "dbb9207ce9e203ac01ff7c935738bb3c918373cfa70247ccc70a71a75c863a4f"
 dependencies = [
- "deunicode",
  "lazy_static",
  "maplit",
  "regex",
  "trim-in-place",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1219,9 +1219,9 @@ checksum = "50ae970a522c697c39de23b630ae81ff124f6291cc591a76c17d45b0ff1d4a88"
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -49,7 +49,7 @@ strum_macros = "0.21"
 tinyvec = "1"
 unicase = "2"
 void = "1"
-wikidot-normalize = "0.8"
+wikidot-normalize = "0.9"
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 


### PR DESCRIPTION
This upgrades the `wikidot-normalize` dependency to use the version which has changes from https://github.com/scpwiki/wikidot-normalize/pull/1.