### PR TITLE
Make karma value an enum

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.9.0"
+version = "1.9.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/data/karma.rs
+++ b/ftml/src/data/karma.rs
@@ -19,6 +19,7 @@
  */
 
 use std::convert::TryFrom;
+use std::fmt::{self, Display};
 
 /// Represents the Karma level a user has.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -29,6 +30,18 @@ pub enum KarmaLevel {
     Three,
     Four,
     Five,
+}
+
+impl KarmaLevel {
+    #[inline]
+    pub fn new(value: u8) -> Option<Self> {
+        KarmaLevel::try_from(value).ok()
+    }
+
+    #[inline]
+    pub fn value(self) -> u8 {
+        self.into()
+    }
 }
 
 impl From<KarmaLevel> for u8 {
@@ -58,5 +71,11 @@ impl TryFrom<u8> for KarmaLevel {
             5 => Ok(KarmaLevel::Five),
             _ => Err(value),
         }
+    }
+}
+
+impl Display for KarmaLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.value())
     }
 }

--- a/ftml/src/data/karma.rs
+++ b/ftml/src/data/karma.rs
@@ -22,7 +22,8 @@ use std::convert::TryFrom;
 use std::fmt::{self, Display};
 
 /// Represents the Karma level a user has.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize_repr, Deserialize_repr, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum KarmaLevel {
     Zero,
     One,

--- a/ftml/src/data/karma.rs
+++ b/ftml/src/data/karma.rs
@@ -1,0 +1,62 @@
+/*
+ * data/karma.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2021 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use std::convert::TryFrom;
+
+/// Represents the Karma level a user has.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum KarmaLevel {
+    Zero,
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+}
+
+impl From<KarmaLevel> for u8 {
+    #[inline]
+    fn from(level: KarmaLevel) -> u8 {
+        match level {
+            KarmaLevel::Zero => 0,
+            KarmaLevel::One => 1,
+            KarmaLevel::Two => 2,
+            KarmaLevel::Three => 3,
+            KarmaLevel::Four => 4,
+            KarmaLevel::Five => 5,
+        }
+    }
+}
+
+impl TryFrom<u8> for KarmaLevel {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<KarmaLevel, u8> {
+        match value {
+            0 => Ok(KarmaLevel::Zero),
+            1 => Ok(KarmaLevel::One),
+            2 => Ok(KarmaLevel::Two),
+            3 => Ok(KarmaLevel::Three),
+            4 => Ok(KarmaLevel::Four),
+            5 => Ok(KarmaLevel::Five),
+            _ => Err(value),
+        }
+    }
+}

--- a/ftml/src/data/mod.rs
+++ b/ftml/src/data/mod.rs
@@ -21,11 +21,13 @@
 //! Module for POD (plain old data) structs.
 
 mod backlinks;
+mod karma;
 mod page_info;
 mod page_ref;
 mod user_info;
 
 pub use self::backlinks::Backlinks;
+pub use self::karma::KarmaLevel;
 pub use self::page_info::PageInfo;
 pub use self::page_ref::{PageRef, PageRefParseError};
 pub use self::user_info::UserInfo;

--- a/ftml/src/data/user_info.rs
+++ b/ftml/src/data/user_info.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::KarmaLevel;
 use std::borrow::Cow;
 
 /// Returned information about a user.
@@ -33,7 +34,7 @@ pub struct UserInfo<'a> {
     pub user_name: Cow<'a, str>,
 
     /// The user's karma, from 0-5.
-    pub user_karma: u8,
+    pub user_karma: KarmaLevel,
 
     /// Inline image data.
     ///
@@ -56,7 +57,7 @@ impl UserInfo<'_> {
         UserInfo {
             user_id: 0,
             user_name: cow!("michal-frackowiak"),
-            user_karma: 5,
+            user_karma: KarmaLevel::new(5).unwrap(),
             user_avatar_data: cow!(AVATAR_BASE64_DATA),
             user_profile_url: cow!("/user:info/michal-frackowiak"),
         }


### PR DESCRIPTION
Creates `ftml::data::KarmaLevel`, which converts easily to `u8` as a value. Follow-up to #471 