### PR TITLE
[WJ-803] Update logging levels

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-slog = { version = "2.7", features = ["max_level_trace"], optional = true }
+slog = { version = "2.7", optional = true }
 str-macro = "1"
 strum = "0.21"
 strum_macros = "0.21"

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -91,7 +91,7 @@ where
                 ranges.push(start..end);
                 includes.push(include);
             }
-            Err(_) => debug!(log, "Unable to parse include regex match"),
+            Err(_) => warn!(log, "Unable to parse include regex match"),
         }
     }
 
@@ -122,7 +122,7 @@ where
     for ((range, include), fetched) in joined_iter {
         let (page_ref, _) = include.into();
 
-        debug!(
+        info!(
             log,
             "Replacing range for included page";
             "span" => SpanWrap::from(&range),

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -111,15 +111,15 @@ where
     let includes_iter = includes.into_iter();
     let fetched_iter = fetched_pages.into_iter();
 
+    let joined_iter = ranges_iter.zip(includes_iter).zip(fetched_iter).rev();
+
     // Borrowing from the original text and doing in-place insertions
     // will not work here. We are trying to both return the page names
     // (slices from the input string), and replace it with new content.
     let mut output = String::from(input);
     let mut pages = Vec::new();
 
-    for ((range, include), fetched) in
-        ranges_iter.zip(includes_iter).zip(fetched_iter).rev()
-    {
+    for ((range, include), fetched) in joined_iter {
         let (page_ref, _) = include.into();
 
         debug!(

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -42,7 +42,7 @@ pub fn parse_include_block<'t>(
             let first = pairs.next().expect("No pairs returned on successful parse");
             let span = first.as_span();
 
-            debug!(
+            info!(
                 log,
                 "Parsed include block";
                 "span" => SpanWrap::from(span.start()..span.end()),
@@ -56,7 +56,7 @@ pub fn parse_include_block<'t>(
             Ok((include, start + span.end()))
         }
         Err(_error) => {
-            debug!(
+            warn!(
                 log,
                 "Include block was invalid";
                 "error" => str!(_error),
@@ -76,7 +76,7 @@ fn process_pairs<'t>(
     let page_raw = pairs.next().ok_or(IncludeParseError)?.as_str();
     let page_ref = PageRef::parse(page_raw)?;
 
-    trace!(
+    debug!(
         log,
         "Got page for include";
         "site" => page_ref.site(),

--- a/ftml/src/parsing/collect/text.rs
+++ b/ftml/src/parsing/collect/text.rs
@@ -82,7 +82,7 @@ where
         invalid_conditions,
         warn_kind,
         |log, parser| {
-            trace!(log, "Ingesting token in string span");
+            debug!(log, "Ingesting token in string span");
 
             end = Some(parser.current());
             ok!(true; ())

--- a/ftml/src/parsing/consume.rs
+++ b/ftml/src/parsing/consume.rs
@@ -85,7 +85,7 @@ pub fn consume<'p, 'r, 't>(
                 return Ok(output);
             }
             Err(warning) => {
-                trace!(
+                warn!(
                     log,
                     "Rule failed, returning warning";
                     "warning" => warning.kind().name(),
@@ -96,18 +96,18 @@ pub fn consume<'p, 'r, 't>(
         }
     }
 
-    debug!(log, "All rules exhausted, using generic text fallback");
+    warn!(log, "All rules exhausted, using generic text fallback");
     let element = text!(current.slice);
     parser.step()?;
 
     // We should only carry styles over from *successful* consumptions
-    trace!(log, "Removing non-warnings from exceptions list");
+    debug!(log, "Removing non-warnings from exceptions list");
     all_exceptions.retain(|exception| matches!(exception, ParseException::Warning(_)));
 
     // If we've hit the recursion limit, just bail
     if let Some(ParseException::Warning(warning)) = all_exceptions.last() {
         if warning.kind() == ParseWarningKind::RecursionDepthExceeded {
-            trace!(log, "Found recursion depth error, failing");
+            error!(log, "Found recursion depth error, failing");
             return Err(warning.clone());
         }
     }

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -92,7 +92,7 @@ where
     // For producing table of contents indexes
     let mut incrementer = Incrementer(0);
 
-    debug!(log, "Finished paragraph gathering, matching on consumption");
+    info!(log, "Finished paragraph gathering, matching on consumption");
     match result {
         Ok(ParseSuccess {
             item: mut elements,
@@ -122,7 +122,7 @@ where
             // Add a footnote block at the end,
             // if the user doesn't have one already
             if !has_footnote_block {
-                debug!(log, "No footnote block in elements, appending one");
+                info!(log, "No footnote block in elements, appending one");
 
                 elements.push(Element::FootnoteBlock {
                     title: None,
@@ -144,7 +144,7 @@ where
             // If this happens, then just return the input source as the output
             // and the warning.
 
-            warn!(
+            crit!(
                 log,
                 "Fatal error occurred at highest-level parsing: {:#?}", warning,
             );

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -146,7 +146,8 @@ where
 
             crit!(
                 log,
-                "Fatal error occurred at highest-level parsing: {:#?}", warning,
+                "Fatal error occurred at highest-level parsing: {:#?}",
+                warning,
             );
 
             let wikitext = tokenization.full_text().inner();

--- a/ftml/src/parsing/paragraph/mod.rs
+++ b/ftml/src/parsing/paragraph/mod.rs
@@ -76,14 +76,14 @@ where
                     //
                     // Pass a warning up the chain
 
-                    debug!(log, "Hit the end of input, producing warning");
+                    warn!(log, "Hit the end of input, producing warning");
 
                     return Err(parser.make_warn(ParseWarningKind::EndOfInput));
                 } else {
                     // Avoid an unnecessary Element::Null and just exit
                     // If there's no close condition, then this is not a warning
 
-                    debug!(log, "Hit the end of input, terminating token iteration");
+                    warn!(log, "Hit the end of input, terminating token iteration");
 
                     break;
                 }
@@ -91,7 +91,7 @@ where
 
             // If we've hit a paragraph break, then finish the current paragraph
             Token::ParagraphBreak => {
-                debug!(
+                info!(
                     log,
                     "Hit a paragraph break, creating a new paragraph container",
                 );
@@ -110,7 +110,7 @@ where
             _ => {
                 if let Some(ref mut close_condition_fn) = close_condition_fn {
                     if close_condition_fn(parser).unwrap_or(false) {
-                        debug!(
+                        info!(
                             log,
                             "Hit closing condition for paragraphs, terminating token iteration",
                         );

--- a/ftml/src/parsing/paragraph/stack.rs
+++ b/ftml/src/parsing/paragraph/stack.rs
@@ -60,7 +60,7 @@ impl<'t> ParagraphStack<'t> {
 
     #[inline]
     pub fn push_element(&mut self, element: Element<'t>, paragraph_safe: bool) {
-        debug!(
+        info!(
             self.log,
             "Pushing element to stack";
             "element" => element.name(),
@@ -82,7 +82,7 @@ impl<'t> ParagraphStack<'t> {
 
     #[inline]
     pub fn push_exceptions(&mut self, exceptions: &mut Vec<ParseException<'t>>) {
-        debug!(
+        info!(
             self.log,
             "Pushing exception to stack";
             "exceptions-len" => exceptions.len(),
@@ -116,7 +116,7 @@ impl<'t> ParagraphStack<'t> {
 
         // Don't create empty paragraphs
         if self.current.is_empty() {
-            trace!(
+            debug!(
                 self.log,
                 "No paragraph created, no pending elements in stack",
             );
@@ -149,7 +149,7 @@ impl<'t> ParagraphStack<'t> {
     /// This returns all collected elements, exceptions, and returns the final
     /// paragraph safety value.
     pub fn into_result<'r>(mut self) -> ParseResult<'r, 't, Vec<Element<'t>>> {
-        debug!(
+        info!(
             self.log,
             "Converting paragraph parse stack into ParseResult",
         );
@@ -183,7 +183,7 @@ impl<'t> ParagraphStack<'t> {
     /// and either have an alternate means of determining paragraph safety, or
     /// statically know what that value would be.
     pub fn into_elements(mut self) -> Vec<Element<'t>> {
-        debug!(
+        info!(
             self.log,
             "Converting paragraph parse stack into a Vec<Element>",
         );

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -253,7 +253,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     // State evaluation
     pub fn evaluate(&self, condition: ParseCondition) -> bool {
-        debug!(
+        info!(
             &self.log,
             "Evaluating parser condition";
             "current-token" => self.current.token,
@@ -265,7 +265,7 @@ impl<'r, 't> Parser<'r, 't> {
             ParseCondition::CurrentToken(token) => self.current.token == token,
             ParseCondition::TokenPair(current, next) => {
                 if self.current().token != current {
-                    trace!(
+                    debug!(
                         &self.log,
                         "Current token in pair doesn't match, failing";
                         "expected" => current,
@@ -278,7 +278,7 @@ impl<'r, 't> Parser<'r, 't> {
                 match self.look_ahead(0) {
                     Some(actual) => {
                         if actual.token != next {
-                            trace!(
+                            debug!(
                                 &self.log,
                                 "Second token in pair doesn't match, failing";
                                 "expected" => next,
@@ -289,7 +289,7 @@ impl<'r, 't> Parser<'r, 't> {
                         }
                     }
                     None => {
-                        trace!(
+                        debug!(
                             &self.log,
                             "Second token in pair doesn't exist, failing";
                             "expected" => next,
@@ -306,7 +306,7 @@ impl<'r, 't> Parser<'r, 't> {
 
     #[inline]
     pub fn evaluate_any(&self, conditions: &[ParseCondition]) -> bool {
-        trace!(
+        info!(
             &self.log,
             "Evaluating to see if any parser condition is true";
             "conditions-len" => conditions.len(),
@@ -320,7 +320,7 @@ impl<'r, 't> Parser<'r, 't> {
     where
         F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseWarning>,
     {
-        debug!(&self.log, "Evaluating closure for parser condition");
+        info!(&self.log, "Evaluating closure for parser condition");
 
         f(&mut self.clone()).unwrap_or(false)
     }
@@ -329,7 +329,7 @@ impl<'r, 't> Parser<'r, 't> {
     where
         F: FnOnce(&mut Parser<'r, 't>) -> Result<bool, ParseWarning>,
     {
-        debug!(
+        info!(
             &self.log,
             "Evaluating closure for parser condition, saving progress on success",
         );
@@ -393,7 +393,7 @@ impl<'r, 't> Parser<'r, 't> {
                 Ok(current)
             }
             None => {
-                trace!(
+                warn!(
                     self.log,
                     "Exhausted all tokens, yielding end of input warning",
                 );

--- a/ftml/src/parsing/rule/impls/block/blocks/align.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align.rs
@@ -66,7 +66,7 @@ pub fn parse_alignment_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing alignment block";
         "block-rule" => block_rule.name,

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing anchor block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing blockquote block"; "in-head" => in_head);
+    info!(log, "Parsing blockquote block"; "in-head" => in_head);
 
     assert!(!flag_star, "Blockquote doesn't allow star flag");
     assert!(!flag_score, "Blockquote doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing bold block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -56,7 +56,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing character / HTML entity block"; "in-head" => in_head);
+    info!(log, "Parsing character / HTML entity block"; "in-head" => in_head);
 
     assert!(!flag_star, "Char doesn't allow star flag");
     assert!(!flag_score, "Char doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing checkbox block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing code block"; "in-head" => in_head);
+    info!(log, "Parsing code block"; "in-head" => in_head);
 
     assert!(!flag_star, "Code doesn't allow star flag");
     assert!(!flag_score, "Code doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing collapsible block";
         "in-head" => in_head,
@@ -98,7 +98,7 @@ fn parse_hide_location(s: &str, parser: &Parser) -> Result<(bool, bool), ParseWa
         }
     }
 
-    debug!(&parser.log(), "Unknown hideLocation argument"; "value" => s);
+    warn!(&parser.log(), "Unknown hideLocation argument"; "value" => s);
 
     Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments))
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/css.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing CSS block"; "in-head" => in_head);
+    info!(log, "Parsing CSS block"; "in-head" => in_head);
 
     assert!(!flag_star, "CSS doesn't allow star flag");
     assert!(!flag_score, "CSS doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing deletion block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing div block";
         "flag-score" => flag_score,

--- a/ftml/src/parsing/rule/impls/block/blocks/footnote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/footnote.rs
@@ -47,7 +47,7 @@ fn parse_footnote_ref<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing footnote ref block";
         "in-head" => in_head,
@@ -107,7 +107,7 @@ fn parse_footnote_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing footnote list block";
         "in-head" => in_head,
@@ -124,7 +124,7 @@ fn parse_footnote_block<'r, 't>(
     let hide = arguments.get_bool(parser, "hide")?.unwrap_or(false);
 
     if !arguments.is_empty() {
-        debug!(
+        warn!(
             log,
             "Invalid argument keys found";
             "arguments" => format!("{:#?}", arguments),

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing hidden block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/html.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/html.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing HTML block"; "in-head" => in_head);
+    info!(log, "Parsing HTML block"; "in-head" => in_head);
 
     assert!(!flag_star, "HTML doesn't allow star flag");
     assert!(!flag_score, "HTML doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/ifcategory.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ifcategory.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing ifcategory block";
         "in-head" => in_head,
@@ -86,11 +86,11 @@ fn parse_fn<'r, 't>(
 
     // Return elements based on condition
     let elements = if check_ifcategory(log, parser.page_info(), &conditions) {
-        trace!(log, "Conditions passed, including elements");
+        debug!(log, "Conditions passed, including elements");
 
         Elements::Multiple(elements)
     } else {
-        trace!(log, "Conditions failed, excluding elements");
+        debug!(log, "Conditions failed, excluding elements");
 
         // Filter out non-warning exceptions
         exceptions.retain(|ex| matches!(ex, ParseException::Warning(_)));

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing iframe block"; "in-head" => in_head);
+    info!(log, "Parsing iframe block"; "in-head" => in_head);
 
     assert!(!flag_star, "iframe doesn't allow star flag");
     assert!(!flag_score, "iframe doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/iftags.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iftags.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing iftags block";
         "in-head" => in_head,
@@ -70,11 +70,11 @@ fn parse_fn<'r, 't>(
 
     // Return elements based on condition
     let elements = if check_iftags(log, parser.page_info(), &conditions) {
-        trace!(log, "Conditions passed, including elements");
+        debug!(log, "Conditions passed, including elements");
 
         Elements::Multiple(elements)
     } else {
-        trace!(log, "Conditions failed, excluding elements");
+        debug!(log, "Conditions failed, excluding elements");
 
         // Filter out non-warning exceptions
         exceptions.retain(|ex| matches!(ex, ParseException::Warning(_)));

--- a/ftml/src/parsing/rule/impls/block/blocks/image.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/image.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing image block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/include_elements.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include_elements.rs
@@ -43,7 +43,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Found invalid include-elements block");
+    info!(log, "Found invalid include-elements block");
 
     assert!(!flag_star, "Include (elements) doesn't allow star flag");
     assert!(!flag_score, "Include (elements) doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
@@ -46,7 +46,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     _in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Found invalid include-messy block");
+    info!(log, "Found invalid include-messy block");
 
     assert!(!flag_star, "Include (messy) doesn't allow star flag");
     assert!(!flag_score, "Include (messy) doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing insertion block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing invisible block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing italics block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/later.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/later.rs
@@ -46,7 +46,7 @@ fn parse_fn<'r, 't>(
     _flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing later block (easter egg)"; "in-head" => in_head);
+    info!(log, "Parsing later block (easter egg)"; "in-head" => in_head);
 
     assert_block_name(&BLOCK_LATER, name);
     parser.get_head_none(&BLOCK_LATER, in_head)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing newlines block"; "in-head" => in_head);
+    info!(log, "Parsing newlines block"; "in-head" => in_head);
 
     assert!(!flag_star, "Lines doesn't allow star flag");
     assert!(!flag_score, "Lines doesn't allow score flag");
@@ -60,7 +60,7 @@ fn parse_count<'r, 't>(
 
     match argument.parse::<NonZeroU32>() {
         Ok(value) if value.get() > 100 => {
-            debug!(
+            warn!(
                 &parser.log(),
                 "Number of lines is too great (max 100)";
                 "lines" => value.get(),
@@ -70,7 +70,7 @@ fn parse_count<'r, 't>(
         }
         Ok(value) => Ok(value),
         Err(_error) => {
-            debug!(&parser.log(), "Invalid numeric expression: {}", _error);
+            warn!(&parser.log(), "Invalid numeric expression: {}", _error);
 
             Err(parser.make_warn(ParseWarningKind::BlockMalformedArguments))
         }

--- a/ftml/src/parsing/rule/impls/block/blocks/list.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/list.rs
@@ -101,7 +101,7 @@ fn parse_list_block<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing list block";
         "block-rule" => block_rule.name,
@@ -193,7 +193,7 @@ fn parse_list_item<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing list item block";
         "block-rule" => BLOCK_LI.name,

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing highlight block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing backlinks module");
+    info!(log, "Parsing backlinks module");
     assert_module_name(&MODULE_BACKLINKS, name);
 
     let page = arguments.get("page");

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing categories module");
+    info!(log, "Parsing categories module");
     assert_module_name(&MODULE_CATEGORIES, name);
 
     let include_hidden = arguments

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing categories module");
+    info!(log, "Parsing categories module");
     assert_module_name(&MODULE_CSS, name);
 
     let css = parser.get_body_text(&BLOCK_MODULE)?;

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing join module");
+    info!(log, "Parsing join module");
     assert_module_name(&MODULE_JOIN, name);
 
     let button_text = arguments.get("button");

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing PageTree module");
+    info!(log, "Parsing PageTree module");
     assert_module_name(&MODULE_PAGE_TREE, name);
 
     let root = arguments.get("root");

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
@@ -32,7 +32,7 @@ fn parse_fn<'r, 't>(
     name: &'t str,
     _arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
-    debug!(log, "Parsing categories module");
+    info!(log, "Parsing categories module");
     assert_module_name(&MODULE_RATE, name);
 
     ok!(false; Some(Module::Rate))

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing module block"; "in-head" => in_head);
+    info!(log, "Parsing module block"; "in-head" => in_head);
 
     assert!(!flag_star, "Module doesn't allow star flag");
     assert!(!flag_score, "Module doesn't allow score flag");

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing monospace block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing paragraph block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing radio button block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -39,7 +39,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing size block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing span block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing strikethrough block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing subscript block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing superscript block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/table.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/table.rs
@@ -83,7 +83,7 @@ where
     'r: 't,
     ParsedBlock<'t>: 't,
 {
-    debug!(
+    info!(
         log,
         "Parsing {} block",
         description;

--- a/ftml/src/parsing/rule/impls/block/blocks/toc.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/toc.rs
@@ -38,7 +38,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing table-of-contents block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing underline block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/blocks/user.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/user.rs
@@ -37,7 +37,7 @@ fn parse_fn<'r, 't>(
     flag_score: bool,
     in_head: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Parsing user block";
         "in-head" => in_head,

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -44,7 +44,7 @@ where
         token: Token,
         kind: ParseWarningKind,
     ) -> Result<&'t str, ParseWarning> {
-        trace!(
+        debug!(
             &self.log(),
             "Looking for token {:?} (warning {:?})",
             token,
@@ -64,7 +64,7 @@ where
     }
 
     fn get_optional_token(&mut self, token: Token) -> Result<(), ParseWarning> {
-        trace!(
+        debug!(
             &self.log(),
             "Looking for optional token";
             "token" => token,
@@ -78,18 +78,18 @@ where
     }
 
     pub fn get_optional_line_break(&mut self) -> Result<(), ParseWarning> {
-        debug!(&self.log(), "Looking for optional line break");
+        info!(&self.log(), "Looking for optional line break");
         self.get_optional_token(Token::LineBreak)
     }
 
     #[inline]
     pub fn get_optional_space(&mut self) -> Result<(), ParseWarning> {
-        debug!(&self.log(), "Looking for optional space");
+        info!(&self.log(), "Looking for optional space");
         self.get_optional_token(Token::Whitespace)
     }
 
     pub fn get_optional_spaces_any(&mut self) -> Result<(), ParseWarning> {
-        debug!(&self.log(), "Looking for optional spaces (any)");
+        info!(&self.log(), "Looking for optional spaces (any)");
 
         let tokens = &[
             Token::Whitespace,
@@ -112,7 +112,7 @@ where
         &mut self,
         flag_star: bool,
     ) -> Result<(&'t str, bool), ParseWarning> {
-        debug!(&self.log(), "Looking for identifier");
+        info!(&self.log(), "Looking for identifier");
 
         if flag_star {
             self.get_optional_token(Token::LeftBlockStar)?;
@@ -159,7 +159,7 @@ where
 
     /// Matches an ending block, returning the name present.
     pub fn get_end_block(&mut self) -> Result<&'t str, ParseWarning> {
-        debug!(&self.log(), "Looking for end block");
+        info!(&self.log(), "Looking for end block");
 
         self.get_token(Token::LeftBlockEnd, ParseWarningKind::BlockExpectedEnd)?;
         self.get_optional_space()?;
@@ -223,7 +223,7 @@ where
     where
         F: FnMut(&mut Parser<'r, 't>) -> Result<(), ParseWarning>,
     {
-        trace!(&self.log(), "Running generic in block body parser");
+        debug!(&self.log(), "Running generic in block body parser");
 
         debug_assert!(
             !block_rule.accepts_names.is_empty(),
@@ -264,7 +264,7 @@ where
         &mut self,
         block_rule: &BlockRule,
     ) -> Result<&'t str, ParseWarning> {
-        debug!(
+        info!(
             &self.log(),
             "Getting block body as text";
             "block-rule" => format!("{:#?}", block_rule),
@@ -282,7 +282,7 @@ where
         block_rule: &BlockRule,
         as_paragraphs: bool,
     ) -> ParseResult<'r, 't, Vec<Element<'t>>> {
-        debug!(
+        info!(
             &self.log(),
             "Getting block body as elements";
             "block-rule" => format!("{:#?}", block_rule),
@@ -444,7 +444,7 @@ where
         );
 
         if !in_head {
-            debug!(
+            warn!(
                 &self.log(),
                 "Block is already over, there is no name or arguments",
             );
@@ -471,7 +471,7 @@ where
     where
         F: FnOnce(&Self, Option<&'t str>) -> Result<T, ParseWarning>,
     {
-        debug!(
+        info!(
             &self.log(),
             "Looking for a value argument, then ']]'";
             "in-head" => in_head,
@@ -509,7 +509,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseWarning> {
-        debug!(&self.log(), "No arguments, looking for end of head block");
+        info!(&self.log(), "No arguments, looking for end of head block");
 
         self.get_optional_space()?;
         self.get_head_block(block_rule, in_head)?;
@@ -522,7 +522,7 @@ where
         block_rule: &BlockRule,
         in_head: bool,
     ) -> Result<(), ParseWarning> {
-        trace!(&self.log(), "Getting end of the head block");
+        debug!(&self.log(), "Getting end of the head block");
 
         // If we're still in the head, finish
         if in_head {

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -45,7 +45,7 @@ fn block_regular<'r, 't>(
     log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to process a block");
+    info!(log, "Trying to process a block");
 
     parse_block(log, parser, false)
 }
@@ -54,7 +54,7 @@ fn block_star<'r, 't>(
     log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to process a block (with star flag)");
+    info!(log, "Trying to process a block (with star flag)");
 
     parse_block(log, parser, true)
 }
@@ -63,7 +63,7 @@ fn block_skip<'r, 't>(
     log: &Logger,
     parser: &mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(
+    info!(
         log,
         "Trying to see if we skip a newline due to upcoming block",
     );
@@ -109,7 +109,7 @@ fn parse_block<'r, 't>(
 where
     'r: 't,
 {
-    debug!(
+    info!(
         log,
         "Trying to process a block";
         "star" => flag_star,
@@ -126,7 +126,7 @@ where
     parser.get_optional_space()?;
 
     let (name, in_head) = parser.get_block_name(flag_star)?;
-    trace!(log, "Got block name"; "name" => name, "in-head" => in_head);
+    debug!(log, "Got block name"; "name" => name, "in-head" => in_head);
 
     let (name, flag_score) = match name.strip_suffix('_') {
         Some(name) => (name, true),

--- a/ftml/src/parsing/rule/impls/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/blockquote.rs
@@ -35,7 +35,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Parsing nested native blockquotes");
+    info!(log, "Parsing nested native blockquotes");
 
     // Context variables
     let mut depths = Vec::new();
@@ -50,7 +50,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
             // Invalid token, bail
             _ => {
-                debug!(
+                warn!(
                     log,
                     "Didn't find blockquote token, ending list iteration";
                     "token" => current.token,

--- a/ftml/src/parsing/rule/impls/bold.rs
+++ b/ftml/src/parsing/rule/impls/bold.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create bold (strong) container");
+    info!(log, "Trying to create bold (strong) container");
 
     check_step(parser, Token::Bold)?;
 

--- a/ftml/src/parsing/rule/impls/center.rs
+++ b/ftml/src/parsing/rule/impls/center.rs
@@ -31,7 +31,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create centered container");
+    info!(log, "Trying to create centered container");
 
     // Check that the rule has "= "
     macro_rules! next {

--- a/ftml/src/parsing/rule/impls/clear_float.rs
+++ b/ftml/src/parsing/rule/impls/clear_float.rs
@@ -33,7 +33,7 @@ fn try_consume_fn<'p, 'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let current = parser.current();
 
-    debug!(
+    info!(
         log,
         "Consuming token to create a clear float";
         "slice" => current.slice,

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create color container");
+    info!(log, "Trying to create color container");
 
     check_step(parser, Token::Color)?;
 

--- a/ftml/src/parsing/rule/impls/comment.rs
+++ b/ftml/src/parsing/rule/impls/comment.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming tokens until end of comment");
+    info!(log, "Consuming tokens until end of comment");
 
     check_step(parser, Token::LeftComment)?;
 
@@ -52,21 +52,21 @@ fn try_consume_fn<'p, 'r, 't>(
         match token {
             // Hit the end of the comment, return
             Token::RightComment => {
-                trace!(log, "Reached end of comment, returning");
+                debug!(log, "Reached end of comment, returning");
                 parser.step()?;
                 return ok!(Elements::None);
             }
 
             // Hit the end of the input, abort
             Token::InputEnd => {
-                trace!(log, "Reached end of input, aborting");
+                debug!(log, "Reached end of input, aborting");
 
                 return Err(parser.make_warn(ParseWarningKind::EndOfInput));
             }
 
             // Consume any other token
             _ => {
-                trace!(log, "Token inside comment received. Discarding.");
+                debug!(log, "Token inside comment received. Discarding.");
                 parser.step()?;
             }
         }

--- a/ftml/src/parsing/rule/impls/dash.rs
+++ b/ftml/src/parsing/rule/impls/dash.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token to create an em dash");
+    info!(log, "Consuming token to create an em dash");
 
     // — - EM DASH
     ok!(text!("\u{2014}"))

--- a/ftml/src/parsing/rule/impls/double_angle.rs
+++ b/ftml/src/parsing/rule/impls/double_angle.rs
@@ -32,7 +32,7 @@ fn try_consume_fn<'p, 'r, 't>(
 ) -> ParseResult<'r, 't, Elements<'t>> {
     let current = parser.current();
 
-    debug!(
+    info!(
         log,
         "Consuming token to create a left/right double angle quote";
         "token" => current.token,

--- a/ftml/src/parsing/rule/impls/email.rs
+++ b/ftml/src/parsing/rule/impls/email.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token as an email");
+    info!(log, "Consuming token as an email");
 
     ok!(Element::Email(cow!(parser.current().slice)))
 }

--- a/ftml/src/parsing/rule/impls/header.rs
+++ b/ftml/src/parsing/rule/impls/header.rs
@@ -31,7 +31,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create header container");
+    info!(log, "Trying to create header container");
 
     macro_rules! step {
         ($token:expr) => {{

--- a/ftml/src/parsing/rule/impls/horizontal_rule.rs
+++ b/ftml/src/parsing/rule/impls/horizontal_rule.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token to create a horizontal rule");
+    info!(log, "Consuming token to create a horizontal rule");
 
     check_step(parser, Token::TripleDash)?;
     parser.get_optional_line_break()?;

--- a/ftml/src/parsing/rule/impls/italics.rs
+++ b/ftml/src/parsing/rule/impls/italics.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create italics (emphasis) container");
+    info!(log, "Trying to create italics (emphasis) container");
 
     check_step(parser, Token::Italics)?;
 

--- a/ftml/src/parsing/rule/impls/line_break.rs
+++ b/ftml/src/parsing/rule/impls/line_break.rs
@@ -36,7 +36,7 @@ fn line_break<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming newline token as line break");
+    info!(log, "Consuming newline token as line break");
 
     // Skip this newline if we're coming up on a rule that starts
     // on its own line.
@@ -67,7 +67,7 @@ fn line_break<'p, 'r, 't>(
     });
 
     if upcoming_skip {
-        debug!(log, "Skipping line break element because of upcoming token");
+        info!(log, "Skipping line break element because of upcoming token");
 
         return ok!(Elements::None);
     }

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -38,7 +38,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create a single-bracket anchor link");
+    info!(log, "Trying to create a single-bracket anchor link");
 
     check_step(parser, Token::LeftBracketAnchor)?;
 
@@ -83,7 +83,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
     debug!(
         log,
-        "Retrieved label for link, now build element";
+        "Retrieved label for link, building element";
         "label" => label,
     );
 

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -44,7 +44,7 @@ fn link<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to create a single-bracket link (regular)");
+    debug!(log, "Trying to create a single-bracket link (regular)");
 
     check_step(parser, Token::LeftBracket)?;
 
@@ -55,7 +55,7 @@ fn link_new_tab<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to create a single-bracket link (new tab)");
+    debug!(log, "Trying to create a single-bracket link (new tab)");
 
     check_step(parser, Token::LeftBracketStar)?;
 
@@ -74,7 +74,7 @@ fn try_consume_link<'p, 'r, 't>(
     rule: Rule,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Trying to create a single-bracket link";
         "target" => target.map(|t| t.name()),

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -48,7 +48,7 @@ fn link<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to create a triple-bracket link (regular)");
+    info!(log, "Trying to create a triple-bracket link (regular)");
 
     check_step(parser, Token::LeftLink)?;
 
@@ -59,7 +59,7 @@ fn link_new_tab<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    trace!(log, "Trying to create a triple-bracket link (new tab)");
+    info!(log, "Trying to create a triple-bracket link (new tab)");
 
     check_step(parser, Token::LeftLinkStar)?;
 
@@ -135,7 +135,7 @@ fn build_same<'p, 'r, 't>(
     url: &'t str,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Building link with same URL and label";
         "url" => url,
@@ -163,7 +163,7 @@ fn build_separate<'p, 'r, 't>(
     url: &'t str,
     target: Option<AnchorTarget>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(
+    info!(
         log,
         "Building link with separate URL and label";
         "url" => url,

--- a/ftml/src/parsing/rule/impls/list.rs
+++ b/ftml/src/parsing/rule/impls/list.rs
@@ -43,7 +43,7 @@ fn try_consume_fn<'p, 'r, 't>(
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
     // We don't know the list type(s) yet, so just log that we're starting
-    debug!(log, "Parsing a list");
+    info!(log, "Parsing a list");
 
     // Context variables
     let mut depths = Vec::new();
@@ -71,7 +71,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
             // Invalid token, bail
             _ => {
-                debug!(
+                warn!(
                     log,
                     "Didn't find correct bullet token or couldn't determine list depth, ending list iteration";
                     "token" => current.token,
@@ -85,7 +85,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
         // Check that the depth isn't obscenely deep, to avoid DOS attacks via stack overflow.
         if depth > MAX_LIST_DEPTH {
-            info!(
+            warn!(
                 log,
                 "List item has a depth greater than the maximum! Failing";
                 "depth" => depth,
@@ -115,14 +115,14 @@ fn try_consume_fn<'p, 'r, 't>(
 
         debug!(
             log,
-            "Parsing listen item";
+            "Parsing list item";
             "list-type" => list_type.name(),
         );
 
         // For now, always expect whitespace after the bullet
         let current = parser.current();
         if current.token != Token::Whitespace {
-            debug!(
+            warn!(
                 log,
                 "Didn't find whitespace after bullet token, ending list iteration";
                 "token" => current.token,

--- a/ftml/src/parsing/rule/impls/monospace.rs
+++ b/ftml/src/parsing/rule/impls/monospace.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create monospace container");
+    info!(log, "Trying to create monospace container");
 
     check_step(parser, Token::LeftMonospace)?;
 

--- a/ftml/src/parsing/rule/impls/null.rs
+++ b/ftml/src/parsing/rule/impls/null.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     _parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token and outputting null element");
+    info!(log, "Consuming token and outputting null element");
 
     ok!(Elements::None)
 }

--- a/ftml/src/parsing/rule/impls/raw.rs
+++ b/ftml/src/parsing/rule/impls/raw.rs
@@ -36,7 +36,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming tokens until end of raw");
+    info!(log, "Consuming tokens until end of raw");
 
     // Are we in a @@..@@ type raw, or a @<..>@ type?
     let ending_token = match parser.current().token {
@@ -51,7 +51,7 @@ fn try_consume_fn<'p, 'r, 't>(
     // * Raw Raw  Raw -> Element::Raw("@@")
     // * Raw ??   Raw -> Element::Raw(slice)
     if ending_token == Token::Raw {
-        trace!(log, "First token is '@@', checking for special cases");
+        debug!(log, "First token is '@@', checking for special cases");
 
         // Get next two tokens. If they don't exist, exit early
         let next_1 = parser.look_ahead_warn(0)?;

--- a/ftml/src/parsing/rule/impls/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/strikethrough.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create strikethrough container");
+    info!(log, "Trying to create strikethrough container");
 
     check_step(parser, Token::DoubleDash)?;
 

--- a/ftml/src/parsing/rule/impls/subscript.rs
+++ b/ftml/src/parsing/rule/impls/subscript.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create subscript container");
+    info!(log, "Trying to create subscript container");
 
     check_step(parser, Token::Subscript)?;
 

--- a/ftml/src/parsing/rule/impls/superscript.rs
+++ b/ftml/src/parsing/rule/impls/superscript.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create superscript container");
+    info!(log, "Trying to create superscript container");
 
     check_step(parser, Token::Superscript)?;
 

--- a/ftml/src/parsing/rule/impls/table.rs
+++ b/ftml/src/parsing/rule/impls/table.rs
@@ -40,14 +40,14 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to parse simple table");
+    info!(log, "Trying to parse simple table");
 
     let mut rows = Vec::new();
     let mut exceptions = Vec::new();
     let mut _paragraph_break = false;
 
     'table: loop {
-        debug!(log, "Parsing next table row");
+        info!(log, "Parsing next table row");
 
         let mut cells = Vec::new();
 
@@ -74,7 +74,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
         // Loop for each cell in the row
         'row: loop {
-            debug!(log, "Parsing next table cell"; "cells" => cells.len());
+            info!(log, "Parsing next table cell"; "cells" => cells.len());
 
             let mut elements = Vec::new();
             let TableCellStart {
@@ -109,7 +109,7 @@ fn try_consume_fn<'p, 'r, 't>(
                     // Since normally a newline will end the row, but we want a <br>
                     // in the cell contents.
                     (Token::Underscore, Some(Token::LineBreak)) => {
-                        trace!(log, "Handling newline escape in table");
+                        debug!(log, "Handling newline escape in table");
 
                         elements.push(Element::LineBreak);
                         parser.step_n(2)?;
@@ -124,7 +124,7 @@ fn try_consume_fn<'p, 'r, 't>(
                         | Token::TableColumnRight,
                         Some(next),
                     ) => {
-                        trace!(log, "Ending cell, row, or table"; "next-token" => next.name());
+                        debug!(log, "Ending cell, row, or table"; "next-token" => next.name());
 
                         match next {
                             // End the table entirely, there's a newline in between,
@@ -153,7 +153,7 @@ fn try_consume_fn<'p, 'r, 't>(
 
                     // Ignore leading whitespace
                     (Token::Whitespace, _) if elements.is_empty() => {
-                        trace!(log, "Ignoring leading whitespace");
+                        debug!(log, "Ignoring leading whitespace");
 
                         parser.step()?;
                         continue 'cell;
@@ -170,7 +170,7 @@ fn try_consume_fn<'p, 'r, 't>(
                             | Token::TableColumnRight,
                         ),
                     ) => {
-                        trace!(log, "Ignoring trailing whitespace");
+                        debug!(log, "Ignoring trailing whitespace");
 
                         parser.step()?;
                         continue 'cell;
@@ -178,13 +178,13 @@ fn try_consume_fn<'p, 'r, 't>(
 
                     // Invalid tokens
                     (Token::LineBreak | Token::ParagraphBreak | Token::InputEnd, _) => {
-                        trace!(log, "Invalid termination tokens in table, ending");
+                        debug!(log, "Invalid termination tokens in table, ending");
                         finish_table!();
                     }
 
                     // Consume tokens like normal
                     _ => {
-                        trace!(log, "Consuming cell contents as elements");
+                        debug!(log, "Consuming cell contents as elements");
 
                         let new_elements = consume(log, parser)?
                             .chain(&mut exceptions, &mut _paragraph_break);

--- a/ftml/src/parsing/rule/impls/text.rs
+++ b/ftml/src/parsing/rule/impls/text.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token as plain text element");
+    info!(log, "Consuming token as plain text element");
 
     let ExtractedToken { slice, .. } = parser.current();
 

--- a/ftml/src/parsing/rule/impls/underline.rs
+++ b/ftml/src/parsing/rule/impls/underline.rs
@@ -30,7 +30,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Trying to create underline container");
+    info!(log, "Trying to create underline container");
 
     check_step(parser, Token::Underline)?;
 

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -31,7 +31,7 @@ fn try_consume_fn<'p, 'r, 't>(
     log: &Logger,
     parser: &'p mut Parser<'r, 't>,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    debug!(log, "Consuming token as a URL");
+    info!(log, "Consuming token as a URL");
 
     let token = parser.current();
     let url = cow!(token.slice);

--- a/ftml/src/parsing/token/mod.rs
+++ b/ftml/src/parsing/token/mod.rs
@@ -145,7 +145,7 @@ impl Token {
         log: &Logger,
         text: &'a str,
     ) -> Vec<ExtractedToken<'a>> {
-        debug!(log, "Running lexer on input");
+        info!(log, "Running lexer on input");
 
         match TokenLexer::parse(Rule::document, text) {
             Ok(pairs) => {
@@ -167,7 +167,7 @@ impl Token {
                 // Return all of the input as one big raw text
                 // and log this as an error, since it shouldn't be happening
 
-                error!(log, "Error while lexing input in pest: {}", _error);
+                crit!(log, "Error while lexing input in pest: {}", _error);
 
                 vec![ExtractedToken {
                     token: Token::Other,

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -165,7 +165,7 @@ impl Replacer {
 pub fn substitute(log: &Logger, text: &mut String) {
     let mut buffer = String::new();
 
-    debug!(log, "Performing typography substitutions"; "text" => &*text);
+    info!(log, "Performing typography substitutions"; "text" => &*text);
 
     macro_rules! replace {
         ($replacer:expr) => {

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -38,7 +38,7 @@ impl Handle {
         module: &Module,
         mode: ModuleRenderMode,
     ) {
-        debug!(
+        info!(
             log,
             "Rendering module";
             "module" => module.name(),
@@ -56,14 +56,14 @@ impl Handle {
     }
 
     pub fn get_page_title(&self, log: &Logger, link: &LinkLocation) -> String {
-        debug!(log, "Fetching page title"; "link" => link);
+        info!(log, "Fetching page title"; "link" => link);
 
         // TODO
         format!("TODO: actual title ({:?})", link)
     }
 
     pub fn get_user_info<'a>(&self, log: &Logger, name: &'a str) -> Option<UserInfo<'a>> {
-        debug!(log, "Fetching user info"; "name" => name);
+        info!(log, "Fetching user info"; "name" => name);
 
         let mut info = UserInfo::dummy();
         info.user_name = cow!(name);
@@ -78,7 +78,7 @@ impl Handle {
         info: &PageInfo,
         source: &ImageSource<'a>,
     ) -> Cow<'a, str> {
-        debug!(log, "Getting file link for image");
+        info!(log, "Getting file link for image");
 
         let (site, page, file): (&str, &str, &str) = match source {
             ImageSource::Url(url) => return Cow::clone(url),
@@ -126,7 +126,7 @@ impl Handle {
         language: &str,
         message: &str,
     ) -> &'static str {
-        debug!(
+        info!(
             log,
             "Fetching message";
             "language" => language,
@@ -142,7 +142,7 @@ impl Handle {
             "table-of-contents" => "Table of Contents",
             "footnote-block-title" => "Footnotes",
             _ => {
-                error!(
+                info!(
                     log,
                     "Unknown message requested";
                     "message" => message,
@@ -154,7 +154,7 @@ impl Handle {
     }
 
     pub fn post_html(&self, log: &Logger, info: &PageInfo, html: &str) -> String {
-        debug!(log, "Submitting HTML to create iframe-able snippet");
+        info!(log, "Submitting HTML to create iframe-able snippet");
 
         let _ = info;
         let _ = html;
@@ -164,7 +164,7 @@ impl Handle {
     }
 
     pub fn post_code(&self, log: &Logger, index: NonZeroUsize, code: &str) {
-        debug!(
+        info!(
             log,
             "Submitting code snippet";
             "index" => index.get(),

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -66,7 +66,7 @@ pub fn render_collapsible(log: &Logger, ctx: &mut HtmlContext, collapsible: Coll
         show_bottom,
     } = collapsible;
 
-    debug!(
+    info!(
         log,
         "Rendering collapsible";
         "elements-len" => elements.len(),

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::tree::{Container, HtmlTag};
 
 pub fn render_container(log: &Logger, ctx: &mut HtmlContext, container: &Container) {
-    debug!(log, "Rendering container"; "container" => container.ctype().name());
+    info!(log, "Rendering container"; "container" => container.ctype().name());
 
     // Get HTML tag type for this type of container
     let tag_spec = container.ctype().html_tag(ctx);
@@ -51,7 +51,7 @@ pub fn render_color(
     color: &str,
     elements: &[Element],
 ) {
-    debug!(
+    info!(
         log,
         "Rendering color container";
         "color" => color,

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_footnote(log: &Logger, ctx: &mut HtmlContext) {
-    debug!(log, "Rendering footnote reference");
+    info!(log, "Rendering footnote reference");
 
     let index = ctx.next_footnote_index();
 
@@ -45,7 +45,7 @@ pub fn render_footnote(log: &Logger, ctx: &mut HtmlContext) {
 }
 
 pub fn render_footnote_block(log: &Logger, ctx: &mut HtmlContext, title: Option<&str>) {
-    debug!(
+    info!(
         log,
         "Rendering footnote block";
         "title" => title.unwrap_or("<default>"),

--- a/ftml/src/render/html/element/iframe.rs
+++ b/ftml/src/render/html/element/iframe.rs
@@ -27,7 +27,7 @@ pub fn render_iframe(
     url: &str,
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering iframe block";
         "url" => url,
@@ -41,7 +41,7 @@ pub fn render_iframe(
 }
 
 pub fn render_html(log: &Logger, ctx: &mut HtmlContext, contents: &str) {
-    debug!(
+    info!(
         log,
         "Rendering html block (submitting to remote for iframe)";
         "contents" => contents,

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -30,7 +30,7 @@ pub fn render_image(
     alignment: Option<FloatAlignment>,
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering image element";
         "source" => source.name(),

--- a/ftml/src/render/html/element/input.rs
+++ b/ftml/src/render/html/element/input.rs
@@ -28,7 +28,7 @@ pub fn render_radio_button(
     checked: bool,
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Creating radio button";
         "name" => name,
@@ -49,7 +49,7 @@ pub fn render_checkbox(
     checked: bool,
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Creating checkbox";
         "checked" => checked,

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -29,7 +29,7 @@ pub fn render_anchor(
     attributes: &AttributeMap,
     target: Option<AnchorTarget>,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering anchor";
         "elements-len" => elements.len(),
@@ -57,7 +57,7 @@ pub fn render_link(
     label: &LinkLabel,
     target: Option<AnchorTarget>,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering link";
         "link" => link,

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -28,7 +28,7 @@ pub fn render_list(
     list_items: &[ListItem],
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering list";
         "list-type" => ltype.name(),

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -61,7 +61,7 @@ use crate::tree::Element;
 use ref_map::*;
 
 pub fn render_elements(log: &Logger, ctx: &mut HtmlContext, elements: &[Element]) {
-    debug!(log, "Rendering elements"; "elements-len" => elements.len());
+    info!(log, "Rendering elements"; "elements-len" => elements.len());
 
     for element in elements {
         render_element(log, ctx, element);
@@ -75,7 +75,7 @@ pub fn render_element(log: &Logger, ctx: &mut HtmlContext, element: &Element) {
         };
     }
 
-    debug!(log, "Rendering element"; "element" => element.name());
+    info!(log, "Rendering element"; "element" => element.name());
 
     match element {
         Element::Container(container) => render_container(log, ctx, container),

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -23,7 +23,7 @@ use crate::tree::Table;
 use std::num::NonZeroU32;
 
 pub fn render_table(log: &Logger, ctx: &mut HtmlContext, table: &Table) {
-    debug!(log, "Rendering table");
+    info!(log, "Rendering table");
 
     let mut column_span_buf = String::new();
     let value_one = NonZeroU32::new(1).unwrap();

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_wikitext_raw(log: &Logger, ctx: &mut HtmlContext, text: &str) {
-    debug!(log, "Escaping raw string"; "text" => text);
+    info!(log, "Escaping raw string"; "text" => text);
 
     ctx.html()
         .span()
@@ -30,7 +30,7 @@ pub fn render_wikitext_raw(log: &Logger, ctx: &mut HtmlContext, text: &str) {
 }
 
 pub fn render_email(log: &Logger, ctx: &mut HtmlContext, email: &str) {
-    debug!(log, "Rendering email address"; "email" => email);
+    info!(log, "Rendering email address"; "email" => email);
 
     // Since our usecase doesn't typically have emails as real,
     // but rather as fictional elements, we're just rendering as text.
@@ -47,7 +47,7 @@ pub fn render_code(
     language: Option<&str>,
     contents: &str,
 ) {
-    debug!(
+    info!(
         log,
         "Rendering code block";
         "language" => language.unwrap_or("<none>"),

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -27,7 +27,7 @@ pub fn render_table_of_contents(
     align: Option<Alignment>,
     attributes: &AttributeMap,
 ) {
-    debug!(
+    info!(
         log,
         "Creating table of contents";
         "align" => align.map(|a| a.name()),

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 
 pub fn render_user(log: &Logger, ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
-    debug!(
+    info!(
         log,
         "Rendering user block";
         "name" => name,

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -28,7 +28,7 @@ use crate::url::normalize_link;
 use std::borrow::Cow;
 
 pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]) {
-    debug!(log, "Rendering elements"; "elements-len" => elements.len());
+    info!(log, "Rendering elements"; "elements-len" => elements.len());
 
     for element in elements {
         render_element(log, ctx, element);
@@ -36,7 +36,7 @@ pub fn render_elements(log: &Logger, ctx: &mut TextContext, elements: &[Element]
 }
 
 pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
-    debug!(log, "Rendering element"; "element" => element.name());
+    info!(log, "Rendering element"; "element" => element.name());
 
     match element {
         Element::Container(container) => {
@@ -263,7 +263,7 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
             }
         }
         Element::TableOfContents { .. } => {
-            debug!(log, "Rendering table of contents");
+            info!(log, "Rendering table of contents");
 
             let table_of_contents_title =
                 ctx.handle()
@@ -275,13 +275,13 @@ pub fn render_element(log: &Logger, ctx: &mut TextContext, element: &Element) {
             render_elements(log, ctx, ctx.table_of_contents());
         }
         Element::Footnote => {
-            debug!(log, "Rendering footnote reference");
+            info!(log, "Rendering footnote reference");
 
             let index = ctx.next_footnote_index();
             str_write!(ctx, "[{}]", index);
         }
         Element::FootnoteBlock { title, hide } => {
-            debug!(log, "Rendering footnote block");
+            info!(log, "Rendering footnote block");
 
             if *hide || ctx.footnotes().is_empty() {
                 return;


### PR DESCRIPTION
Previously I had a strange paradigm where I wouldn't use `warn!` or `error!` for internal parser issues, because technically it was valid wikitext. However this makes logging kind of hard to read since everything is `debug!` with a few `info!`s. This changes logging to more readily use higher levels. Any "top-level" execution (including rules, blocks, and main functions) use `info!` to declare start instead of `debug!`. It also reverts `slog` to use the original level (i.e. excludes `trace!()`).