### PR TITLE
[WJ-877] Refactor tags table schema

### DIFF
--- a/web/app/Services/Wikitext/PageInfo.php
+++ b/web/app/Services/Wikitext/PageInfo.php
@@ -45,7 +45,7 @@ class PageInfo
         $siteSlug = $page->getSite()->getUnixName();
         $title = $page->getTitle();
         $altTitle = null;
-        $tags = $page->getTagsAsArray();
+        $tags = $page->getTags();
         $language = 'default';
 
         return new PageInfo($pageSlug, $categorySlug, $siteSlug, $title, $altTitle, $tags, $language);

--- a/web/database/migrations/2021_09_30_065641_modify_tags_table.php
+++ b/web/database/migrations/2021_09_30_065641_modify_tags_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+      // Creating new column in Page table.
+      Schema::table('page', function (Blueprint $table) {
+        $table->jsonb('tags')->default('[]');
+      });
+
+      // Moving all tags from 'page_tag' table to new column in 'page' table.
+      $pages = DB::table('page_tag')->pluck('page_id')->toArray();
+      foreach ($pages as $page) {
+        $tags = DB::table('page_tag')->where('page_id', $page)->pluck('tag')->toArray();
+        DB::table('page')
+          ->where('page_id', $page)
+          ->update(['tags' => $tags]);
+      }
+
+      // Drop 'page_tag' table.
+      Schema::drop('page_tag');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/web/database/migrations/2021_09_30_065641_modify_tags_table.php
+++ b/web/database/migrations/2021_09_30_065641_modify_tags_table.php
@@ -39,6 +39,18 @@ class ModifyTagsTable extends Migration
      */
     public function down()
     {
-        //
+        // Recreates page_tag table.
+        Schema::create('page_tag', function (Blueprint $table) {
+            $table->id('tag_id');
+            $table->unsignedInteger('site_id')->nullable()->index();
+            $table->unsignedInteger('page_id')->nullable()->index();
+            $table->string('tag', 20)->nullable();
+        });
+
+        // Remove column from page table.
+        Schema::table('page', function (Blueprint $table) {
+            $table->dropColumn('tags');
+        });
+
     }
 }

--- a/web/database/migrations/2021_09_30_065641_modify_tags_table.php
+++ b/web/database/migrations/2021_09_30_065641_modify_tags_table.php
@@ -22,6 +22,7 @@ class ModifyTagsTable extends Migration
       $pages = DB::table('page_tag')->pluck('page_id')->toArray();
       foreach ($pages as $page) {
         $tags = DB::table('page_tag')->where('page_id', $page)->pluck('tag')->toArray();
+
         DB::table('page')
           ->where('page_id', $page)
           ->update(['tags' => $tags]);

--- a/web/lib/text_wiki/Text/Wiki/Parse/Default/Iftags.php
+++ b/web/lib/text_wiki/Text/Wiki/Parse/Default/Iftags.php
@@ -68,7 +68,7 @@ class Text_Wiki_Parse_Iftags extends Text_Wiki_Parse {
     		return;
     	}
 
-    	$tags = $page->getTagsAsArray();
+    	$tags = $page->getTags();
 
     	$tags0 = preg_split('/[, ]+/', trim($matches[1]));
 

--- a/web/php/Actions/WikiPageAction.php
+++ b/web/php/Actions/WikiPageAction.php
@@ -1434,7 +1434,6 @@ class WikiPageAction extends SmartyAction
         $od = new Outdater();
         $od->pageEvent("tag_change", $page);
 
-        $db->commit();
         if (GlobalProperties::$UI_SLEEP) {
             sleep(1);
         }

--- a/web/php/Actions/WikiPageAction.php
+++ b/web/php/Actions/WikiPageAction.php
@@ -1424,7 +1424,7 @@ class WikiPageAction extends SmartyAction
             }
         }
 
-        // Turn tags into a non-associative array, then ensure all tags are unique — remove any duplicates.
+        // Turn tags into an array, then ensure all tags are unique — remove any duplicates. If tags are empty, set tags to an empty array to ensure JSONB encoding functions properly.
         if ($tags === '') {
             $tags = [];
         } else {

--- a/web/php/Actions/WikiPageAction.php
+++ b/web/php/Actions/WikiPageAction.php
@@ -1424,9 +1424,14 @@ class WikiPageAction extends SmartyAction
             }
         }
 
-        // Turn tags into an array, then ensure all tags are unique — remove any duplicates.
-        $tags = explode(" ", $tags);
-        $tags = array_unique($tags);
+        // Turn tags into a non-associative array, then ensure all tags are unique — remove any duplicates.
+        if ($tags === '') {
+            $tags = [];
+        } else {
+            $tags = preg_split("/[ ,]+/", $tags);
+            $tags = array_unique(array_values($tags));
+        }
+
 
         // Save the tags.
         PagePeer::saveTags($pageId, $tags);

--- a/web/php/DB/Page.php
+++ b/web/php/DB/Page.php
@@ -2,7 +2,7 @@
 
 namespace Wikidot\DB;
 
-
+use Illuminate\Support\Facades\DB;
 use Ozone\Framework\Database\Criteria;
 use Wikidot\Utils\ProcessException;
 use Ozone\Framework\Database\Database;
@@ -161,20 +161,7 @@ class Page extends PageBase
 
     public function getTags()
     {
-        $c = new Criteria();
-        $c->add('page_id', $this->getPageId());
-        $tags = PageTagPeer::instance()->select($c);
-        return $tags;
-    }
-
-    public function getTagsAsArray()
-    {
-        $tags = $this->getTags();
-        $t = array();
-        foreach ($tags as $ta) {
-            $t[] = $ta->getTag();
-        }
-        return $t;
+        return PagePeer::getTags($this->getPageId());
     }
 
     public function getTitle()

--- a/web/php/DB/PagePeer.php
+++ b/web/php/DB/PagePeer.php
@@ -24,4 +24,10 @@ class PagePeer extends PagePeerBase
     public static function getTags($pageId) {
         return json_decode(DB::table('page')->where('page_id', $pageId)->value('tags'));
     }
+
+    public static function saveTags($pageId, $newTags) {
+        DB::table('page')
+          ->where('page_id', $pageId)
+          ->update(['tags' => $newTags]);
+    }
 }

--- a/web/php/DB/PagePeer.php
+++ b/web/php/DB/PagePeer.php
@@ -2,6 +2,7 @@
 
 namespace Wikidot\DB;
 
+use Illuminate\Support\Facades\DB;
 use Ozone\Framework\Database\Criteria;
 use Wikidot\Utils\WDStringUtils;
 
@@ -18,5 +19,9 @@ class PagePeer extends PagePeerBase
         $c->add("site_id", $siteId);
         $c->add("unix_name", WDStringUtils::toUnixName($name));
         return $this->selectOne($c);
+    }
+
+    public static function getTags($pageId) {
+        return json_decode(DB::table('page')->where('page_id', $pageId)->value('tags'));
     }
 }

--- a/web/php/Modules/PageTags/PageTagsModule.php
+++ b/web/php/Modules/PageTags/PageTagsModule.php
@@ -41,21 +41,10 @@ class PageTagsModule extends SmartyModule
         $taglist = AllowedTags::getAllowedTags($siteId);
 
         // Fetch the tags and convert them to a string.
+        $tags = DB::table('page')->where('page_id', $pageId)->pluck('tag')->toArray();
+        $tags = implode(' ', $tags);
 
-        $c = new Criteria();
-        $c->add("page_id", $pageId);
-        $c->addOrderAscending("tag");
-
-        $tags = PageTagPeer::instance()->selectByCriteria($c);
-
-        $t2 = array();
-        foreach ($tags as $t) {
-            $t2[] = $t->getTag();
-        }
-
-        $t3 = implode(' ', $t2);
-
-        $runData->contextAdd("tags", $t3);
+        $runData->contextAdd("tags", $tags);
         $runData->contextAdd("taglist", $taglist);
     }
 }

--- a/web/php/Modules/PageTags/PageTagsModule.php
+++ b/web/php/Modules/PageTags/PageTagsModule.php
@@ -2,11 +2,11 @@
 
 namespace Wikidot\Modules\PageTags;
 
+use Illuminate\Support\Facades\DB;
 use Ozone\Framework\Database\Criteria;
 use Wikidot\DB\PagePeer;
 use Wikidot\DB\PageTagPeer;
 use Wikidot\DB\AllowedTags;
-
 use Ozone\Framework\SmartyModule;
 use Wikidot\Utils\ProcessException;
 use Wikidot\Utils\WDPermissionManager;
@@ -40,9 +40,9 @@ class PageTagsModule extends SmartyModule
         $siteId = $site->getSiteId();
         $taglist = AllowedTags::getAllowedTags($siteId);
 
-        // Fetch the tags and convert them to a string.
-        $tags = DB::table('page')->where('page_id', $pageId)->pluck('tag')->toArray();
-        $tags = implode(' ', $tags);
+        // Fetch the tags, decode them from JSON, and convert them to a string.
+        $tags = DB::table('page')->where('page_id', $pageId)->value('tags');
+        $tags = implode(" ", json_decode($tags));
 
         $runData->contextAdd("tags", $tags);
         $runData->contextAdd("taglist", $taglist);

--- a/web/php/Modules/PageTags/PageTagsModule.php
+++ b/web/php/Modules/PageTags/PageTagsModule.php
@@ -40,9 +40,9 @@ class PageTagsModule extends SmartyModule
         $siteId = $site->getSiteId();
         $taglist = AllowedTags::getAllowedTags($siteId);
 
-        // Fetch the tags, decode them from JSON, and convert them to a string.
-        $tags = DB::table('page')->where('page_id', $pageId)->value('tags');
-        $tags = implode(" ", json_decode($tags));
+        // Fetch the tags and convert them to a string.
+        $tags = PagePeer::getTags($pageId);
+        $tags = implode(" ", $tags);
 
         $runData->contextAdd("tags", $tags);
         $runData->contextAdd("taglist", $taglist);

--- a/web/php/Modules/Wiki/HotTags/GlobalHotTagsModule.php
+++ b/web/php/Modules/Wiki/HotTags/GlobalHotTagsModule.php
@@ -127,11 +127,10 @@ class GlobalHotTagsModule extends SmartyModule
         $db = Database::connection();
         //select tags
         if ($category == null) {
-            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page_tag  WHERE site_id='".$site->getSiteId()."' GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
+            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page  WHERE site_id='".$site->getSiteId()."' GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
         } else {
-            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page_tag, page  WHERE page_tag.site_id='".$site->getSiteId()."' " .
-                    " AND page.category_id='".$category->getCategoryId()."' " .
-                    " AND page.page_id = page_tag.page_id " .
+            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page  WHERE site_id='".$site->getSiteId()."' " .
+                    " AND category_id='".$category->getCategoryId()."' " .
                     "GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
 
             $runData->contextAdd("category", $category);

--- a/web/php/Modules/Wiki/HotTags/PagesListByTagModule.php
+++ b/web/php/Modules/Wiki/HotTags/PagesListByTagModule.php
@@ -80,14 +80,13 @@ class PagesListByTagModule extends SmartyModule
         }
 
         $c = new Criteria();
-        $c->setExplicitFrom("page, page_tag");
-        $c->add("page_tag.tag", $tag);
-        $c->add("page_tag.site_id", $site->getSiteId());
-        $c->add("page_tag.page_id", "page.page_id", "=", false);
+        $c->setExplicitFrom("page");
+        $c->add("tags", $tag);
+        $c->add("site_id", $site->getSiteId());
         if ($category) {
-            $c->add("page.category_id", $category->getCategoryId());
+            $c->add("category_id", $category->getCategoryId());
         }
-        $c->addOrderAscending('COALESCE(page.title, page.unix_name)');
+        $c->addOrderAscending('COALESCE(title, unix_name)');
 
         $pages = PagePeer::instance()->select($c);
 

--- a/web/php/Modules/Wiki/PagesTagCloud/PagesListByTagModule.php
+++ b/web/php/Modules/Wiki/PagesTagCloud/PagesListByTagModule.php
@@ -81,14 +81,13 @@ class PagesListByTagModule extends SmartyModule
         }
 
         $c = new Criteria();
-        $c->setExplicitFrom("page, page_tag");
-        $c->add("page_tag.tag", $tag);
-        $c->add("page_tag.site_id", $site->getSiteId());
-        $c->add("page_tag.page_id", "page.page_id", "=", false);
+        $c->setExplicitFrom("page");
+        $c->add("tags", $tag);
+        $c->add("site_id", $site->getSiteId());
         if ($category) {
-            $c->add("page.category_id", $category->getCategoryId());
+            $c->add("category_id", $category->getCategoryId());
         }
-        $c->addOrderAscending('COALESCE(page.title, page.unix_name)');
+        $c->addOrderAscending('COALESCE(title, unix_name)');
 
         $pages = PagePeer::instance()->select($c);
 

--- a/web/php/Modules/Wiki/PagesTagCloud/PagesTagCloudModule.php
+++ b/web/php/Modules/Wiki/PagesTagCloud/PagesTagCloudModule.php
@@ -249,11 +249,10 @@ class PagesTagCloudModule extends SmartyModule
         //select tags
 
         if ($category == null) {
-            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page_tag  WHERE site_id='".$site->getSiteId()."' GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
+            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page  WHERE site_id='".$site->getSiteId()."' GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
         } else {
-            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page_tag, page  WHERE page_tag.site_id='".$site->getSiteId()."' " .
-                    " AND page.category_id='".$category->getCategoryId()."' " .
-                    " AND page.page_id = page_tag.page_id " .
+            $q = "SELECT * FROM (SELECT tag, COUNT(*) AS weight FROM page  WHERE site_id='".$site->getSiteId()."' " .
+                    " AND category_id='".$category->getCategoryId()."' " .
                     "GROUP BY tag ORDER BY weight DESC LIMIT $limit) AS foo ORDER BY tag";
 
             $runData->contextAdd("category", $category);

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -149,7 +149,7 @@ class WikiScreen extends Screen
 
             // Get the tags and convert them to string.
             $tags = PagePeer::getTags($pageId);
-            if($tags != null) {
+            if(!empty($tags)) {
                 $tags = implode(" ", $tags);
             }
             $runData->contextAdd("tags", $tags);

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -13,7 +13,6 @@ use Wikidot\DB\MemberPeer;
 use Wikidot\DB\SiteViewerPeer;
 use Wikidot\DB\PagePeer;
 use Wikidot\DB\CategoryPeer;
-use Wikidot\DB\PageTagPeer;
 use Wikidot\DB\ForumThreadPeer;
 use Wikidot\DB\NotificationPeer;
 use Wikidot\Utils\GlobalProperties;

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -3,6 +3,7 @@
 namespace Wikidot\Screens\Wiki;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Ozone\Framework\Database\Criteria;
 use Ozone\Framework\Database\Database;
 use Ozone\Framework\Ozone;
@@ -148,15 +149,8 @@ class WikiScreen extends Screen
             $runData->contextAdd("showPageoptions", $showPageOptions);
 
             // get the tags
-            $c = new Criteria();
-            $c->add("page_id", $page->getPageId());
-            $c->addOrderAscending("tag");
-            $tags = PageTagPeer::instance()->select($c);
-            $t2 = array();
-            foreach ($tags as $t) {
-                $t2[] = $t->getTag();
-            }
-            $runData->contextAdd("tags", $t2);
+            $tags = DB::table('page')->where('page_id', $pageId)->pluck('tags')->toArray();
+            $runData->contextAdd("tags", $tags);
 
             // has discussion?
             if ($page->getThreadId()!== null) {

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -149,7 +149,8 @@ class WikiScreen extends Screen
             $runData->contextAdd("showPageoptions", $showPageOptions);
 
             // get the tags
-            $tags = DB::table('page')->where('page_id', $pageId)->pluck('tags')->toArray();
+            $tags = DB::table('page')->where('page_id', $pageId)->value('tags');
+            $tags = implode(" ", json_decode($tags));
             $runData->contextAdd("tags", $tags);
 
             // has discussion?

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -149,8 +149,10 @@ class WikiScreen extends Screen
             $runData->contextAdd("showPageoptions", $showPageOptions);
 
             // Get the tags and convert them to string.
-            $tags = $tags = PagePeer::getTags($pageId);
-            $tags = implode(" ", $tags);
+            $tags = PagePeer::getTags($pageId);
+            if($tags != null) {
+                $tags = implode(" ", $tags);
+            }
             $runData->contextAdd("tags", $tags);
 
             // has discussion?

--- a/web/php/Screens/Wiki/WikiScreen.php
+++ b/web/php/Screens/Wiki/WikiScreen.php
@@ -148,9 +148,9 @@ class WikiScreen extends Screen
             $showPageOptions = true;
             $runData->contextAdd("showPageoptions", $showPageOptions);
 
-            // get the tags
-            $tags = DB::table('page')->where('page_id', $pageId)->value('tags');
-            $tags = implode(" ", json_decode($tags));
+            // Get the tags and convert them to string.
+            $tags = $tags = PagePeer::getTags($pageId);
+            $tags = implode(" ", $tags);
             $runData->contextAdd("tags", $tags);
 
             // has discussion?

--- a/web/php/Utils/Indexer.php
+++ b/web/php/Utils/Indexer.php
@@ -99,12 +99,6 @@ class Indexer
         $title = db_escape_string(htmlspecialchars($thread->getTitle()));
         $description = db_escape_string(htmlspecialchars($thread->getDescription()));
 
-        $db = Database::connection();
-        $v = pg_version($db->getLink());
-        if (!preg_match('/^8\.3/', $v['server'])) {
-            // $db->query("SELECT set_curcfg('default')");  # This is related to tsearch2 which is no longer available.
-        }
-
         $ie->setVector("setweight( to_tsvector('$title'), 'C') || setweight( to_tsvector('$description'), 'C') || to_tsvector('".db_escape_string($text)."')", true);
 
         $ie->save();

--- a/web/php/Utils/Indexer.php
+++ b/web/php/Utils/Indexer.php
@@ -7,6 +7,7 @@ use Ozone\Framework\Database\Database;
 use Wikidot\DB\FtsEntryPeer;
 use Wikidot\DB\FtsEntry;
 use Wikidot\DB\PageTagPeer;
+use Wikidot\DB\PagePeer;
 use Wikidot\DB\ForumPostPeer;
 
 /**
@@ -53,21 +54,15 @@ class Indexer
         $unixName =  db_escape_string(htmlspecialchars($page->getUnixName()));
 
         //get tags
-        $c = new Criteria();
-        $c->add("page_id", $page->getPageId());
-        $c->addOrderAscending("tag");
-        $tags = PageTagPeer::instance()->select($c);
-        $tagstring = '';
-        foreach ($tags as $tag) {
-            $tagstring .= $tag->getTag().' ';
-        }
+        $tags = PagePeer::getTags($page->getPageId());
+        $tags = implode(' ', $tags);
 
         $db = Database::connection();
         $v = pg_version($db->getLink());
 //      if(!preg_match(';^8\.3;', $v['server'])){
 //          $db->query("SELECT set_curcfg('default')");
 //      }
-        $ie->setVector("(setweight( to_tsvector('$title'), 'A') || to_tsvector('".db_escape_string($text)."') || setweight( to_tsvector('$tagstring'), 'B'))", true);
+        $ie->setVector("(setweight( to_tsvector('$title'), 'A') || to_tsvector('".db_escape_string($text)."') || setweight( to_tsvector('$tags'), 'B'))", true);
         $ie->save();
     }
 


### PR DESCRIPTION
[WJ-877](https://scuttle.atlassian.net/browse/WJ-877) ("Refactor tags table schema") has been mostly resolved with this PR. This PR modifies the `page` table to have an column that stores JSONB arrays for the tags instead of a separate table. Additionally, it also refactors the php in numerous areas to account for this change, and drops the now-deprecated `page_tags` table.