### PR TITLE
[WJ-797] Redirect non-normalized URLs

### DIFF
--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -202,7 +202,7 @@ class LegacyTools
         $runData->contextAdd("wikiPageName", $wikiPage);
         $return['wikiPageName'] = $wikiPage;
         $settings = $site->getSettings();
-        /** @var Page $page */
+        /** @var ?Page $page */
         $page = PagePeer::instance()->selectByName($site->getSiteId(), $wikiPage);
         if ($page == null) {
             $runData->contextAdd("pageNotExists", true);

--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -26,8 +26,10 @@ use Wikidot\Utils\WDStringUtils;
 use Wikijump\Models\User;
 
 /** A collection of static methods to smooth the transition to Wikijump code. */
-class LegacyTools
+final class LegacyTools
 {
+    // Disallow creating instances
+    private function __construct() {}
 
     /**
      * A function to take an absolute path to a file and transform it to a properly namespaced class.
@@ -66,7 +68,7 @@ class LegacyTools
      * @return array|string
      * @throws \Wikidot\Utils\ProcessException
      */
-    public function generateScreenVars()
+    public static function generateScreenVars()
     {
         /**
          * Create a RunData instance.

--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -523,7 +523,7 @@ final class LegacyTools
         $slugNormal = WDStringUtils::toUnixName($slug);
         if ($slug !== $slugNormal) {
             // Redirect to the normalized version
-            $newUrl = GlobalProperties::$HTTP_SCHEMA . '://' . $site->getDomain() . $wikiPageNormal . $pageParameters;
+            $newUrl = GlobalProperties::$HTTP_SCHEMA . '://' . $site->getDomain() . '/' . $slugNormal . $pageParameters;
             header('HTTP/1.1 301 Moved Permanently');
             header('Location: ' . $newUrl);
             exit();

--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -198,10 +198,19 @@ class LegacyTools
         /**
          * Get Page
          */
-        if ($wikiPage=="") {
-            $wikiPage=$site->getDefaultPage();
+        if ($wikiPage === '') {
+            $wikiPage = $site->getDefaultPage();
         }
-        $wikiPage = WDStringUtils::toUnixName($wikiPage);
+        $wikiPageNormal = WDStringUtils::toUnixName($wikiPage);
+        if ($wikiPage !== $wikiPageNormal) {
+            // Redirect to normalized version
+            $newUrl = GlobalProperties::$HTTP_SCHEMA . '://' . $site->getDomain() . $wikiPageNormal . $pageParameters;
+            header('HTTP/1.1 301 Moved Permanently');
+            header('Location: ' . $newUrl);
+            exit();
+        }
+        $wikiPage = $wikiPageNormal;
+
         $runData->setTemp("pageUnixName", $wikiPage);
         $runData->contextAdd("wikiPageName", $wikiPage);
         $return['wikiPageName'] = $wikiPage;

--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -191,6 +191,10 @@ class LegacyTools
             }
         }
 
+        // Gets parameters (e.g. /noredirect/true), if any
+        $pageParameters = preg_replace('/^\/[^\/]+/u', '', $_SERVER['REQUEST_URI']);
+        $return['pageParameters'] = $pageParameters;
+
         /**
          * Get Page
          */

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -63,10 +63,19 @@ class WikiScreen extends Screen
             }
         }
 
-        if ($wikiPage=="") {
-            $wikiPage=$site->getDefaultPage();
+        if ($wikiPage === '') {
+            $wikiPage = $site->getDefaultPage();
         }
-        $wikiPage = WDStringUtils::toUnixName($wikiPage);
+        $wikiPageNormal = WDStringUtils::toUnixName($wikiPage);
+        if ($wikiPage !== $wikiPageNormal) {
+            // Redirect to normalized version
+            $pageParameters = preg_replace('/^\/[^\/]+/u', '', $_SERVER['REQUEST_URI']);
+            $newUrl = GlobalProperties::$HTTP_SCHEMA . '://' . $site->getDomain() . '/' . $wikiPageNormal . $pageParameters;
+            header('HTTP/1.1 301 Moved Permanently');
+            header('Location: ' . $newUrl);
+            exit();
+        }
+        $wikiPage = $wikiPageNormal;
         $runData->setTemp("pageUnixName", $wikiPage);
 
         if ($runData->getAction() == null

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -70,7 +70,6 @@ class WikiScreen extends Screen
 
         if ($runData->getAction() == null
                 && $runData->getRequestMethod() == "GET"
-
                 && $privateAccessGranted
             ) {
             // try to get content from the memorycache server

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -17,6 +17,7 @@ use Wikidot\DB\ForumThreadPeer;
 use Wikidot\DB\NotificationPeer;
 use Wikidot\Utils\GlobalProperties;
 use Wikidot\Utils\WDStringUtils;
+use Wikijump\Helpers\LegacyTools;
 use Wikijump\Models\UserMessage;
 
 class WikiScreen extends Screen
@@ -63,19 +64,8 @@ class WikiScreen extends Screen
             }
         }
 
-        if ($wikiPage === '') {
-            $wikiPage = $site->getDefaultPage();
-        }
-        $wikiPageNormal = WDStringUtils::toUnixName($wikiPage);
-        if ($wikiPage !== $wikiPageNormal) {
-            // Redirect to normalized version
-            $pageParameters = preg_replace('/^\/[^\/]+/u', '', $_SERVER['REQUEST_URI']);
-            $newUrl = GlobalProperties::$HTTP_SCHEMA . '://' . $site->getDomain() . '/' . $wikiPageNormal . $pageParameters;
-            header('HTTP/1.1 301 Moved Permanently');
-            header('Location: ' . $newUrl);
-            exit();
-        }
-        $wikiPage = $wikiPageNormal;
+        $pageParameters = LegacyTools::getPageParameters();
+        $wikiPage = LegacyTools::redirectToNormalUrl($site, $wikiPage, $pageParameters);
         $runData->setTemp("pageUnixName", $wikiPage);
 
         if ($runData->getAction() == null

--- a/web/php/Utils/WikiFlowController.php
+++ b/web/php/Utils/WikiFlowController.php
@@ -162,7 +162,6 @@ class WikiFlowController extends WebFlowController
                     header("HTTP/1.1 301 Moved Permanently");
                     header("Location: ".'https://'.$_SERVER["HTTP_HOST"].$_SERVER['REQUEST_URI']);
                     exit();
-                    break;
             }
         }
 

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -94,8 +94,7 @@ Route::get('/user--avatar/{user}', function (User $user) {
  * This route will use Blade instead of Smarty for rendering.
  */
 Route::get('/what-is-a-wiki', function() {
-   $legacy = new LegacyTools();
-   $values = $legacy->generateScreenVars();
+   $values = LegacyTools::generateScreenVars();
    return view('layouts.legacy', [
        'site' => $values['site'] ?? null,
        'pageNotExists' => $values['pageNotExists'] ?? null,
@@ -141,8 +140,7 @@ Route::any( "/{path?}", [OzoneController::class, 'handle'] )
 
 /** Use blade for everything. Soon™. */
 //Route::any( "/{path?}", function() {
-//    $legacy = new LegacyTools();
-//    $values = $legacy->generateScreenVars();
+//    $values = LegacyTools::generateScreenVars();
 //    return view(
 //        'layouts.legacy',
 //        [

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -153,6 +153,7 @@ Route::any( "/{path?}", [OzoneController::class, 'handle'] )
 //            'wikiPage' => ($values['wikiPage'] ?? null),
 //            'wikiPageName' => ($values['wikiPageName'] ?? null),
 //            'pageContent' => ($values['pageContent'] ?? null),
+//            'pageParameters' => ($values['pageParameters'] ?? null),
 //            'topBarContent' => $values['topBarContent'] ?? null,
 //            'sideBar1Content' => $values['sideBar1Content'] ?? null,
 //            'breadcrumbs' => $values['breadcrumbs'] ?? null,

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -104,6 +104,7 @@ Route::get('/what-is-a-wiki', function() {
        'wikiPage' => ($values['wikiPage'] ?? null),
        'wikiPageName' => ($values['wikiPageName'] ?? null),
        'pageContent' => ($values['pageContent'] ?? null),
+       'pageParameters' => ($values['pageParameters'] ?? null),
        'topBarContent' => $values['topBarContent'] ?? null,
        'sideBar1Content' => $values['sideBar1Content'] ?? null,
        'breadcrumbs' => $values['breadcrumbs'] ?? null,
@@ -119,7 +120,6 @@ Route::get('/what-is-a-wiki', function() {
        'useCustomDomainScriptSecure' => $values['useCustomDomainScriptSecure'],
        'login' => $values['login'],
        'pageOptions' => $values['pageOptions'],
-
    ]);
 });
 


### PR DESCRIPTION
If you were to visit a non-normal URL on mainline wikidot, such as `/SCP 001`, it will redirect you to `/scp-001`. This behavior was not mimicked by our version of wikidot, so this PR adds this redirection. To help achieve this, it also extracts the raw parameter list from the request URI (e.g. `/noredirect/true`) so the URL matches.

In Laravel this should be a cleaner redirect function, that makes use of a properly-parsed parameter list. But for now this is fine.

I tested to ensure this works with our new international normalization as well. Here I visited `/SCP--五`:
![image](https://user-images.githubusercontent.com/8848022/132416126-75577506-5f27-4e9c-bec4-051d1182f48a.png)

I also confirmed it preserves URL parameters as expected.
