### PR TITLE
[WJ-807] Configure dependabot for automatic package updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,7 +10,7 @@ updates:
 
   # Frontend
   - package-ecosystem: npm
-    directory: '/client
+    directory: '/client'
     schedule:
       interval: daily
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+# Config documentation: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Laravel
+  - package-ecosystem: composer
+    directory: '/web'
+    schedule:
+      interval: weekly  # Eventually change to 'daily'
+
+  # Frontend
+  - package-ecosystem: npm
+    directory: '/client
+    schedule:
+      interval: daily
+
+  # FTML
+  - package-ecosystem: cargo
+    directory: '/ftml'
+    schedule:
+      interval: daily


### PR DESCRIPTION
We previously didn't have a `dependabot.yaml`, so WJ-807 asks that we make one.