### PR TITLE
Fix unicode underscore bug in path normalization

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "wikidot-normalize"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb9207ce9e203ac01ff7c935738bb3c918373cfa70247ccc70a71a75c863a4f"
+checksum = "439561319fd3f8a28f27f231c1ee16fea40f3858cce4239040b8072067e4800c"
 dependencies = [
  "lazy_static",
  "maplit",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.5.1"
+version = "1.5.2"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 


### PR DESCRIPTION
The failing test in #389 was actually a result of a bug in [`wikidot-normalize`](https://github.com/scpwiki/wikidot-normalize), because it used the wrong method for getting character byte boundaries. This was fixed in 0.9.1 of that library, and a test was added to catch regressions.

This PR upgrades that dependency and bumps the patch version number to mark it.

Thanks to @leo60228 for catching this.
