### PR TITLE
[WJ-830] Add styling for note

### DIFF
--- a/client/modules/ftml-components/src/_default.scss
+++ b/client/modules/ftml-components/src/_default.scss
@@ -1,0 +1,8 @@
+/* DIVS */
+
+.wiki-note {
+    width: auto;
+    margin: 0.5em 5em;
+    border: 1px solid #999;
+    text-align: center;
+}

--- a/client/modules/ftml-components/src/index.scss
+++ b/client/modules/ftml-components/src/index.scss
@@ -1,5 +1,6 @@
 // Base
 @import "base";
+@import "default";
 
 // Components
 @import "components/code/code";


### PR DESCRIPTION
Because it's a not-commonly-used block that we really don't need, I'm not implementing `[[note]]` as a block. Instead, they will use the default class `wiki-note` to apply the same styling (i.e. `[[div class="wiki-note"]]`).

I'm adding a separate SCSS file for "default", that is, for our various `wiki-xxx` classes.