### PR TITLE
Replace slog-mock with full dummy macros

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -324,7 +324,6 @@ dependencies = [
  "serde_repr",
  "slog",
  "slog-bunyan",
- "slog-mock",
  "sloggers",
  "str-macro",
  "strum",
@@ -979,25 +978,6 @@ checksum = "ae939ed7d169eed9699f4f5cd440f046f5dc5dfc27c19e3cd311619594c175e0"
 dependencies = [
  "regex",
  "slog",
-]
-
-[[package]]
-name = "slog-mock"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc48a71f0881128ea552942968e461da5e0231635a35153e91102c184005806"
-dependencies = [
- "slog-mock-proc-macros",
-]
-
-[[package]]
-name = "slog-mock-proc-macros"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ce8051ef748381b9e6410dce2c1b533e584f700617028a04cef9db9cbd238"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -42,7 +42,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
 slog = { version = "2.7", features = ["max_level_trace"], optional = true }
-slog-mock = "0.4"
 str-macro = "1"
 strum = "0.21"
 strum_macros = "0.21"

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -55,11 +55,11 @@ pub fn parse_include_block<'t>(
             // Adjust offset and return
             Ok((include, start + span.end()))
         }
-        Err(error) => {
+        Err(_error) => {
             debug!(
                 log,
                 "Include block was invalid";
-                "error" => str!(error),
+                "error" => str!(_error),
                 "start" => start,
                 "slice" => text,
             );

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -122,10 +122,6 @@ extern crate str_macro;
 #[macro_use]
 extern crate slog;
 
-#[cfg(not(feature = "log"))]
-#[macro_use]
-extern crate slog_mock;
-
 // Library top-level modules
 
 #[cfg(test)]

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -93,7 +93,57 @@ cfg_if! {
         #[macro_use]
         #[allow(unused_macros)]
         mod macros {
-            // Dummy filename/lineno macros
+            // Logging levels
+            macro_rules! crit {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            macro_rules! error {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            macro_rules! warn {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            macro_rules! info {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            macro_rules! debug {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            macro_rules! trace {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            // Logging helpers
+            macro_rules! slog_o {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
+            // Alias for slog_o!
+            macro_rules! o {
+                ($($input:tt)*) => {
+                    ()
+                };
+            }
+
             macro_rules! slog_filename {
                 () => {
                     ()

--- a/ftml/src/log.rs
+++ b/ftml/src/log.rs
@@ -95,39 +95,51 @@ cfg_if! {
         mod macros {
             // Logging levels
             macro_rules! crit {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             macro_rules! error {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             macro_rules! warn {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             macro_rules! info {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             macro_rules! debug {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             macro_rules! trace {
-                ($($input:tt)*) => {
+                ($log:expr, $($input:tt)*) => {{
+                    let _ = $log;
+
                     ()
-                };
+                }};
             }
 
             // Logging helpers

--- a/ftml/src/parsing/collect/generic.rs
+++ b/ftml/src/parsing/collect/generic.rs
@@ -63,7 +63,7 @@ use super::prelude::*;
 pub fn collect<'p, 'r, 't, F>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
-    rule: Rule,
+    _rule: Rule,
     close_conditions: &[ParseCondition],
     invalid_conditions: &[ParseCondition],
     warn_kind: Option<ParseWarningKind>,
@@ -74,18 +74,16 @@ where
 {
     // Log collect_until() call
     let log = {
-        let ExtractedToken { token, slice, span } = parser.current();
-
         &log.new(slog_o!(
-            "rule" => str!(rule.name()),
-            "token" => str!(token.name()),
-            "slice" => str!(slice),
-            "span" => SpanWrap::from(span),
+            "rule" => str!(_rule.name()),
+            "token" => str!(parser.current().token.name()),
+            "slice" => str!(parser.current().slice),
+            "span" => SpanWrap::from(parser.current().span),
             "remaining-len" => parser.remaining().len(),
         ))
     };
 
-    info!(log, "Trying to collect tokens for rule {:?}", rule);
+    info!(log, "Trying to collect tokens for rule {:?}", _rule);
 
     let mut exceptions = Vec::new();
     let mut paragraph_safe = true;

--- a/ftml/src/parsing/collect/generic.rs
+++ b/ftml/src/parsing/collect/generic.rs
@@ -74,11 +74,17 @@ where
 {
     // Log collect_until() call
     let log = {
+        let ExtractedToken {
+            token: _token,
+            slice: _slice,
+            span: _span,
+        } = parser.current();
+
         &log.new(slog_o!(
             "rule" => str!(_rule.name()),
-            "token" => str!(parser.current().token.name()),
-            "slice" => str!(parser.current().slice),
-            "span" => SpanWrap::from(parser.current().span),
+            "token" => str!(_token.name()),
+            "slice" => str!(_slice),
+            "span" => SpanWrap::from(_span),
             "remaining-len" => parser.remaining().len(),
         ))
     };

--- a/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
@@ -44,9 +44,9 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     flag_star: bool,
     flag_score: bool,
-    in_head: bool,
+    _in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Found invalid include-messy block"; "in-head" => in_head);
+    debug!(log, "Found invalid include-messy block");
 
     assert!(!flag_star, "Include messy doesn't allow star flag");
     assert!(!flag_score, "Include messy doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -69,8 +69,8 @@ fn parse_count<'r, 't>(
             Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments))
         }
         Ok(value) => Ok(value),
-        Err(error) => {
-            debug!(&parser.log(), "Invalid numeric expression: {}", error);
+        Err(_error) => {
+            debug!(&parser.log(), "Invalid numeric expression: {}", _error);
 
             Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments))
         }

--- a/ftml/src/parsing/rule/impls/comment.rs
+++ b/ftml/src/parsing/rule/impls/comment.rs
@@ -35,14 +35,14 @@ fn try_consume_fn<'p, 'r, 't>(
     check_step(parser, Token::LeftComment)?;
 
     loop {
-        let ExtractedToken { token, span, slice } = parser.current();
+        let ExtractedToken { token, span: _span, slice: _slice } = parser.current();
 
         debug!(
             log,
             "Received token inside comment";
             "token" => token,
-            "slice" => slice,
-            "span" => SpanWrap::from(span),
+            "slice" => _slice,
+            "span" => SpanWrap::from(_span),
         );
 
         match token {

--- a/ftml/src/parsing/rule/impls/comment.rs
+++ b/ftml/src/parsing/rule/impls/comment.rs
@@ -35,7 +35,11 @@ fn try_consume_fn<'p, 'r, 't>(
     check_step(parser, Token::LeftComment)?;
 
     loop {
-        let ExtractedToken { token, span: _span, slice: _slice } = parser.current();
+        let ExtractedToken {
+            token,
+            span: _span,
+            slice: _slice,
+        } = parser.current();
 
         debug!(
             log,

--- a/ftml/src/parsing/rule/impls/raw.rs
+++ b/ftml/src/parsing/rule/impls/raw.rs
@@ -121,7 +121,11 @@ fn try_consume_fn<'p, 'r, 't>(
     };
 
     loop {
-        let ExtractedToken { token, slice: _slice, span: _span } = parser.current();
+        let ExtractedToken {
+            token,
+            slice: _slice,
+            span: _span,
+        } = parser.current();
 
         debug!(
             log,

--- a/ftml/src/parsing/rule/impls/raw.rs
+++ b/ftml/src/parsing/rule/impls/raw.rs
@@ -121,14 +121,14 @@ fn try_consume_fn<'p, 'r, 't>(
     };
 
     loop {
-        let ExtractedToken { token, span, slice } = parser.current();
+        let ExtractedToken { token, slice: _slice, span: _span } = parser.current();
 
         debug!(
             log,
             "Received token inside raw";
             "token" => token,
-            "slice" => slice,
-            "span" => SpanWrap::from(span),
+            "slice" => _slice,
+            "span" => SpanWrap::from(_span),
         );
 
         // Check token

--- a/ftml/src/parsing/token/mod.rs
+++ b/ftml/src/parsing/token/mod.rs
@@ -163,11 +163,11 @@ impl Token {
                 tokens.extend(pairs.map(|pair| Token::convert_pair(log, pair)));
                 tokens
             }
-            Err(error) => {
+            Err(_error) => {
                 // Return all of the input as one big raw text
                 // and log this as an error, since it shouldn't be happening
 
-                error!(log, "Error while lexing input in pest: {}", error);
+                error!(log, "Error while lexing input in pest: {}", _error);
 
                 vec![ExtractedToken {
                     token: Token::Other,

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -133,6 +133,8 @@ impl Handle {
             "message" => message,
         );
 
+        let _ = language;
+
         // TODO
         match message {
             "collapsible-open" => "+ open block",
@@ -151,8 +153,11 @@ impl Handle {
         }
     }
 
-    pub fn post_html(&self, log: &Logger, _info: &PageInfo, _html: &str) -> String {
+    pub fn post_html(&self, log: &Logger, info: &PageInfo, html: &str) -> String {
         debug!(log, "Submitting HTML to create iframe-able snippet");
+
+        let _ = info;
+        let _ = html;
 
         // TODO
         str!("https://example.com/")
@@ -165,6 +170,9 @@ impl Handle {
             "index" => index.get(),
             "code" => code,
         );
+
+        let _ = index;
+        let _ = code;
 
         // TODO
     }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -87,6 +87,7 @@ pub fn render_link(
     });
 }
 
+#[cfg(feature = "log")]
 fn target_str(target: Option<AnchorTarget>) -> &'static str {
     match target {
         Some(target) => target.name(),

--- a/ftml/src/text.rs
+++ b/ftml/src/text.rs
@@ -97,14 +97,14 @@ impl<'t> FullText<'t> {
     fn slice_impl(
         &self,
         log: &Logger,
-        slice_kind: &'static str,
+        _slice_kind: &'static str,
         start: usize,
         end: usize,
     ) -> &'t str {
         info!(
             log,
             "Extracting {} slice from full text",
-            slice_kind;
+            _slice_kind;
             "start" => start,
             "end" => end,
         );


### PR DESCRIPTION
The now-decommissioned [`slog-mock`](https://github.com/ammongit/slog-mock) crate would take in slog macros and then produce code which essentially took every argument and did `let _ = <item>;` to it. This would prevent unused value warnings when compiling without logging.

However, the compiler does not actually remove that code, it still runs it (since there could potentially be side effects), so it wasn't compiling out all formatting and debug code like expected. This PR replaces all the slog macros with empty ones which truly have no output. This means that all values used in logging were unused, which this PR addresses by marking them as such for both variants (i.e. making them `_variable`s).

With this merged, all logging code should truly be removed when the `log` feature is disabled. This should have performance benefits, especially for ftml.

There were also unexpected discoveries, such as a revealing a bug which was fixed in #417.