### PR TITLE
Use latest wasm-pack in our ftml CI builds

### DIFF
--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -60,10 +60,7 @@ jobs:
       - name: WASM Toolchain
         uses: jetli/wasm-pack-action@v0.3.0
         with:
-          # Normally this is 'latest', but we're temporarily
-          # downgrading because the action is failing on the latest
-          # wasm-pack version.
-          version: 'v0.10.0'
+          version: latest
 
       - name: Cargo Cache
         uses: actions/cache@v2


### PR DESCRIPTION
This was previously pinned due to an error. But now, it works.