### PR TITLE
Make all vendored files binary

### DIFF
--- a/client/.gitattributes
+++ b/client/.gitattributes
@@ -1,2 +1,3 @@
-pnpm-lock.yaml         merge=binary
+pnpm-lock.yaml         binary
+vendor/                binary
 *.json                 linguist-language=JSON-with-Comments

--- a/client/modules/ftml-wasm/.gitattributes
+++ b/client/modules/ftml-wasm/.gitattributes
@@ -1,1 +1,0 @@
-vendor/* binary

--- a/client/modules/wj-prism/.gitattributes
+++ b/client/modules/wj-prism/.gitattributes
@@ -1,1 +1,0 @@
-vendor/* binary


### PR DESCRIPTION
This centralizes the `.gitattributes` files so that everything in `vendor/` directories are considered binary.