### PR TITLE
Use single-nested list blocks in docs

### DIFF
--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -317,7 +317,7 @@ Arguments:
 Example:
 
 ```
-The author of The Dark Tower series[[footnote]]Did you know that world-renowned writer Stephen King was once hit by a car? Just something to consider[[/footnote]] began work in the late 1970s.
+The author of The Dark Tower series[[footnote]]Did you know that world-renowned writer Stephen King was once hit by a car? Just something to consider.[[/footnote]] began work in the late 1970s.
 ```
 
 ### Footnote Block

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -577,12 +577,11 @@ Example:
 
 ```
 [[ul]]
-  [[li]]
-    [[ol]]
-      [[li]] Item A [[/li]]
-      [[li]] Item B [[/li]]
-    [[/ol]]
-  [[/li]]
+  [[ol]]
+    [[li]] Item A [[/li]]
+    [[li]] Item B [[/li]]
+  [[/ol]]
+
   [[li]] Item C [[/li]]
 [[/ul]]
 ```


### PR DESCRIPTION
Minor change, this documentation was written when the only method of nesting lists was through `[[li]]`, which is incorrect here. This showcases proper sub-lists.