### PR TITLE
Get ftml-wasm-worker and deps to publish nicely, beautify logging

### DIFF
--- a/client/modules/cm-espells/src/espells/index.ts
+++ b/client/modules/cm-espells/src/espells/index.ts
@@ -209,5 +209,5 @@ function localeLanguage(locale: string) {
 }
 
 async function importWorker() {
-  return (await import("./espells.worker?worker&inline")).default
+  return (await import("./espells.worker?worker")).default
 }

--- a/client/modules/cm-lang-ftml/src/content/index.ts
+++ b/client/modules/cm-lang-ftml/src/content/index.ts
@@ -2,7 +2,7 @@ import { decode, transfer, WorkerModule } from "@wikijump/threads-worker-module"
 import type { ContentModuleInterface } from "./content.worker"
 
 async function importWorker() {
-  return (await import("./content.worker?worker&inline")).default
+  return (await import("./content.worker?worker")).default
 }
 
 export class ContentWorker extends WorkerModule<ContentModuleInterface> {

--- a/client/modules/ftml-wasm-worker/README.md
+++ b/client/modules/ftml-wasm-worker/README.md
@@ -1,3 +1,15 @@
-# ftml-wasm-worker
+# @wikijump/ftml-wasm-worker
 
 Exports a web-workerized version of `ftml-wasm`. This package has been highly optimized for fast, safe, and reliable usage of the WASM version of FTML.
+
+Part of the [Wikijump project.](https://github.com/scpwiki/wikijump)
+
+## Installation
+
+```
+$ npm install @wikijump/ftml-wasm-worker
+```
+
+## License
+
+Released under the AGPL-3.0 license. See [LICENSE](https://github.com/scpwiki/wikijump/blob/develop/LICENSE.md).

--- a/client/modules/ftml-wasm-worker/package.json
+++ b/client/modules/ftml-wasm-worker/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/ftml-wasm-worker",
   "license": "agpl-3.0-or-later",
   "description": "A web workerized version of ftml-wasm",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "keywords": [
     "wikijump"
   ],

--- a/client/modules/ftml-wasm-worker/package.json
+++ b/client/modules/ftml-wasm-worker/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/ftml-wasm-worker",
   "license": "agpl-3.0-or-later",
   "description": "A web workerized version of ftml-wasm",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "keywords": [
     "wikijump"
   ],

--- a/client/modules/ftml-wasm-worker/src/ftml.ts
+++ b/client/modules/ftml-wasm-worker/src/ftml.ts
@@ -3,7 +3,7 @@ import { decode, transfer, WorkerModule } from "@wikijump/threads-worker-module"
 import type { FTMLWorkerInterface } from "./worker/ftml.worker"
 
 async function importFTML() {
-  return (await import("./worker/ftml.worker?worker&inline")).default
+  return (await import("./worker/ftml.worker?worker")).default
 }
 
 class FTMLWorker extends WorkerModule<FTMLWorkerInterface> {

--- a/client/modules/threads-worker-module/README.md
+++ b/client/modules/threads-worker-module/README.md
@@ -1,3 +1,15 @@
-# threads-worker-module
+# @wikijump/threads-worker-module
 
 A smart wrapper around Threads.js worker modules.
+
+Part of the [Wikijump project.](https://github.com/scpwiki/wikijump)
+
+## Installation
+
+```
+$ npm install @wikijump/threads-worker-module
+```
+
+##
+
+Released under the AGPL-3.0 license. See [LICENSE](https://github.com/scpwiki/wikijump/blob/develop/LICENSE.md).

--- a/client/modules/threads-worker-module/package.json
+++ b/client/modules/threads-worker-module/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/threads-worker-module",
   "license": "agpl-3.0-or-later",
   "description": "Smart wrapper around Threads.js worker modules.",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "keywords": [
     "wikijump"
   ],

--- a/client/modules/threads-worker-module/package.json
+++ b/client/modules/threads-worker-module/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/threads-worker-module",
   "license": "agpl-3.0-or-later",
   "description": "Smart wrapper around Threads.js worker modules.",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "keywords": [
     "wikijump"
   ],

--- a/client/modules/util/README.md
+++ b/client/modules/util/README.md
@@ -1,3 +1,15 @@
 # @wikijump/util
 
 Exports a plethora of utility functions widely used by Wikijump's packages.
+
+Part of the [Wikijump project.](https://github.com/scpwiki/wikijump)
+
+## Installation
+
+```
+$ npm install @wikijump/util
+```
+
+## License
+
+Released under the AGPL-3.0 license. See [LICENSE](https://github.com/scpwiki/wikijump/blob/develop/LICENSE.md).

--- a/client/modules/util/package.json
+++ b/client/modules/util/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/util",
   "license": "agpl-3.0-or-later",
   "description": "Collection of common utility methods.",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "keywords": [
     "wikijump"
   ],

--- a/client/modules/util/package.json
+++ b/client/modules/util/package.json
@@ -2,7 +2,7 @@
   "name": "@wikijump/util",
   "license": "agpl-3.0-or-later",
   "description": "Collection of common utility methods.",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "keywords": [
     "wikijump"
   ],
@@ -12,8 +12,5 @@
   "main": "src/index.ts",
   "eslintConfig": {
     "extends": "../../.eslintrc.js"
-  },
-  "dependencies": {
-    "is-what": "^4.0.0"
   }
 }

--- a/client/modules/util/src/index.ts
+++ b/client/modules/util/src/index.ts
@@ -1,5 +1,3 @@
-import { isAnyObject } from "is-what"
-
 export * from "./decorators"
 
 // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2694461
@@ -80,7 +78,7 @@ export function has<K extends string, T>(
   key: K,
   obj: T
 ): obj is T extends Record<any, any> ? Has<K, T> : never {
-  if (!isAnyObject(obj)) return false
+  if (typeof obj !== "object") return false
   // @ts-ignore
   return key in obj && obj[key] !== undefined
 }
@@ -343,7 +341,7 @@ export function createAnimQueued<T extends AnyFunction>(fn: T) {
   }
 }
 
-const HAS_IDLE_CALLBACK = "requestIdleCallback" in window
+const HAS_IDLE_CALLBACK = "requestIdleCallback" in globalThis
 
 /** Safely calls `requestIdleCallback` in an awaitable `Promise`. */
 // bad coverage as requestIdleCallback isn't always available

--- a/client/nabs.yml
+++ b/client/nabs.yml
@@ -20,21 +20,21 @@ cover: wtr --playwright --coverage
 
 lint:
   $depend: []
-  $action: run-p lint:eslint lint:stylelint lint:prettier
+  $action: run-p -lns lint:eslint lint:stylelint lint:prettier
   eslint: eslint "./**/*.js" "./**/*.ts"
   stylelint: stylelint "modules/**/*.scss" "web/**/*.scss"
   prettier: prettier --ignore-unknown --check "modules/**" "web/**"
 
   fix:
     $depend: []
-    $action: run-p lint:fix:eslint lint:fix:stylelint lint:fix:prettier
+    $action: run-p -lns lint:fix:eslint lint:fix:stylelint lint:fix:prettier
     eslint: eslint "./**/*.js" "./**/*.ts" --fix
     stylelint: stylelint "modules/**/*.scss" "web/**/*.scss" --fix
     prettier: prettier --write --ignore-unknown "modules/**" "web/**"
 
 typecheck: tsc
 
-validate: run-p lint typecheck
+validate: run-p -lns lint typecheck
 
 # -- MISC.
 

--- a/client/package.json
+++ b/client/package.json
@@ -8,9 +8,9 @@
     "build:web": "pnpm --filter {web} --parallel --if-present -r build",
     "cover": "wtr --playwright --coverage",
     "dev:dev-sandbox": "pnpm --filter dev-sandbox dev",
-    "lint": "run-p lint:eslint lint:stylelint lint:prettier",
+    "lint": "run-p -lns lint:eslint lint:stylelint lint:prettier",
     "lint:eslint": "eslint \"./**/*.js\" \"./**/*.ts\"",
-    "lint:fix": "run-p lint:fix:eslint lint:fix:stylelint lint:fix:prettier",
+    "lint:fix": "run-p -lns lint:fix:eslint lint:fix:stylelint lint:fix:prettier",
     "lint:fix:eslint": "eslint \"./**/*.js\" \"./**/*.ts\" --fix",
     "lint:fix:prettier": "prettier --write --ignore-unknown \"modules/**\" \"web/**\"",
     "lint:fix:stylelint": "stylelint \"modules/**/*.scss\" \"web/**/*.scss\" --fix",
@@ -20,7 +20,7 @@
     "publish-module": "node scripts/publish.js",
     "test": "wtr --playwright",
     "typecheck": "tsc",
-    "validate": "run-p lint typecheck",
+    "validate": "run-p -lns lint typecheck",
     "nabs": "nabs"
   },
   "browserslist": [
@@ -40,6 +40,7 @@
     "@typescript-eslint/typescript-estree": "^4.31.0",
     "@web/test-runner": "^0.13.17",
     "@web/test-runner-playwright": "^0.8.8",
+    "chalk": "^4.1.2",
     "eslint": "^7.32.0",
     "eslint-plugin-regexp": "^1.1.0",
     "eslint-plugin-svelte3": "^3.2.1",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -14,6 +14,7 @@ importers:
       '@typescript-eslint/typescript-estree': ^4.31.0
       '@web/test-runner': ^0.13.17
       '@web/test-runner-playwright': ^0.8.8
+      chalk: ^4.1.2
       eslint: ^7.32.0
       eslint-plugin-regexp: ^1.1.0
       eslint-plugin-svelte3: ^3.2.1
@@ -48,6 +49,7 @@ importers:
       '@typescript-eslint/typescript-estree': 4.31.0_typescript@4.4.3
       '@web/test-runner': 0.13.17_rollup@2.56.3
       '@web/test-runner-playwright': 0.8.8
+      chalk: 4.1.2
       eslint: 7.32.0
       eslint-plugin-regexp: 1.1.0_eslint@7.32.0
       eslint-plugin-svelte3: 3.2.1_eslint@7.32.0+svelte@3.42.5

--- a/client/scripts/pretty-logs.js
+++ b/client/scripts/pretty-logs.js
@@ -7,7 +7,7 @@ function linebreak() {
 }
 
 function separator() {
-  console.log(chalk.gray("-------------------------"))
+  console.log(chalk.gray("─────────────────────────"))
 }
 
 function header(title) {
@@ -29,13 +29,13 @@ function info(...msgs) {
 
 function warn(...msgs) {
   const msg = msgs.join("\n")
-  console.warn(chalk.yellow("-------- WARNING --------"))
+  console.warn(chalk.yellow("──────── WARNING ────────"))
   console.warn(chalk.yellow(msg))
 }
 
 function error(...msgs) {
   const msg = msgs.join("\n")
-  console.warn(chalk.redBright("--------- ERROR ---------"))
+  console.warn(chalk.redBright("───────── ERROR ─────────"))
   console.warn(chalk.redBright(msg))
 }
 

--- a/client/scripts/pretty-logs.js
+++ b/client/scripts/pretty-logs.js
@@ -1,0 +1,70 @@
+const readline = require("readline")
+const { execSync } = require("child_process")
+const chalk = require("chalk")
+
+function linebreak() {
+  console.log("")
+}
+
+function separator() {
+  console.log(chalk.gray("-------------------------"))
+}
+
+function header(title) {
+  const dashes = Math.round((24 - (title.length + 2)) / 2)
+  const chrs = "─".repeat(dashes)
+  console.log(chalk.bgBlue(`${chrs} ${title} ${chrs}`))
+}
+
+function section(title) {
+  const dashes = Math.round((24 - (title.length + 2)) / 2)
+  const chrs = "─".repeat(dashes)
+  console.log(chalk.blueBright(`${chrs} ${title} ${chrs}`))
+}
+
+function info(...msgs) {
+  const msg = msgs.join("\n")
+  console.log(chalk.green(msg))
+}
+
+function warn(...msgs) {
+  const msg = msgs.join("\n")
+  console.warn(chalk.yellow("-------- WARNING --------"))
+  console.warn(chalk.yellow(msg))
+}
+
+function error(...msgs) {
+  const msg = msgs.join("\n")
+  console.warn(chalk.redBright("--------- ERROR ---------"))
+  console.warn(chalk.redBright(msg))
+}
+
+function cmd(command) {
+  execSync(command, { stdio: "inherit" })
+}
+
+function question(question) {
+  return new Promise((resolve, reject) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    })
+
+    rl.question(chalk.magentaBright(question), answer => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}
+
+module.exports = {
+  linebreak,
+  separator,
+  header,
+  section,
+  info,
+  warn,
+  error,
+  cmd,
+  question
+}

--- a/client/scripts/publish.js
+++ b/client/scripts/publish.js
@@ -1,9 +1,28 @@
-const { execSync } = require("child_process")
+const { section, linebreak, info, question, cmd } = require("./pretty-logs.js")
 
 const arg = process.argv[2]
 
-if (arg) {
-  execSync(`pnpm pack-module -- ${arg}`, { stdio: "inherit" })
-  process.chdir(`modules/${arg}/dist`)
-  execSync(`npm publish --access public`, { stdio: "inherit" })
-}
+;(async () => {
+  if (arg) {
+    cmd(`pnpm pack-module -- ${arg}`)
+
+    section("PUBLISH")
+    linebreak()
+
+    const answer = await question("Do you want to publish this package? [y/n] -> ")
+
+    linebreak()
+
+    if (answer.trim().toLowerCase() === "y") {
+      process.chdir(`modules/${arg}/dist`)
+      cmd("npm publish --access public")
+
+      linebreak()
+      info(`Published "${arg}"`)
+    } else {
+      info(`Aborted publishing "${arg}"`)
+    }
+
+    linebreak()
+  }
+})()


### PR DESCRIPTION
This PR gets `ftml-wasm-worker` and it's dependencies published on NPM without issues. It also adds some pretty colors to the logging, which I originally added so that errors could be seen easier. Additionally, the `publish` script now asks if you're sure you want to publish.

![image](https://user-images.githubusercontent.com/34875062/133088832-6aac1460-0df5-418a-b352-b1002f844a4e.png)
![image](https://user-images.githubusercontent.com/34875062/133088956-57367a41-9135-48b8-9760-91e4cf2aae53.png)

