### PR TITLE
Add support for publishing client packages

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -51,7 +51,10 @@ To publish a module, run this command:
 $ pnpm publish-module -- module-name
 ```
 
-This will package the module, as described above, and then publish it. Of course, you want to exercise caution when publishing.
+This will package the module, as described above, and then publish it. Of course, you want to exercise caution when publishing. In order to publish, you'll need to make sure of three things:
+1. You are part of the `wikijump` team on NPM (modules are scoped to that team)
+2. That every local dependency that the package has is also on NPM
+3. That you are absolutely sure you're good to go to publish
 
 ### Development
 

--- a/client/README.md
+++ b/client/README.md
@@ -44,6 +44,15 @@ $ pnpm pack-module -- module-name
 
 This will "package" the module `module-name`. What this does is that it starts a special build process on that module, which will yield a publishable NPM package in the modules `dist` folder. Any important changes that would've needed to been made to the module and its `package.json` are handled automatically.
 
+### Publishing
+
+To publish a module, run this command:
+```
+$ pnpm publish-module -- module-name
+```
+
+This will package the module, as described above, and then publish it. Of course, you want to exercise caution when publishing.
+
 ### Development
 
 Currently, there is no "monorepo-wide" development mode. Since packages generally have their source directly consumed, there isn't any reason to be building them.

--- a/client/modules/ftml-wasm/README.md
+++ b/client/modules/ftml-wasm/README.md
@@ -1,13 +1,15 @@
-# ftml-wasm
+# @wikijump/ftml-wasm
 
-This package contains the WebAssembly compilation of FTML.
+This package contains the WebAssembly compilation of [FTML](https://github.com/scpwiki/wikijump/tree/develop/ftml), and an ergonomic interface for using it.
 
-For the time being, this WASM compilation is built statically and committed, for the following reasons:
+Part of the [Wikijump project.](https://github.com/scpwiki/wikijump)
 
-- A frontend developer does not need to install Rust to get quickly set up with an inital build.
-- The current build process is not equipped to handle external files e.g. FTML.
-- Breaking changes to FTML will not break the bindings in this package - they will simply be outdated.
-- The full build process is much faster, which is important during this intial phase of iterative development.
-- The build process is simplified by not needing a full Rust compilation.
+## Installation
 
-Eventually, the WASM compilation will be run during a build step and will be up-to-date with the current FTML version.
+```
+$ npm install @wikijump/ftml-wasm
+```
+
+## License
+
+Released under the AGPL-3.0 license. See [LICENSE](https://github.com/scpwiki/wikijump/blob/develop/LICENSE.md).

--- a/client/modules/ftml-wasm/package.json
+++ b/client/modules/ftml-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/ftml-wasm",
   "license": "agpl-3.0-or-later",
   "description": "WASM-JS bindings for FTML.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "keywords": [
     "wikijump",
     "ftml",

--- a/client/modules/ftml-wasm/package.json
+++ b/client/modules/ftml-wasm/package.json
@@ -2,9 +2,12 @@
   "name": "@wikijump/ftml-wasm",
   "license": "agpl-3.0-or-later",
   "description": "WASM-JS bindings for FTML.",
-  "version": "0.0.0",
+  "version": "1.6.1",
   "keywords": [
-    "wikijump"
+    "wikijump",
+    "ftml",
+    "wasm",
+    "rust"
   ],
   "private": true,
   "scripts": {

--- a/client/nabs.yml
+++ b/client/nabs.yml
@@ -8,6 +8,7 @@ build:
   web: pnpm --filter {web} --parallel --if-present -r build
 
 pack-module: node scripts/vite-pack.js
+publish-module: node scripts/publish.js
 
 # -- TESTING
 

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "lint:prettier": "prettier --ignore-unknown --check \"modules/**\" \"web/**\"",
     "lint:stylelint": "stylelint \"modules/**/*.scss\" \"web/**/*.scss\"",
     "pack-module": "node scripts/vite-pack.js",
+    "publish-module": "node scripts/publish.js",
     "test": "wtr --playwright",
     "typecheck": "tsc",
     "validate": "run-p lint typecheck",

--- a/client/scripts/publish.js
+++ b/client/scripts/publish.js
@@ -1,0 +1,9 @@
+const execSync = require("child_process").execSync
+
+const arg = process.argv[2]
+
+if (arg) {
+  execSync(`pnpm pack-module -- ${arg}`, { stdio: "inherit" })
+  process.chdir(`modules/${arg}/dist`)
+  execSync(`npm publish --access public`, { stdio: "inherit" })
+}

--- a/client/scripts/publish.js
+++ b/client/scripts/publish.js
@@ -1,4 +1,4 @@
-const execSync = require("child_process").execSync
+const { execSync } = require("child_process")
 
 const arg = process.argv[2]
 

--- a/client/scripts/vite-pack.js
+++ b/client/scripts/vite-pack.js
@@ -89,13 +89,13 @@ config.build.lib = {
 // modify the package.json for NPM publish
 
 // point to built files
-json.types = `${json.main}`
-json.main = `cjs/wj-${package}.cjs`
-json.module = `esm/wj-${package}.mjs`
+json.types = `./${json.main}`
+json.main = `./cjs/wj-${package}.cjs`
+json.module = `./esm/wj-${package}.mjs`
 json.exports ??= {}
 json.exports["."] = {
-  import: `esm/wj-${package}.mjs`,
-  require: `cjs/wj-${package}.cjs`
+  import: `./esm/wj-${package}.mjs`,
+  require: `./cjs/wj-${package}.cjs`
 }
 
 // delete fields that would mess with things


### PR DESCRIPTION
This PR adds a simple script for publishing an NPM package. An example of a published package is [`@wikijump/ftml-wasm`](https://www.npmjs.com/package/@wikijump/ftml-wasm).