### PR TITLE
[WJ-51] Allow empty values in URL parameters

### DIFF
--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -90,12 +90,25 @@ class ParameterList {
 		return !array_search($name, $this->parameterArray) === false;
 	}
 
-	public function getParameterValue($name, $type = null, $type2 = null) {
+	public function getParameterValue(string $name, $type = null, $type2 = null) {
 		if($type == null || $this->parameterTypes[$name] == $type || $this->parameterTypes[$name] == $type2){
 			return $this->parameterArray[$name];
 		}
 		return null;
 	}
+
+    public function getParameterValueBoolean(string $name): ?bool
+    {
+        switch ($this->getParameterValue($name)) {
+            case 'true':
+                return true;
+            case 'false':
+                return false;
+            case null:
+            default:
+                return null;
+        }
+    }
 
 	public function delParameter($key){
 		unset($this->parameterArray[$key]);

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -59,7 +59,7 @@ class ParameterList {
             $this->allParameters['GET'] = [];
             for ($i = 1; $i < count($split); $i++) {
                 $key = $split[$i];
-                if (!$key || $key === 'true' || $key === 'false') {
+                if (!$key || self::convertBool($key) !== null) {
                     continue;
                 }
 
@@ -111,6 +111,17 @@ class ParameterList {
         }
 
         // Boolean
+        $bool = self::convertBool($value);
+        if ($bool !== null) {
+            return $bool;
+        }
+
+        // String
+        return $value;
+    }
+
+    private static function convertBool(string $value): ?bool
+    {
         switch ($value) {
             case 'yes':
             case 'true':
@@ -120,10 +131,9 @@ class ParameterList {
             case 'false':
             case 'f':
                 return false;
+            default:
+                return null;
         }
-
-        // String
-        return $value;
     }
 
     public function containsParameter(string $name): bool

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -2,24 +2,19 @@
 
 namespace Ozone\Framework;
 
-
-
-
-
 /**
  * Parameters for the web request.
  *
  */
 class ParameterList {
 
-	private $parameterArray = [];
-	private $parameterTypes = [];
-	private $parameterFrom = [];
+	private array $parameterArray = [];
+	private array $parameterTypes = [];
+	private array $parameterFrom = [];
 
-	private $allParameters = [];
+	private array $allParameters = [];
 
 	public function initParameterList($runData) {
-
 		if($runData->isAjaxMode()){
 			$this->allParameters['AMODULE'] = [];
 			foreach ($_POST as $key => $value) {
@@ -165,5 +160,4 @@ class ParameterList {
  			return null;
 		}
 	}
-
 }

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -31,32 +31,33 @@ class ParameterList {
 			$qs =  $_SERVER['QUERY_STRING'];
 			/* Check if there is a "?" char - if so, remove it. */
 			$qs = preg_replace('/\?.*$/', '', $qs);
-			$splited = explode('/', $qs);
-			if(count($splited)>= 1){
-				$this->parameterArray['template'] = $splited[0];
+			$split = explode('/', $qs);
+			if (count($split) >= 1) {
+				$this->parameterArray['template'] = $split[0];
 				$this->parameterTypes['template'] = 'GET';
 			}
 
             /**
              * If an & is present in the URI, split that into key-value pairs.
              */
-                $uri = $_SERVER['REQUEST_URI'];
-                $uri = preg_replace('/^[^?]*\?/', '', $uri);
-                $uriPairs = explode('&', $uri);
-                foreach ($uriPairs as $uriPair) {
-                    $u = explode('=', $uriPair);
-                    $key = $u[0];
-                    $value = $u[1];
-                    $this->parameterArray[$key] = urldecode($value);
-                    $this->parameterTypes[$key] = 'GET';
-                    $this->parameterFrom[$key] = 0;
-                    $this->allParameters['GET'][$key] = urldecode($value);
-                }
+            $uri = $_SERVER['REQUEST_URI'];
+            $uri = preg_replace('/^[^?]*\?/', '', $uri);
+            $uriPairs = explode('&', $uri);
+            foreach ($uriPairs as $uriPair) {
+                $u = explode('=', $uriPair);
+                $key = $u[0];
+                $value = $u[1];
+                $this->parameterArray[$key] = urldecode($value);
+                $this->parameterTypes[$key] = 'GET';
+                $this->parameterFrom[$key] = 0;
+                $this->allParameters['GET'][$key] = urldecode($value);
+            }
+
 			// now populate other parameters...
 			$this->allParameters['GET'] = [];
-			for($i=1; $i<count($splited); $i+=2){
-				$key = $splited[$i];
-				$value=$splited[$i+1];
+			for($i=1; $i<count($split); $i+=2){
+				$key = $split[$i];
+				$value=$split[$i+1];
 				$this->parameterArray[$key] = urldecode($value);
 				$this->parameterTypes[$key] = 'GET';
 				$this->parameterFrom[$key] = 0;

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -147,30 +147,6 @@ class ParameterList {
         return null;
     }
 
-    /**
-     * Like getParameterValue(), but 'casts' the string to boolean.
-     * Returns null if it doesn't exist or is another value.
-     *
-     * @param string $name
-     * @return bool|null
-     */
-    public function getParameterValueBoolean(string $name): ?bool
-    {
-        switch ($this->getParameterValue($name)) {
-            case 'true':
-            case 't':
-            case 'yes':
-                return true;
-            case 'false':
-            case 'f':
-            case 'no':
-                return false;
-            case null:
-            default:
-                return null;
-        }
-    }
-
     public function delParameter(string $key): void
     {
         unset($this->parameterArray[$key]);

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -76,7 +76,38 @@ class ParameterList {
 		}
 	}
 
-	public function containsParameter($name): bool
+    /**
+     * Converts an arbitrary parameter value to its appropriate PHP type.
+     *
+     * @param ?string $value The value to be converted
+     * @return bool|int|string|null The value after conversion
+     */
+    private function convertValue(?string $value)
+    {
+        // Integer
+        if (is_numeric($value)) {
+            return intvalue($value);
+        }
+
+        // Boolean or Null
+        switch ($value) {
+            case 'yes':
+            case 'true':
+            case 't':
+                return true;
+            case 'no':
+            case 'false':
+            case 'f':
+                return false;
+            case null:
+                return null;
+        }
+
+        // String
+        return $value;
+    }
+
+	public function containsParameter(string $name): bool
     {
 		return !array_search($name, $this->parameterArray) === false;
 	}

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -98,9 +98,9 @@ class ParameterList {
      */
     private static function convertValue(?string $value)
     {
-        // Null
+        // Empty
         if ($value === null) {
-            return null;
+            return '';
         }
 
         // Decode since we know it's not null
@@ -149,7 +149,7 @@ class ParameterList {
 
     /**
      * Like getParameterValue(), but 'casts' the string to boolean.
-     * Returns null if it doesn't exist or is another value..
+     * Returns null if it doesn't exist or is another value.
      *
      * @param string $name
      * @return bool|null

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -99,10 +99,11 @@ class ParameterList {
     private static function convertValue(?string $value)
     {
         // Null
-        if (is_null($value)) {
+        if ($value === null) {
             return null;
         }
 
+        // Decode since we know it's not null
         $value = urldecode($value);
 
         // Integer

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -44,9 +44,9 @@ class ParameterList {
             $uri = preg_replace('/^[^?]*\?/', '', $uri);
             $uriPairs = explode('&', $uri);
             foreach ($uriPairs as $uriPair) {
-                $u = explode('=', $uriPair);
-                $key = $u[0];
-                $value = $u[1];
+                $pair = explode('=', $uriPair);
+                $key = $pair[0];
+                $value = $pair[1];
                 $this->parameterArray[$key] = urldecode($value);
                 $this->parameterTypes[$key] = 'GET';
                 $this->parameterFrom[$key] = 0;

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -31,7 +31,7 @@ class ParameterList {
             $qs =  $_SERVER['QUERY_STRING'];
             /* Check if there is a "?" char - if so, remove it. */
             $qs = preg_replace('/\?.*$/', '', $qs);
-            $split = explode('/', $qs);
+            $split = explode('/', $qs); // In the form ModuleName/key1/value1/key2/value2/...
             if (count($split) >= 1) {
                 $this->parameterArray['template'] = $split[0];
                 $this->parameterTypes['template'] = 'GET';
@@ -59,7 +59,7 @@ class ParameterList {
             $this->allParameters['GET'] = [];
             for ($i = 1; $i < count($split); $i++) {
                 $key = $split[$i];
-                if (!$key || key === 'true' || key === 'false') {
+                if (!$key || $key === 'true' || $key === 'false') {
                     continue;
                 }
 
@@ -70,6 +70,11 @@ class ParameterList {
                 $this->parameterTypes[$key] = 'GET';
                 $this->parameterFrom[$key] = 0;
                 $this->allParameters['GET'][$key] = $value;
+
+                if ($valueRaw !== null) {
+                    // Skip the next item, since it's the value we just processed
+                    $i++;
+                }
             }
 
             // POST parameters are not affected by mod_rewrite

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -14,7 +14,8 @@ class ParameterList {
 
 	private array $allParameters = [];
 
-	public function initParameterList($runData) {
+	public function initParameterList($runData): void
+    {
 		if($runData->isAjaxMode()){
 			$this->allParameters['AMODULE'] = [];
 			foreach ($_POST as $key => $value) {
@@ -24,7 +25,6 @@ class ParameterList {
 				$this->parameterTypes[$key] = "AMODULE";
 				$this->parameterFrom[$key] = 0; // 0 means "direct", + values means 'inherited'
 				$this->allParameters['AMODULE'][$key] = $value;
-
 			}
 		} else{
 			//initialize GET parameters from the url... because of mod_rewrite
@@ -63,21 +63,16 @@ class ParameterList {
 				$this->allParameters['GET'][$key] = urldecode($value);
 			}
 
-
 			// POST parameters are not affected by mod_rewrite
 			$this->allParameters['POST'] = [];
 			foreach ($_POST as $key => $value) {
-
 				$value = $this->fixNewLines($value);
-
 				$this->parameterArray[$key] = $value;
 				$this->parameterTypes[$key] = 'POST';
 				$this->parameterFrom[$key] = 0;
 				$this->allParameters['POST'][$key] = urldecode($value);
 			}
-
 		}
-
 	}
 
 	public function containsParameter($name): bool
@@ -85,19 +80,34 @@ class ParameterList {
 		return !array_search($name, $this->parameterArray) === false;
 	}
 
-	public function getParameterValue(string $name, $type = null, $type2 = null) {
+    /**
+     * @return mixed|null
+     */
+	public function getParameterValue(string $name, $type = null, $type2 = null)
+	{
 		if($type == null || $this->parameterTypes[$name] == $type || $this->parameterTypes[$name] == $type2){
 			return $this->parameterArray[$name];
 		}
 		return null;
 	}
 
+    /**
+     * Like getParameterValue(), but 'casts' the string to boolean.
+     * Returns null if it doesn't exist or is another value..
+     *
+     * @param string $name
+     * @return bool|null
+     */
     public function getParameterValueBoolean(string $name): ?bool
     {
         switch ($this->getParameterValue($name)) {
             case 'true':
+            case 't':
+            case 'yes':
                 return true;
             case 'false':
+            case 'f':
+            case 'no':
                 return false;
             case null:
             default:
@@ -105,7 +115,8 @@ class ParameterList {
         }
     }
 
-	public function delParameter($key){
+	public function delParameter(string $key): void
+    {
 		unset($this->parameterArray[$key]);
 		unset($this->parameterTypes[$key]);
 	}
@@ -115,35 +126,41 @@ class ParameterList {
      * @param $name
      * @return string
      */
-	public function getParameterType($name) : string {
+	public function getParameterType(string $name): string
+	{
 		return $this->parameterTypes[$name];
 	}
 
-	public function asArray() {
+	public function asArray(): array
+    {
 		return $this->parameterArray;
 	}
 
-	public function asArrayAll(){
+	public function asArrayAll(): array
+    {
 		return $this->allParameters;
 	}
 
-	public function addParameter($key, $value, $type=null){
-			$this->parameterArray["$key"] = $value;
-			$this->parameterTypes["$key"] = $type;
-			$this->allParameters[$type][$key] = $value;
+	public function addParameter(string $key, string $value, ?string $type=null): void
+    {
+        $this->parameterArray["$key"] = $value;
+        $this->parameterTypes["$key"] = $type;
+        $this->allParameters[$type][$key] = $value;
 	}
 
-	public function numberOfParameters(){
+	public function numberOfParameters(): int
+    {
 		return count($this->parameterArray);
 	}
 
-	private function fixNewLines($text){
+	private function fixNewLines(string $text): string
+    {
 		$text = str_replace("\r\n", "\n", $text);
 		$text = str_replace("\r", "\n", $text);
 		return $text;
 	}
 
-	public function getParametersByType($type){
+	public function getParametersByType(?string $type) {
 		$out = [];
 		foreach($this->parameterArray as $key => $value){
 			if($this->parameterTypes[$key] === $type){
@@ -153,7 +170,7 @@ class ParameterList {
 		return $out;
 	}
 
-	public function resolveParameter($key, $from) {
+	public function resolveParameter(string $key, string $from) {
 		if(isset($this->allParameters[$from][$key])) {
 			return $this->allParameters[$from][$key];
 		} else {

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -8,34 +8,34 @@ namespace Ozone\Framework;
  */
 class ParameterList {
 
-	private array $parameterArray = [];
-	private array $parameterTypes = [];
-	private array $parameterFrom = [];
+    private array $parameterArray = [];
+    private array $parameterTypes = [];
+    private array $parameterFrom = [];
 
-	private array $allParameters = [];
+    private array $allParameters = [];
 
-	public function initParameterList($runData): void
+    public function initParameterList($runData): void
     {
-		if($runData->isAjaxMode()){
-			$this->allParameters['AMODULE'] = [];
-			foreach ($_POST as $key => $value) {
-				$value = $this->fixNewLines($value);
+        if($runData->isAjaxMode()){
+            $this->allParameters['AMODULE'] = [];
+            foreach ($_POST as $key => $value) {
+                $value = $this->fixNewLines($value);
 
-				$this->parameterArray[$key] = $value;
-				$this->parameterTypes[$key] = "AMODULE";
-				$this->parameterFrom[$key] = 0; // 0 means "direct", + values means 'inherited'
-				$this->allParameters['AMODULE'][$key] = $value;
-			}
-		} else{
-			//initialize GET parameters from the url... because of mod_rewrite
-			$qs =  $_SERVER['QUERY_STRING'];
-			/* Check if there is a "?" char - if so, remove it. */
-			$qs = preg_replace('/\?.*$/', '', $qs);
-			$split = explode('/', $qs);
-			if (count($split) >= 1) {
-				$this->parameterArray['template'] = $split[0];
-				$this->parameterTypes['template'] = 'GET';
-			}
+                $this->parameterArray[$key] = $value;
+                $this->parameterTypes[$key] = "AMODULE";
+                $this->parameterFrom[$key] = 0; // 0 means "direct", + values means 'inherited'
+                $this->allParameters['AMODULE'][$key] = $value;
+            }
+        } else{
+            //initialize GET parameters from the url... because of mod_rewrite
+            $qs =  $_SERVER['QUERY_STRING'];
+            /* Check if there is a "?" char - if so, remove it. */
+            $qs = preg_replace('/\?.*$/', '', $qs);
+            $split = explode('/', $qs);
+            if (count($split) >= 1) {
+                $this->parameterArray['template'] = $split[0];
+                $this->parameterTypes['template'] = 'GET';
+            }
 
             /**
              * If an & is present in the URI, split that into key-value pairs.
@@ -53,28 +53,30 @@ class ParameterList {
                 $this->allParameters['GET'][$key] = urldecode($value);
             }
 
-			// now populate other parameters...
-			$this->allParameters['GET'] = [];
-			for($i=1; $i<count($split); $i+=2){
-				$key = $split[$i];
-				$value=$split[$i+1];
-				$this->parameterArray[$key] = urldecode($value);
-				$this->parameterTypes[$key] = 'GET';
-				$this->parameterFrom[$key] = 0;
-				$this->allParameters['GET'][$key] = urldecode($value);
-			}
+            // Parse path parameters.
+            // This was edited to be more flexible in how it handles parameters, see
+            // https://github.com/scpwiki/wikidot-path
+            $this->allParameters['GET'] = [];
+            for($i = 1; $i < count($split); $i += 2){
+                $key = $split[$i];
+                $value=$split[$i+1];
+                $this->parameterArray[$key] = urldecode($value);
+                $this->parameterTypes[$key] = 'GET';
+                $this->parameterFrom[$key] = 0;
+                $this->allParameters['GET'][$key] = urldecode($value);
+            }
 
-			// POST parameters are not affected by mod_rewrite
-			$this->allParameters['POST'] = [];
-			foreach ($_POST as $key => $value) {
-				$value = $this->fixNewLines($value);
-				$this->parameterArray[$key] = $value;
-				$this->parameterTypes[$key] = 'POST';
-				$this->parameterFrom[$key] = 0;
-				$this->allParameters['POST'][$key] = urldecode($value);
-			}
-		}
-	}
+            // POST parameters are not affected by mod_rewrite
+            $this->allParameters['POST'] = [];
+            foreach ($_POST as $key => $value) {
+                $value = $this->fixNewLines($value);
+                $this->parameterArray[$key] = $value;
+                $this->parameterTypes[$key] = 'POST';
+                $this->parameterFrom[$key] = 0;
+                $this->allParameters['POST'][$key] = urldecode($value);
+            }
+        }
+    }
 
     /**
      * Converts an arbitrary parameter value to its appropriate PHP type.
@@ -107,21 +109,21 @@ class ParameterList {
         return $value;
     }
 
-	public function containsParameter(string $name): bool
+    public function containsParameter(string $name): bool
     {
-		return !array_search($name, $this->parameterArray) === false;
-	}
+        return !array_search($name, $this->parameterArray) === false;
+    }
 
     /**
      * @return mixed|null
      */
-	public function getParameterValue(string $name, $type = null, $type2 = null)
-	{
-		if($type == null || $this->parameterTypes[$name] == $type || $this->parameterTypes[$name] == $type2){
-			return $this->parameterArray[$name];
-		}
-		return null;
-	}
+    public function getParameterValue(string $name, $type = null, $type2 = null)
+    {
+        if($type == null || $this->parameterTypes[$name] == $type || $this->parameterTypes[$name] == $type2){
+            return $this->parameterArray[$name];
+        }
+        return null;
+    }
 
     /**
      * Like getParameterValue(), but 'casts' the string to boolean.
@@ -147,66 +149,66 @@ class ParameterList {
         }
     }
 
-	public function delParameter(string $key): void
+    public function delParameter(string $key): void
     {
-		unset($this->parameterArray[$key]);
-		unset($this->parameterTypes[$key]);
-	}
+        unset($this->parameterArray[$key]);
+        unset($this->parameterTypes[$key]);
+    }
 
     /**
      * Returns type of the passed parameter: POST or GET.
      * @param $name
      * @return string
      */
-	public function getParameterType(string $name): string
-	{
-		return $this->parameterTypes[$name];
-	}
-
-	public function asArray(): array
+    public function getParameterType(string $name): string
     {
-		return $this->parameterArray;
-	}
+        return $this->parameterTypes[$name];
+    }
 
-	public function asArrayAll(): array
+    public function asArray(): array
     {
-		return $this->allParameters;
-	}
+        return $this->parameterArray;
+    }
 
-	public function addParameter(string $key, string $value, ?string $type=null): void
+    public function asArrayAll(): array
+    {
+        return $this->allParameters;
+    }
+
+    public function addParameter(string $key, string $value, ?string $type=null): void
     {
         $this->parameterArray["$key"] = $value;
         $this->parameterTypes["$key"] = $type;
         $this->allParameters[$type][$key] = $value;
-	}
+    }
 
-	public function numberOfParameters(): int
+    public function numberOfParameters(): int
     {
-		return count($this->parameterArray);
-	}
+        return count($this->parameterArray);
+    }
 
-	private function fixNewLines(string $text): string
+    private function fixNewLines(string $text): string
     {
-		$text = str_replace("\r\n", "\n", $text);
-		$text = str_replace("\r", "\n", $text);
-		return $text;
-	}
+        $text = str_replace("\r\n", "\n", $text);
+        $text = str_replace("\r", "\n", $text);
+        return $text;
+    }
 
-	public function getParametersByType(?string $type) {
-		$out = [];
-		foreach($this->parameterArray as $key => $value){
-			if($this->parameterTypes[$key] === $type){
-				$out[$key] = $value;
-			}
-		}
-		return $out;
-	}
+    public function getParametersByType(?string $type) {
+        $out = [];
+        foreach($this->parameterArray as $key => $value){
+            if($this->parameterTypes[$key] === $type){
+                $out[$key] = $value;
+            }
+        }
+        return $out;
+    }
 
-	public function resolveParameter(string $key, string $from) {
-		if(isset($this->allParameters[$from][$key])) {
-			return $this->allParameters[$from][$key];
-		} else {
- 			return null;
-		}
-	}
+    public function resolveParameter(string $key, string $from) {
+        if(isset($this->allParameters[$from][$key])) {
+            return $this->allParameters[$from][$key];
+        } else {
+             return null;
+        }
+    }
 }

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -155,7 +155,7 @@ class ParameterList {
 
     /**
      * Returns type of the passed parameter: POST or GET.
-     * @param $name
+     * @param string $name
      * @return string
      */
     public function getParameterType(string $name): string

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -110,14 +110,8 @@ class ParameterList {
             return intvalue($value);
         }
 
-        // Boolean
-        $bool = self::convertBool($value);
-        if ($bool !== null) {
-            return $bool;
-        }
-
-        // String
-        return $value;
+        // Boolean, or String (fallback)
+        return self::convertBool($value) ?? $value;
     }
 
     private static function convertBool(string $value): ?bool

--- a/web/lib/ozoneframework/php/core/ParameterList.php
+++ b/web/lib/ozoneframework/php/core/ParameterList.php
@@ -205,10 +205,6 @@ class ParameterList {
     }
 
     public function resolveParameter(string $key, string $from) {
-        if(isset($this->allParameters[$from][$key])) {
-            return $this->allParameters[$from][$key];
-        } else {
-             return null;
-        }
+        return $this->allParameters[$from][$key] ?? null;
     }
 }

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -12,24 +12,21 @@ class PageRedirectModule extends SmartyModule
     public function build($runData)
     {
         $pl = $runData->getParameterList();
-
-        $noRedirect = $pl->getParameterValueBoolean("noredirect");
+        $redirect = !$pl->getParameterValueBoolean("noredirect");
 
         if ($runData->isAjaxMode()) {
-            $noRedirect = true;
+            $redirect = false;
         }
 
         $target = trim($pl->getParameterValue("destination"));
 
-        if ($target == "") {
+        if ($target === '') {
             throw new ProcessException(_('No redirection destination specified. Please use the destination="page-name" or destination="url" attribute.'));
         }
 
         $currentUri = $_SERVER['REQUEST_URI'];
 
-        if (!$noRedirect) {
-            // ok, redirect!!!
-
+        if ($redirect) {
             // check if mapping should be done.
             if ($target[strlen($target)-1] === '/' && strpos($currentUri, '/', 1)) {
                 $map = true;

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -44,7 +44,7 @@ class PageRedirectModule extends SmartyModule
     private static function shouldRedirect($value): bool
     {
         // Null means the key only was included, which here means true.
-        $noredirect = $value === true || $value === null;
+        $noredirect = $value === true || $value === '';
         return !$noredirect;
     }
 }

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -27,6 +27,7 @@ class PageRedirectModule extends SmartyModule
         $currentUri = $_SERVER['REQUEST_URI'];
 
         if ($redirect) {
+            // NOTE(aismallard): this basically preserves the parameter list (e.g. /edit/true, etc.)
             // check if mapping should be done.
             if ($target[strlen($target)-1] === '/' && strpos($currentUri, '/', 1)) {
                 $map = true;

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -13,7 +13,7 @@ class PageRedirectModule extends SmartyModule
     public function build($runData)
     {
         $pl = $runData->getParameterList();
-        $noredirectFlag = $pl->getParameterValueBoolean('noredirect');
+        $noredirectFlag = $pl->getParameterValue('noredirect');
         $redirect = $noredirectFlag !== true && $noredirectFlag !== '';
 
         if ($runData->isAjaxMode()) {

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -13,14 +13,13 @@ class PageRedirectModule extends SmartyModule
     public function build($runData)
     {
         $pl = $runData->getParameterList();
-        $redirect = !$pl->getParameterValueBoolean("noredirect");
+        $redirect = $this->shouldRedirect($pl->getParameterValueBoolean("noredirect"));
 
         if ($runData->isAjaxMode()) {
             $redirect = false;
         }
 
         $target = trim($pl->getParameterValue("destination"));
-
         if ($target === '') {
             throw new ProcessException(_('No redirection destination specified. Please use the destination="page-name" or destination="url" attribute.'));
         }
@@ -40,5 +39,12 @@ class PageRedirectModule extends SmartyModule
         } else {
             $runData->contextAdd("target", $target);
         }
+    }
+
+    private static function shouldRedirect($value): bool
+    {
+        // Null means the key only was included, which here means true.
+        $noredirect = $value === true || $value === null;
+        return !$noredirect;
     }
 }

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -13,7 +13,7 @@ class PageRedirectModule extends SmartyModule
     {
         $pl = $runData->getParameterList();
 
-        $noRedirect = (bool) $pl->getParameterValue("noredirect");
+        $noRedirect = $pl->getParameterValueBoolean("noredirect");
 
         if ($runData->isAjaxMode()) {
             $noRedirect = true;

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -5,6 +5,7 @@ namespace Wikidot\Modules\Wiki\Redirect;
 use Ozone\Framework\SmartyModule;
 use Wikidot\Utils\ProcessException;
 use Wikidot\Utils\WDStringUtils;
+use Wikijump\Helpers\LegacyTools;
 
 class PageRedirectModule extends SmartyModule
 {
@@ -27,29 +28,10 @@ class PageRedirectModule extends SmartyModule
         $currentUri = $_SERVER['REQUEST_URI'];
 
         if ($redirect) {
-            // NOTE(aismallard): this basically preserves the parameter list (e.g. /edit/true, etc.)
-            // check if mapping should be done.
-            if ($target[strlen($target)-1] === '/' && strpos($currentUri, '/', 1)) {
-                $map = true;
-            } else {
-                $map = false;
-            }
-
-            // check if $target is an URI or just a page name
+            // Check if $target is an URI or just a page name
             if (!strpos($target, '://')) {
                 $target = WDStringUtils::toUnixName($target);
-                $target = '/'.$target;
-                if ($map) {
-                    $target .= '/';
-                }
-            }
-
-            if ($map) {
-                // use more advanced mapping
-
-                //strip page name and take the remaining part
-                $mappedUri = substr($currentUri, strpos($currentUri, '/', 1)+1);
-                $target .= $mappedUri;
+                $target = '/' . $target . LegacyTools::getPageParameters();
             }
 
             header('HTTP/1.1 301 Moved Permanently');

--- a/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
+++ b/web/php/Modules/Wiki/Redirect/PageRedirectModule.php
@@ -13,7 +13,8 @@ class PageRedirectModule extends SmartyModule
     public function build($runData)
     {
         $pl = $runData->getParameterList();
-        $redirect = $this->shouldRedirect($pl->getParameterValueBoolean("noredirect"));
+        $noredirectFlag = $pl->getParameterValueBoolean('noredirect');
+        $redirect = $noredirectFlag !== true && $noredirectFlag !== '';
 
         if ($runData->isAjaxMode()) {
             $redirect = false;
@@ -39,12 +40,5 @@ class PageRedirectModule extends SmartyModule
         } else {
             $runData->contextAdd("target", $target);
         }
-    }
-
-    private static function shouldRedirect($value): bool
-    {
-        // Null means the key only was included, which here means true.
-        $noredirect = $value === true || $value === '';
-        return !$noredirect;
     }
 }


### PR DESCRIPTION
As described in [WJ-51](https://scuttle.atlassian.net/browse/WJ-51), it's always been awkward that you need to say `/some-page/noredirect/true` for the redirect to not take effect, even though `/some-page/noredirect` should seem like it stops redirection. It's worse because `/some-page/noredirect/false` is the same as if it were `true`.

This changes this, with smarter parsing of parameter keys and values based on [`wikidot-path`](https://github.com/scpwiki/wikidot-path). It permits empty values, and actually casts the type based on its value, such as producing a boolean `true`/`false` value if appropriate.

In the future we may want a nicer mapping of permitted keys and what types they want, but for now this is a nice improvement.

Test visiting `https://www.wikijump.test/redir/noredirect`:
![image](https://user-images.githubusercontent.com/8848022/132448154-7da25aa9-9f29-4ccd-a39f-3de8fa131207.png)
