### PR TITLE
Hotfix: Code blocks are not paragraph safe

### DIFF
--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/src/tree/element/object.rs
+++ b/ftml/src/tree/element/object.rs
@@ -356,7 +356,7 @@ impl Element<'_> {
             Element::User { .. } => true,
             Element::Date { .. } => true,
             Element::Color { .. } => true,
-            Element::Code { .. } => true,
+            Element::Code { .. } => false,
             Element::Math { .. } => false,
             Element::MathInline { .. } => true,
             Element::EquationReference(_) => true,

--- a/ftml/test/code-block.html
+++ b/ftml/test/code-block.html
@@ -1,3 +1,3 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>[[div]]
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>[[div]]
 test
-[[/div]]</code></pre></wj-code></p></wj-body>
+[[/div]]</code></pre></wj-code></wj-body>

--- a/ftml/test/code-block.json
+++ b/ftml/test/code-block.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "[[div]]\ntest\n[[/div]]",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "[[div]]\ntest\n[[/div]]",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-empty.html
+++ b/ftml/test/code-empty.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code></code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code></code></pre></wj-code></wj-body>

--- a/ftml/test/code-empty.json
+++ b/ftml/test/code-empty.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-inline-empty.html
+++ b/ftml/test/code-inline-empty.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code></code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code></code></pre></wj-code></wj-body>

--- a/ftml/test/code-inline-empty.json
+++ b/ftml/test/code-inline-empty.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-inline.html
+++ b/ftml/test/code-inline.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></wj-body>

--- a/ftml/test/code-inline.json
+++ b/ftml/test/code-inline.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "text here",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "text here",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-language-empty.html
+++ b/ftml/test/code-language-empty.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code></code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code></code></pre></wj-code></wj-body>

--- a/ftml/test/code-language-empty.json
+++ b/ftml/test/code-language-empty.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "",
-                                "language": "css"
-                            }
-                        }
-                    ]
+                    "contents": "",
+                    "language": "css"
                 }
             },
             {

--- a/ftml/test/code-language-spaces.html
+++ b/ftml/test/code-language-spaces.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code>apple banana</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code>apple banana</code></pre></wj-code></wj-body>

--- a/ftml/test/code-language-spaces.json
+++ b/ftml/test/code-language-spaces.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "apple banana",
-                                "language": "css"
-                            }
-                        }
-                    ]
+                    "contents": "apple banana",
+                    "language": "css"
                 }
             },
             {

--- a/ftml/test/code-language.html
+++ b/ftml/test/code-language.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code>apple banana</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-css"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language">css</span></div><pre><code>apple banana</code></pre></wj-code></wj-body>

--- a/ftml/test/code-language.json
+++ b/ftml/test/code-language.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "apple banana",
-                                "language": "css"
-                            }
-                        }
-                    ]
+                    "contents": "apple banana",
+                    "language": "css"
                 }
             },
             {

--- a/ftml/test/code-multiline.html
+++ b/ftml/test/code-multiline.html
@@ -1,4 +1,4 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>multiple
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>multiple
 **lines**
 of
-code</code></pre></wj-code></p></wj-body>
+code</code></pre></wj-code></wj-body>

--- a/ftml/test/code-multiline.json
+++ b/ftml/test/code-multiline.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "multiple\n**lines**\nof\ncode",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "multiple\n**lines**\nof\ncode",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-spaces.html
+++ b/ftml/test/code-spaces.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></wj-body>

--- a/ftml/test/code-spaces.json
+++ b/ftml/test/code-spaces.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "text here",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "text here",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code-uppercase.html
+++ b/ftml/test/code-uppercase.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></wj-body>

--- a/ftml/test/code-uppercase.json
+++ b/ftml/test/code-uppercase.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "text here",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "text here",
+                    "language": null
                 }
             },
             {

--- a/ftml/test/code.html
+++ b/ftml/test/code.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></p></wj-body>
+<wj-body class="wj-body"><wj-code class="wj-code wj-language-none"><div class="wj-code-panel"><wj-code-copy type="button" class="wj-code-copy" title="Copy to Clipboard"></wj-code-copy><span class="wj-code-language"></span></div><pre><code>text here</code></pre></wj-code></wj-body>

--- a/ftml/test/code.json
+++ b/ftml/test/code.json
@@ -3,19 +3,10 @@
     "tree": {
         "elements": [
             {
-                "element": "container",
+                "element": "code",
                 "data": {
-                    "type": "paragraph",
-                    "attributes": {},
-                    "elements": [
-                        {
-                            "element": "code",
-                            "data": {
-                                "contents": "text here",
-                                "language": null
-                            }
-                        }
-                    ]
+                    "contents": "text here",
+                    "language": null
                 }
             },
             {


### PR DESCRIPTION
This changes `Element::Code` to no longer be considered phrasing, since it's div-like. This was previously an issue, but only surfaced after we changed to custom elements.