### PR TITLE
Bump ftml version to v1.12.2

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.12.0"
+version = "1.12.2"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.12.1"
+version = "1.12.2"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 


### PR DESCRIPTION
We need to bump this because the `Cargo.lock` wasn't properly committed before.