### PR TITLE
Add some capability to at least test things in the dev-sandbox with Firefox

### DIFF
--- a/client/.changeset/fluffy-schools-flow.md
+++ b/client/.changeset/fluffy-schools-flow.md
@@ -1,0 +1,6 @@
+---
+"@wikijump/ftml-wasm": patch
+"@wikijump/ftml-wasm-worker": patch
+---
+
+Change how the FTML WASM is imported by default

--- a/client/modules/ftml-wasm-worker/src/ftml.ts
+++ b/client/modules/ftml-wasm-worker/src/ftml.ts
@@ -1,4 +1,6 @@
 import type { PartialInfo } from "@wikijump/ftml-wasm"
+// TODO: remove this unneeded import when Vite stops being bad
+import wasmURL from "@wikijump/ftml-wasm/vendor/ftml_bg.wasm?url"
 import { decode, transfer, WorkerModule } from "@wikijump/threads-worker-module"
 import type { FTMLWorkerInterface } from "./worker/ftml.worker"
 
@@ -11,7 +13,7 @@ class FTMLWorker extends WorkerModule<FTMLWorkerInterface> {
     super("@wikijump/ftml-wasm-worker", importFTML, {
       persist: true,
       init: async () => {
-        await this.invoke("init")
+        await this.invoke("init", new URL(wasmURL, import.meta.url).toString())
       }
     })
   }

--- a/client/modules/ftml-wasm/src/base.ts
+++ b/client/modules/ftml-wasm/src/base.ts
@@ -1,4 +1,8 @@
 import initFTML, * as Binding from "../vendor/ftml"
+// TODO: get rid of this dumb import
+// stupid vite bug means that I can't dynamically import in a worker
+// so I have to do this
+import wasmURL from "../vendor/ftml_bg.wasm?url"
 
 /** Indicates if the WASM binding is loaded. */
 export let ready = false
@@ -14,7 +18,10 @@ export let wasm: Binding.InitOutput | null = null
 
 /** Loads the WASM required for the FTML library. */
 export async function init(path?: Binding.InitInput) {
-  if (!path) path = (await import("../vendor/ftml_bg.wasm?url")).default
+  // TODO: uncomment this as soon as Vite stops being bad
+  // see TODO above this one
+  // if (!path) path = (await import("../vendor/ftml_bg.wasm?url")).default
+  if (!path) path = new URL(wasmURL, location.href)
   wasm = await initFTML(path)
   ready = true
   resolveLoading()

--- a/client/nabs.yml
+++ b/client/nabs.yml
@@ -50,3 +50,4 @@ validate: run-p -lns lint typecheck
 # -- MISC.
 
 dev:dev-sandbox: pnpm --filter dev-sandbox dev
+preview:dev-sandbox: pnpm --filter dev-sandbox preview

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "modules:pack": "node scripts/vite-pack.js",
     "modules:publish": "node scripts/publish-all.js",
     "modules:version": "changeset version",
+    "preview:dev-sandbox": "pnpm --filter dev-sandbox preview",
     "test": "wtr --playwright",
     "typecheck": "tsc",
     "validate": "run-p -lns lint typecheck",

--- a/client/web/dev-sandbox/package.json
+++ b/client/web/dev-sandbox/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "preview": "vite build && vite preview"
   },
   "type": "module",
   "eslintConfig": {


### PR DESCRIPTION
This PR adds the command `preview:dev-sandbox` so that I can at least _test_ if things work in Firefox, and use its profiler. I had to change some worker imports because I hate literally everything about bundlers and I wish everything wasn't terrible and awful