### PR TITLE
Update rustc version

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "wikidot-normalize"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439561319fd3f8a28f27f231c1ee16fea40f3858cce4239040b8072067e4800c"
+checksum = "d588fdb14aa51e8a5dc3e3b90cdc54dfedf93828d8fb638180cd5b3a92f15d76"
 dependencies = [
  "lazy_static",
  "maplit",

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -27,7 +27,7 @@ The lint `#![deny(unsafe_code)]` is set, and therefore this crate has only safe 
 Available under the terms of the GNU Affero General Public License. See [LICENSE.md](LICENSE.md).
 
 ### Compilation
-This library targets the latest stable Rust. At time of writing, that is `1.54.0`.
+This library targets the latest stable Rust. At time of writing, that is `1.55.0`.
 
 ```sh
 $ cargo build --release


### PR DESCRIPTION
[Rust 1.55.0 was released](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html).