### PR TITLE
Refactor ItemRender use in inner()

### DIFF
--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -234,7 +234,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
     }
 
     #[inline]
-    pub fn inner(&mut self, log: &Logger, item: &dyn ItemRender) -> &mut Self {
+    pub fn inner<R: ItemRender>(&mut self, log: &Logger, item: R) -> &mut Self {
         self.content_start();
         item.render(log, self.ctx);
 

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -115,7 +115,7 @@ pub fn render_collapsible(log: &Logger, ctx: &mut HtmlContext, collapsible: Coll
                             "class" => "wj-collapsible-block-link",
                             "href" => "javascript:;",
                         ))
-                        .inner(log, &show_text);
+                        .inner(log, show_text);
                 });
 
             // Close collapsible link
@@ -136,14 +136,14 @@ pub fn render_collapsible(log: &Logger, ctx: &mut HtmlContext, collapsible: Coll
                                         collapsible_class(show_top),
                                     "href" => "javascript:;",
                                 ))
-                                .inner(log, &hide_text);
+                                .inner(log, hide_text);
                         });
 
                     // Collapsed contents
                     ctx.html()
                         .div()
                         .attr(attr!("class" => "wj-collapsible-block-content"))
-                        .inner(log, &elements);
+                        .inner(log, elements);
 
                     // Bottom div to close
                     ctx.html()
@@ -158,7 +158,7 @@ pub fn render_collapsible(log: &Logger, ctx: &mut HtmlContext, collapsible: Coll
                                         collapsible_class(show_bottom),
                                     "href" => "javascript:;",
                                 ))
-                                .inner(log, &hide_text);
+                                .inner(log, hide_text);
                         });
                 });
         });

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -49,7 +49,7 @@ pub fn render_container(log: &Logger, ctx: &mut HtmlContext, container: &Contain
     };
 
     // Add container internals
-    tag.inner(log, &container.elements());
+    tag.inner(log, container.elements());
 }
 
 pub fn render_color(
@@ -71,5 +71,5 @@ pub fn render_color(
             "is" => "wj-container",
             "style" => "color: " color ";",
         ))
-        .inner(log, &elements);
+        .inner(log, elements);
 }

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -75,7 +75,7 @@ pub fn render_footnote_block(log: &Logger, ctx: &mut HtmlContext, title: Option<
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-title"))
-                .inner(log, &title);
+                .inner(log, title);
 
             ctx.html()
                 .ol()
@@ -111,14 +111,14 @@ pub fn render_footnote_block(log: &Logger, ctx: &mut HtmlContext, title: Option<
                                         ctx.html()
                                             .span()
                                             .attr(attr!("class" => "wj-footnote-sep"))
-                                            .inner(log, &".");
+                                            .inner(log, ".");
                                     });
 
                                 // Footnote contents
                                 ctx.html()
                                     .div()
                                     .attr(attr!("class" => "wj-footnote-contents"))
-                                    .inner(log, &contents);
+                                    .inner(log, contents);
                             });
                     }
                 });

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -48,7 +48,7 @@ pub fn render_anchor(
             "target" => target_value; if target.is_some();;
             attributes
         ))
-        .inner(log, &elements);
+        .inner(log, elements);
 }
 
 pub fn render_link(
@@ -85,7 +85,7 @@ pub fn render_link(
 
     // Add <a> internals, i.e. the link name
     handle.get_link_label(log, link, label, |label| {
-        tag.inner(log, &label);
+        tag.inner(log, label);
     });
 }
 

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -49,7 +49,7 @@ pub fn render_list(
                         ctx.html()
                             .li()
                             .attr(attr!("is" => "wj-list-item";; attributes))
-                            .inner(log, &elements);
+                            .inner(log, elements);
                     }
                     ListItem::SubList { element } => {
                         render_element(log, ctx, element);

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -72,7 +72,7 @@ pub fn render_table(log: &Logger, ctx: &mut HtmlContext, table: &Table) {
 
                                         &cell.attributes,
                                     ))
-                                    .inner(log, &elements);
+                                    .inner(log, elements);
                             }
                         });
                 }

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -29,7 +29,7 @@ pub fn render_wikitext_raw(log: &Logger, ctx: &mut HtmlContext, text: &str) {
             "is" => "wj-raw",
             "class" => "wj-raw",
         ))
-        .inner(log, &text);
+        .inner(log, text);
 }
 
 pub fn render_email(log: &Logger, ctx: &mut HtmlContext, email: &str) {
@@ -44,7 +44,7 @@ pub fn render_email(log: &Logger, ctx: &mut HtmlContext, email: &str) {
             "is" => "wj-email",
             "class" => "wj-email",
         ))
-        .inner(log, &email);
+        .inner(log, email);
 }
 
 pub fn render_code(
@@ -103,12 +103,12 @@ pub fn render_code(
                         .attr(attr!(
                             "class" => "wj-code-language",
                         ))
-                        .inner(log, &language.unwrap_or(""));
+                        .inner(log, language.unwrap_or(""));
                 });
 
             // Code block containing highlighted contents
             ctx.html().pre().contents(|ctx| {
-                ctx.html().code().inner(log, &contents);
+                ctx.html().code().inner(log, contents);
             });
         });
 }

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -70,10 +70,10 @@ pub fn render_table_of_contents(
             ctx.html()
                 .div()
                 .attr(attr!("class" => "title"))
-                .inner(log, &table_of_contents_title);
+                .inner(log, table_of_contents_title);
 
             // TOC List
-            let table_of_contents = &ctx.table_of_contents();
+            let table_of_contents = ctx.table_of_contents();
 
             ctx.html()
                 .div()

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -64,7 +64,7 @@ pub fn render_user(log: &Logger, ctx: &mut HtmlContext, name: &str, show_avatar:
                                 .html()
                                 .span()
                                 .attr(attr!("class" => "wj-user-info-name"))
-                                .inner(log, &&info.user_name);
+                                .inner(log, &info.user_name);
                         });
                 }
                 None => {
@@ -90,7 +90,7 @@ pub fn render_user(log: &Logger, ctx: &mut HtmlContext, name: &str, show_avatar:
                                 .html()
                                 .span()
                                 .attr(attr!("class" => "wj-user-info-name"))
-                                .inner(log, &name);
+                                .inner(log, name);
                         });
                 }
             }

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -84,7 +84,7 @@ impl Render for HtmlRender {
         ctx.html()
             .div()
             .attr(attr!("class" => "wj-body"))
-            .inner(log, &&tree.elements);
+            .inner(log, &tree.elements);
 
         // Build and return HtmlOutput
         ctx.into()

--- a/ftml/src/render/html/render.rs
+++ b/ftml/src/render/html/render.rs
@@ -42,6 +42,13 @@ impl ItemRender for &'_ Cow<'_, str> {
     }
 }
 
+impl ItemRender for String {
+    #[inline]
+    fn render(&self, _log: &Logger, ctx: &mut HtmlContext) {
+        ctx.push_escaped(self);
+    }
+}
+
 impl ItemRender for &'_ Element<'_> {
     #[inline]
     fn render(&self, log: &Logger, ctx: &mut HtmlContext) {


### PR DESCRIPTION
This uses a generic for `ItemRender` instead of a trait object, which eases developer ergonomics by not needing to put `&`s everywhere.