### PR TITLE
[WJ-856] Add random ID generation to HtmlContext

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "cfg-if",
  "entities",
  "enum-map",
+ "getrandom",
  "lazy_static",
  "maplit",
  "parking_lot",
@@ -354,8 +355,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "proptest",
+ "rand",
  "ref-map",
  "regex",
  "self_cell",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -59,6 +59,7 @@ sloggers = "2"
 termcolor = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "*", features = ["js"] }
 self_cell = "0.9"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["console"] }

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "1"
 maplit = "1"
 pest = "2"
 pest_derive = "2"
+rand = "0.8"
 ref-map = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1"
 maplit = "1"
 pest = "2"
 pest_derive = "2"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 ref-map = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -80,7 +80,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
             backlinks: Backlinks::new(),
             info,
             handle,
-            random: Random::new(),
+            random: Random::default(),
             variables: VariableScopes::new(),
             table_of_contents,
             footnotes,

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -22,6 +22,7 @@ use super::builder::HtmlBuilder;
 use super::escape::escape;
 use super::meta::{HtmlMeta, HtmlMetaType};
 use super::output::HtmlOutput;
+use super::random::Random;
 use crate::data::PageRef;
 use crate::next_index::{NextIndex, TableOfContentsIndex};
 use crate::render::Handle;
@@ -43,6 +44,7 @@ where
     backlinks: Backlinks<'static>,
     info: &'i PageInfo<'i>,
     handle: &'h Handle,
+    random: Random,
 
     //
     // Included page scopes
@@ -78,6 +80,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
             backlinks: Backlinks::new(),
             info,
             handle,
+            random: Random::new(),
             variables: VariableScopes::new(),
             table_of_contents,
             footnotes,
@@ -131,6 +134,11 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
     #[inline]
     pub fn handle(&self) -> &'h Handle {
         self.handle
+    }
+
+    #[inline]
+    pub fn random(&mut self) -> &mut Random {
+        &mut self.random
     }
 
     #[inline]

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -29,6 +29,7 @@ mod element;
 mod escape;
 mod meta;
 mod output;
+mod random;
 mod render;
 
 pub use self::meta::{HtmlMeta, HtmlMetaType};

--- a/ftml/src/render/html/random.rs
+++ b/ftml/src/render/html/random.rs
@@ -87,9 +87,9 @@ fn html_id() {
         "Generated HTML ID doesn't match expected",
     );
 
-    let buffer = rand.generate_html_id();
+    let html_id = rand.generate_html_id();
     assert_eq!(
-        buffer, "wj-id-ePZbhugrfP89c4Fk",
+        html_id, "wj-id-ePZbhugrfP89c4Fk",
         "Generated HTML ID doesn't match expected",
     );
 }

--- a/ftml/src/render/html/random.rs
+++ b/ftml/src/render/html/random.rs
@@ -1,0 +1,70 @@
+/*
+ * render/html/random.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use cfg_if::cfg_if;
+use rand::distributions::Alphanumeric;
+use rand::prelude::*;
+use std::iter;
+
+#[cfg(test)]
+const TEST_RANDOM_SEED: [u8; 32] = [
+    0x53, 0x43, 0x50, 0x2d, 0x31, 0x37, 0x33, 0x3a, 0x20, 0x4d, 0x6f, 0x76, 0x65, 0x64,
+    0x20, 0x74, 0x6f, 0x20, 0x53, 0x69, 0x74, 0x65, 0x2d, 0x31, 0x39, 0x20, 0x31, 0x39,
+    0x39, 0x33, 0x2e, 0x0a,
+];
+
+#[derive(Debug)]
+pub struct Random {
+    rng: SmallRng,
+}
+
+impl Random {
+    #[inline]
+    pub fn new() -> Self {
+        let rng;
+
+        cfg_if! {
+            if #[cfg(test)] {
+                rng = SmallRng::from_seed(TEST_RANDOM_SEED);
+            } else {
+                rng = SmallRng::from_entropy()
+            }
+        }
+
+        Random { rng }
+    }
+
+    pub fn generate_html_id_into(&mut self, buffer: &mut String) {
+        buffer.push_str("wj-id-");
+
+        let char_stream = iter::repeat(())
+            .map(|_| self.rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(16);
+
+        buffer.extend(char_stream);
+    }
+
+    pub fn generate_html_id(&mut self) -> String {
+        let mut buffer = String::new();
+        self.generate_html_id_into(&mut buffer);
+        buffer
+    }
+}

--- a/ftml/src/render/html/random.rs
+++ b/ftml/src/render/html/random.rs
@@ -68,3 +68,26 @@ impl Random {
         buffer
     }
 }
+
+#[test]
+fn html_id() {
+    // Random output is deterministic in tests.
+    //
+    // This is to ensure HTML test output is consistent,
+    // but that means we can test for exact values here.
+
+    let mut rand = Random::new();
+    let mut buffer = String::new();
+
+    rand.generate_html_id_into(&mut buffer);
+    assert_eq!(
+        buffer, "wj-id-bW5Ql2DLZtnd9s18",
+        "Generated HTML ID doesn't match expected",
+    );
+
+    let buffer = rand.generate_html_id();
+    assert_eq!(
+        buffer, "wj-id-ePZbhugrfP89c4Fk",
+        "Generated HTML ID doesn't match expected",
+    );
+}

--- a/ftml/src/render/html/random.rs
+++ b/ftml/src/render/html/random.rs
@@ -35,9 +35,9 @@ pub struct Random {
     rng: SmallRng,
 }
 
-impl Random {
+impl Default for Random {
     #[inline]
-    pub fn new() -> Self {
+    fn default() -> Self {
         let rng;
 
         cfg_if! {
@@ -50,7 +50,9 @@ impl Random {
 
         Random { rng }
     }
+}
 
+impl Random {
     pub fn generate_html_id_into(&mut self, buffer: &mut String) {
         buffer.push_str("wj-id-");
 
@@ -76,7 +78,7 @@ fn html_id() {
     // This is to ensure HTML test output is consistent,
     // but that means we can test for exact values here.
 
-    let mut rand = Random::new();
+    let mut rand = Random::default();
     let mut buffer = String::new();
 
     rand.generate_html_id_into(&mut buffer);


### PR DESCRIPTION
This adds a random number generator used for producing random IDs in generation of HTML attributes that need that. However it's modified so that the output is deterministic, which is necessary for HTML tests.