### PR TITLE
[WJ-488] Don't use <tt> for monospace container

### DIFF
--- a/ftml/conf/blocks.toml
+++ b/ftml/conf/blocks.toml
@@ -201,7 +201,7 @@ aliases = ["tt", "mono"]
 head = "map"
 body = "elements"
 html-attributes = true
-html-output = "html,tt"
+html-output = "html,code,wj-monospace"
 
 [paragraph]
 aliases = ["p"]

--- a/ftml/misc/ftml-base.css
+++ b/ftml/misc/ftml-base.css
@@ -48,6 +48,8 @@ code,
 
 /* MODIFIERS */
 
+.wj-monospace {}
+
 .wj-hidden {
     display: none;
 }

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -127,7 +127,7 @@ impl ContainerType {
             ContainerType::Superscript => HtmlTag::new("sup"),
             ContainerType::Subscript => HtmlTag::new("sub"),
             ContainerType::Strikethrough => HtmlTag::new("s"),
-            ContainerType::Monospace => HtmlTag::new("tt"),
+            ContainerType::Monospace => HtmlTag::with_class("code", "wj-monospace"),
             ContainerType::Span => HtmlTag::new("span"),
             ContainerType::Div => HtmlTag::new("div"),
             ContainerType::Mark => HtmlTag::new("mark"),

--- a/ftml/test/bold-nested.html
+++ b/ftml/test/bold-nested.html
@@ -1,1 +1,1 @@
-<p><strong>Apple <em>Banana <u>Cherry</u> Durian <sup>Peach <tt>Melon <sub>Blackberry</sub></tt></sup></em> Mango</strong> Pineapple</p>
+<p><strong>Apple <em>Banana <u>Cherry</u> Durian <sup>Peach <code class="wj-monospace">Melon <sub>Blackberry</sub></code></sup></em> Mango</strong> Pineapple</p>

--- a/ftml/test/monospace-block-alias-1.html
+++ b/ftml/test/monospace-block-alias-1.html
@@ -1,1 +1,1 @@
-<p><tt>Test!</tt></p>
+<p><code class="wj-monospace">Test!</code></p>

--- a/ftml/test/monospace-block-alias-2.html
+++ b/ftml/test/monospace-block-alias-2.html
@@ -1,1 +1,1 @@
-<p><tt>Test!</tt></p>
+<p><code class="wj-monospace">Test!</code></p>

--- a/ftml/test/monospace-block-empty.html
+++ b/ftml/test/monospace-block-empty.html
@@ -1,1 +1,1 @@
-<p>Empty <tt></tt></p>
+<p>Empty <code class="wj-monospace"></code></p>

--- a/ftml/test/monospace-block-italics.html
+++ b/ftml/test/monospace-block-italics.html
@@ -1,1 +1,1 @@
-<p><tt>Apple <strong>Banana</strong></tt> Cherry</p>
+<p><code class="wj-monospace">Apple <strong>Banana</strong></code> Cherry</p>

--- a/ftml/test/monospace-block-paragraph.html
+++ b/ftml/test/monospace-block-paragraph.html
@@ -1,1 +1,1 @@
-<p><tt>Paragraph<br>Subscript</tt></p>
+<p><code class="wj-monospace">Paragraph<br>Subscript</code></p>

--- a/ftml/test/monospace-block.html
+++ b/ftml/test/monospace-block.html
@@ -1,1 +1,1 @@
-<p><tt>Subscript</tt> Text</p>
+<p><code class="wj-monospace">Subscript</code> Text</p>

--- a/ftml/test/monospace.html
+++ b/ftml/test/monospace.html
@@ -1,1 +1,1 @@
-<p><tt>Monospace</tt> Text</p>
+<p><code class="wj-monospace">Monospace</code> Text</p>


### PR DESCRIPTION
This replaces the use of `<tt>` for HTML rendering for `ContainerType::Monospace` with `<code class="wj-monospace">`. This was done because [`<tt>` is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt).