### PR TITLE
Better less stupid Timeout using a new class

### DIFF
--- a/client/.changeset/dull-paws-love.md
+++ b/client/.changeset/dull-paws-love.md
@@ -1,0 +1,5 @@
+---
+"@wikijump/util": minor
+---
+
+Added fancy Timeout class and associated functions.

--- a/client/modules/cm-espells/src/linter.ts
+++ b/client/modules/cm-espells/src/linter.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { EditorView, ViewPlugin, ViewUpdate } from "@wikijump/codemirror/cm"
+import { timeout, Timeout } from "@wikijump/util"
 import espells from "./espells"
 import { Spellcheck } from "./extension"
 import { getLocale } from "./locales"
@@ -8,21 +9,20 @@ import { visibleWords } from "./tokenizer"
 class SpellcheckLinter {
   declare id: number
   declare view: EditorView
-  declare timeout // untyped because TS types setTimeout badly
+  declare timeout: Timeout<Promise<void>>
 
   constructor(view: EditorView) {
     this.view = view
     // ensures that "this" gets preserved regardless of how the function is ran
     this.run = this.run.bind(this)
     this.id = Math.random()
-    this.timeout = setTimeout(this.run, 250)
+    this.timeout = timeout(250, this.run)
   }
 
   update(update: ViewUpdate) {
     if (update.docChanged || update.viewportChanged) {
       this.id = Math.random()
-      clearTimeout(this.timeout)
-      this.timeout = setTimeout(this.run, 250)
+      this.timeout.reset()
     }
   }
 

--- a/client/modules/ftml-components/package.json
+++ b/client/modules/ftml-components/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.10.1",
-    "@wikijump/prism": "workspace:*"
+    "@wikijump/prism": "workspace:*",
+    "@wikijump/util": "workspace:*"
   }
 }

--- a/client/modules/ftml-components/src/components/code/code.ts
+++ b/client/modules/ftml-components/src/components/code/code.ts
@@ -1,4 +1,5 @@
 import { highlight } from "@wikijump/prism"
+import { timeout } from "@wikijump/util"
 import { defineElement } from "../../util"
 
 /**
@@ -110,9 +111,7 @@ export class CodeCopyButton extends HTMLButtonElement {
       const text = code.innerText
       navigator.clipboard.writeText(text).then(() => {
         this.classList.add("wj-code-copy-success")
-        setTimeout(() => {
-          this.classList.remove("wj-code-copy-success")
-        }, 1000)
+        timeout(1000, () => this.classList.remove("wj-code-copy-success"))
       })
     })
   }

--- a/client/modules/ftml-components/src/components/footnotes/footnotes.ts
+++ b/client/modules/ftml-components/src/components/footnotes/footnotes.ts
@@ -1,4 +1,5 @@
 import * as Popper from "@popperjs/core"
+import { clearTimeout, timeout, Timeout } from "@wikijump/util"
 import { defineElement, hover } from "../../util"
 
 // TODO: proper mobile support (need more infrastructure for mobile support)
@@ -11,10 +12,10 @@ export class FootnoteReferenceMarker extends HTMLButtonElement {
   static tag = "wj-footnote-ref-marker"
 
   /** Timer to keep track of the delay for revealing the tooltip. */
-  declare onTimer?: number
+  declare onTimer?: Timeout
 
   /** Timer to keep track of the delay for hiding the tooltip. */
-  declare offTimer?: number
+  declare offTimer?: Timeout
 
   /** The Popper.js instance for handling placement of the tooltip. */
   declare popperInstance?: Popper.Instance
@@ -25,11 +26,11 @@ export class FootnoteReferenceMarker extends HTMLButtonElement {
     hover(this.parent, {
       on: () => {
         clearTimeout(this.offTimer)
-        this.onTimer = setTimeout(() => this.whenHovered(), 50)
+        this.onTimer = timeout(50, () => this.whenHovered())
       },
       off: () => {
         clearTimeout(this.onTimer)
-        this.offTimer = setTimeout(() => this.whenUnhovered(), 50)
+        this.offTimer = timeout(50, () => this.whenUnhovered())
       }
     })
 
@@ -86,10 +87,10 @@ export class FootnoteReferenceMarker extends HTMLButtonElement {
     if (this.popperInstance) {
       // we'll only destroy the instance after
       // a timeout, to give room for a fade animation
-      this.offTimer = setTimeout(() => {
+      this.offTimer = timeout(100, () => {
         this.popperInstance!.destroy()
         this.popperInstance = undefined
-      }, 100)
+      })
     }
   }
 }

--- a/client/modules/util/src/index.ts
+++ b/client/modules/util/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./decorators"
+export * from "./timeout"
 
 // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2694461
 /** Very quickly generates a (non-secure) hash from the given string. */

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -135,3 +135,13 @@ export function timeout<T>(delay: number, cb: () => T) {
 export function tick<T>(cb: () => T) {
   return new Timeout(0, cb)
 }
+
+/**
+ * Clears a {@link Timeout}.
+ *
+ * @param timeout - The timeout to clear.
+ */
+export function clearTimeout(timeout?: Timeout) {
+  if (!timeout) return
+  timeout.clear()
+}

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -3,7 +3,7 @@
  * Additionally provides some extra safety and avoids typing issues with
  * `NodeJS.Timeout`.
  */
-export class Timeout<T> {
+export class Timeout<T = void> {
   // typed as any to avoid NodeJS.Timeout
   private declare timeout: any
 
@@ -58,13 +58,12 @@ export class Timeout<T> {
   // `this is Timeout<T> & { value: T }
   /** Returns true if the timeout has expired already. */
   expired(): this is { value: T } {
-    if (!this.timeout) return true
-    return this.remaining() <= 0
+    return this.timeout === undefined
   }
 
   /** Clears the timeout and prevents it from expiring. */
   clear() {
-    if (!this.timeout || this.expired) return
+    if (!this.timeout) return
     clearTimeout(this.timeout)
     this.timeout = undefined
   }
@@ -105,6 +104,7 @@ export class Timeout<T> {
         const out = cb()
         this.promiseResolve(out)
         this.value = out
+        this.timeout = undefined
         return out
       }
     }
@@ -112,6 +112,7 @@ export class Timeout<T> {
     if (!this.expired) this.started = new Date()
     this.ends = new Date(this.started.getTime() + this.delay)
     this.value = undefined
+    this.clear() // make sure we end the old timeout
     this.timeout = setTimeout(this.cb, this.delay)
   }
 }

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -1,0 +1,136 @@
+/**
+ * Replacement class for `setTimeout`, with tons of utility features.
+ * Additionally provides some extra safety and avoids typing issues with
+ * `NodeJS.Timeout`.
+ */
+export class Timeout<T> {
+  // typed as any to avoid NodeJS.Timeout
+  private declare timeout: any
+
+  /** Function that resolves the timeout's `promise` Promise. */
+  private declare promiseResolve: (resolved: T) => void
+
+  /** The delay given before the callback should be fired. */
+  declare delay: number
+
+  /** The time the timeout will end by. */
+  declare ends: Date
+
+  /** The time the timeout was started. */
+  declare started: Date
+
+  /**
+   * A promise that resolves when the timeout expires. If the timeout is
+   * reset after it has expired, this property will be updated, so make
+   * sure to access this property directly and do not store it.
+   */
+  declare promise: Promise<T>
+
+  /**
+   * The final value returned by the callback function. Always undefined if
+   * the timeout is running.
+   */
+  declare value?: T
+
+  /**
+   * The callback that will be fired when the timeout expires. This **will
+   * not** be the same function that was given when this timeout was
+   * constructed, so identity comparisons won't work.
+   */
+  declare cb: () => T
+
+  /**
+   * @param delay - The delay between now and when the callback should be fired.
+   * @param cb - The callback that will be fired when the timeout expires.
+   */
+  constructor(delay: number, cb: () => T) {
+    this.reset(delay, cb)
+  }
+
+  /** The amount of time remaining before the timeout expires, in milliseconds. */
+  remaining() {
+    if (!this.ends || !this.started) return 0
+    return this.ends.getTime() - new Date().getTime()
+  }
+
+  // apparently, this is how you do typeguards for classes?
+  // it's a bit weird, it appears like it's a shorthand for
+  // `this is Timeout<T> & { value: T }
+  /** Returns true if the timeout has expired already. */
+  expired(): this is { value: T } {
+    if (!this.timeout) return true
+    return this.remaining() <= 0
+  }
+
+  /** Clears the timeout and prevents it from expiring. */
+  clear() {
+    if (!this.timeout || this.expired) return
+    clearTimeout(this.timeout)
+    this.timeout = undefined
+  }
+
+  /**
+   * Extends the timeout, adding the given delay to the current time
+   * remaining. Does nothing if the timeout has already expired.
+   *
+   * @param delay - The delay to add to the current time remaining.
+   */
+  extend(delay: number) {
+    if (this.expired()) return
+    this.reset(this.remaining() + delay)
+  }
+
+  /**
+   * Resets the timeout. Optionally allows changing the delay and callback.
+   *
+   * @param delay - The delay between now and when the callback should be fired.
+   * @param cb - The callback that will be fired when the timeout expires.
+   */
+  reset(delay?: number, cb?: () => T) {
+    if (cb && typeof cb !== "function") {
+      console.error("Avoided potential string eval in timeout!")
+      throw new Error("Timeout callback must be a function")
+    }
+
+    if (this.expired || !this.promise) {
+      this.promise = new Promise<T>(resolve => {
+        this.promiseResolve = resolve
+      })
+    }
+
+    if (delay) this.delay = delay
+
+    if (cb) {
+      this.cb = () => {
+        const out = cb()
+        this.promiseResolve(out)
+        this.value = out
+        return out
+      }
+    }
+
+    if (!this.expired) this.started = new Date()
+    this.ends = new Date(this.started.getTime() + this.delay)
+    this.value = undefined
+    this.timeout = setTimeout(this.cb, this.delay)
+  }
+}
+
+/**
+ * Creates a new {@link Timeout}.
+ *
+ * @param delay - The delay between now and when the callback should be fired.
+ * @param cb - The callback that will be fired when the timeout expires.
+ */
+export function timeout<T>(delay: number, cb: () => T) {
+  return new Timeout(delay, cb)
+}
+
+/**
+ * Creates a new {@link Timeout} that resolves as soon as possible.
+ *
+ * @param cb - The callback that will be fired when the timeout expires.
+ */
+export function tick<T>(cb: () => T) {
+  return new Timeout(0, cb)
+}

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -91,7 +91,7 @@ export class Timeout<T = void> {
       throw new Error("Timeout callback must be a function")
     }
 
-    if (this.expired || !this.promise) {
+    if (this.expired() || !this.promise) {
       this.promise = new Promise<T>(resolve => {
         this.promiseResolve = resolve
       })
@@ -109,7 +109,7 @@ export class Timeout<T = void> {
       }
     }
 
-    if (!this.expired) this.started = new Date()
+    if (this.expired()) this.started = new Date()
     this.ends = new Date(this.started.getTime() + this.delay)
     this.value = undefined
     this.clear() // make sure we end the old timeout
@@ -141,7 +141,9 @@ export function tick<T>(cb: () => T) {
  *
  * @param timeout - The timeout to clear.
  */
-export function clearTimeout(timeout?: Timeout) {
+function clearTimeoutClass(timeout?: Timeout) {
   if (!timeout) return
   timeout.clear()
 }
+
+export { clearTimeoutClass as clearTimeout }

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -47,6 +47,11 @@ export class Timeout<T = void> {
     this.reset(delay, cb)
   }
 
+  /** Function for fulfilling the thenable contract. */
+  then(resolve?: (value: T) => T | PromiseLike<T>) {
+    return this.promise.then(resolve)
+  }
+
   /** The amount of time remaining before the timeout expires, in milliseconds. */
   remaining() {
     if (!this.ends || !this.started) return 0

--- a/client/modules/util/src/timeout.ts
+++ b/client/modules/util/src/timeout.ts
@@ -55,7 +55,8 @@ export class Timeout<T = void> {
   /** The amount of time remaining before the timeout expires, in milliseconds. */
   remaining() {
     if (!this.ends || !this.started) return 0
-    return this.ends.getTime() - new Date().getTime()
+    const remaining = this.ends.getTime() - new Date().getTime()
+    return remaining > 0 ? remaining : 0
   }
 
   // apparently, this is how you do typeguards for classes?
@@ -107,9 +108,9 @@ export class Timeout<T = void> {
     if (cb) {
       this.cb = () => {
         const out = cb()
-        this.promiseResolve(out)
         this.value = out
         this.timeout = undefined
+        this.promiseResolve(out)
         return out
       }
     }
@@ -118,7 +119,7 @@ export class Timeout<T = void> {
     this.ends = new Date(this.started.getTime() + this.delay)
     this.value = undefined
     this.clear() // make sure we end the old timeout
-    this.timeout = setTimeout(this.cb, this.delay)
+    this.timeout = setTimeout(() => this.cb(), this.delay)
   }
 }
 

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -274,9 +274,11 @@ importers:
     specifiers:
       '@popperjs/core': ^2.10.1
       '@wikijump/prism': workspace:*
+      '@wikijump/util': workspace:*
     dependencies:
       '@popperjs/core': 2.10.1
       '@wikijump/prism': link:../prism
+      '@wikijump/util': link:../util
 
   modules/ftml-wasm:
     specifiers: {}


### PR DESCRIPTION
This fixes issues with TypeScript and its weird insistence on using `NodeJS.Timeout` sometimes. This is done through a fancy new `Timeout` class, which will almost assuredly get used by a bunch of stuff later on.