### PR TITLE
[WJ-880] Add Wikijump Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+## Security Policy
+
+The Wikijump Team prioritizes security and will fix issues as soon as they are disclosed.
+
+If you discover a security vulnerability, please reach out to a member of the Wikijump Security Team, who may be contacted as follows:
+
+| GitHub       | Wikidot                                                               | Discord           | Email                     |
+|--------------|-----------------------------------------------------------------------|-------------------|---------------------------|
+| @ammongit    | [aismallard](http://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
+| @rossjrw     | [Croquembouche](http://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
+| @stormbreath | [stormbreath](http://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
+| @danieltharp | [pxdnbluesoul](http://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
+
+### Wikijump
+
+After receiving a report of a security issue within Wikijump, we will validate and determine its scope.
+Once this is done, we will issue an estimate for the time to completion. When a fix has been merged in and deployed,
+you will be notified privately. If this security issue impacts Wikijump _only_, you may disclose it publicly.
+
+### Wikidot
+
+The Wikijump Security Team also receives reports of security issues within Wikidot. You are encouraged to report
+any vulnerabilities or exploits you discover.
+
+However, standard security disclosure cannot apply here, for three important reasons:
+
+1. Wikidot is controlled by a third-party, so we are unable to apply security patches.
+2. Wikidot is completely unmaintained, so even severe vulnerabilities will not be fixed.
+3. Wikidot is actively used by a large number of users, and public disclosure of a vulnerability has the potential to cause a significant amount of harm with no recourse.
+
+Because of this, the strategy we utilize is (unfortunately) based on _mitigation and concealment_.
+When you make your report, we will document it privately like other vulnerabilities, and assess its level of current impact.
+If any occurrences of the issue are found in the wild, every effort will be made to remove or replace them, while minimizing
+the number of people aware of the issue. If needed, a minimal number of administrators of large Wikidot sites will be made aware
+of recommended mitigations.
+Finally, the potential impact on Wikijump will be determined, and if the issue is also present there, it will be promptly fixed.
+
+As such, you will be asked to not discuss the exploit. This request will only be lifted in the very unlikely scenario that Wikidot releases a patch.
+
+A Wikidot bug will **not** be created, both because it is public and will become known to any potential bad actors, but because the issue is extremely
+unlikely to be fixed. If a method of contacting Wikidot, Inc. is found that is able to result in fixes to issues, it will be utilized to patch the
+vulnerabilities under our purview.
+
+We understand that this is not in line with typical practices for [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure),
+but due to the constraints of our lack of platform autonomy and the massive impact malicious use of vulnerabilities has, this is our current strategy.
+
+We acknowledge that concealment is not a substitute for proper patching, and that this is a temporary procedure until we are able to migrate fully onto Wikijump.
+
+If you have questions, please contact a member of the Wikijump Security Team.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,9 @@ Finally, the potential impact on Wikijump will be determined, and if the issue i
 
 As such, you will be asked to not discuss the exploit. This request will only be lifted in the very unlikely scenario that Wikidot releases a patch.
 
-A Wikidot bug will **not** be created, both because it is public and will become known to any potential bad actors, but because the issue is extremely
-unlikely to be fixed. If a method of contacting Wikidot, Inc. is found that is able to result in fixes to issues, we will use this to patch the
-vulnerabilities under our purview.
+We will **not** create an issue on [feedback.wikidot.com](https://feedback.wikidot.com/), both because it is public and will become known
+to any potential bad actors, but because the issue is extremely unlikely to be fixed.
+If a method of contacting Wikidot, Inc. is found that is able to result in fixes to issues, we will use this to patch the vulnerabilities under our purview.
 
 We understand that this is not in line with typical practices for [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure),
 but due to the constraints of our lack of platform autonomy and the potential massive impact of malicious use of vulnerabilities, this is our current strategy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Finally, the potential impact on Wikijump will be determined, and if the issue i
 As such, you will be asked to not discuss the exploit. This request will only be lifted in the very unlikely scenario that Wikidot releases a patch.
 
 A Wikidot bug will **not** be created, both because it is public and will become known to any potential bad actors, but because the issue is extremely
-unlikely to be fixed. If a method of contacting Wikidot, Inc. is found that is able to result in fixes to issues, it will be utilized to patch the
+unlikely to be fixed. If a method of contacting Wikidot, Inc. is found that is able to result in fixes to issues, we will use this to patch the
 vulnerabilities under our purview.
 
 We understand that this is not in line with typical practices for [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,10 @@ or reaching out to a member individually:
 
 ### Wikijump
 
-After receiving a report of a security issue within Wikijump, we will validate and determine its scope.
-Once this is done, we will issue an estimate for the time to completion. When a fix has been merged in and deployed,
-you will be notified privately. If this security issue impacts Wikijump _only_, you may then disclose it publicly.
+After receiving a report of a security issue within Wikijump, we will confirm its receipt within 48 hours.
+After we have validated and determined its scope, we will send a more detailed response within 72 hours.
+When a fix has been merged in and deployed, you will be notified privately.
+If this security issue impacts Wikijump _only_, you may then disclose it publicly.
 
 ### Wikidot
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,7 @@ unlikely to be fixed. If a method of contacting Wikidot, Inc. is found that is a
 vulnerabilities under our purview.
 
 We understand that this is not in line with typical practices for [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure),
-but due to the constraints of our lack of platform autonomy and the massive impact malicious use of vulnerabilities has, this is our current strategy.
+but due to the constraints of our lack of platform autonomy and the potential massive impact of malicious use of vulnerabilities, this is our current strategy.
 
 We acknowledge that concealment is not a substitute for proper patching, and that this is a temporary procedure until we are able to migrate fully onto Wikijump.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@ The Wikijump Team prioritizes security and will fix issues as soon as they are d
 
 If you discover a security vulnerability, please reach out to a member of the Wikijump Security Team, who may be contacted as follows:
 
-| GitHub       | Wikidot                                                               | Discord           | Email                     |
-|--------------|-----------------------------------------------------------------------|-------------------|---------------------------|
-| @ammongit    | [aismallard](http://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
-| @rossjrw     | [Croquembouche](http://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
-| @stormbreath | [stormbreath](http://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
-| @danieltharp | [pxdnbluesoul](http://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
+| GitHub       | Wikidot                                                                | Discord           | Email                     |
+|--------------|------------------------------------------------------------------------|-------------------|---------------------------|
+| @ammongit    | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
+| @rossjrw     | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
+| @stormbreath | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
+| @danieltharp | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
 
 ### Wikijump
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ you will be notified privately. If this security issue impacts Wikijump _only_, 
 
 ### Wikidot
 
-The Wikijump Security Team also receives reports of security issues within Wikidot. You are encouraged to report
+The Wikijump Security Team also receives reports of security issues within Wikidot. We encourage you to report
 any vulnerabilities or exploits you discover.
 
 However, standard security disclosure cannot apply here, for three important reasons:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 The Wikijump Team prioritizes security and will fix issues as soon as they are disclosed.
 
-If you discover a security vulnerability, please reach out to a member of the Wikijump Security Team, who may be contacted as follows:
+If you discover a security vulnerability, please privately contact the Wikijump Security Team. This can be done by emailing security@wikijump.org,
+or reaching out to a member individually:
 
 | GitHub                                         | Wikidot                                                                | Discord           | Email                     |
 |------------------------------------------------|------------------------------------------------------------------------|-------------------|---------------------------|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ or reaching out to a member individually:
 
 After receiving a report of a security issue within Wikijump, we will validate and determine its scope.
 Once this is done, we will issue an estimate for the time to completion. When a fix has been merged in and deployed,
-you will be notified privately. If this security issue impacts Wikijump _only_, you may disclose it publicly.
+you will be notified privately. If this security issue impacts Wikijump _only_, you may then disclose it publicly.
 
 ### Wikidot
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ or reaching out to a member individually:
 |------------------------------------------------|------------------------------------------------------------------------|-------------------|---------------------------|
 | [@ammongit](https://github.com/ammongit)       | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
 | [@stormbreath](https://github.com/stormbreath) | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
-| [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
+| [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | ross@rossjrw.com          |
 | [@danieltharp](https://github.com/danieltharp) | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
 
 ### Wikijump

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ If you discover a security vulnerability, please reach out to a member of the Wi
 | GitHub                                         | Wikidot                                                                | Discord           | Email                     |
 |------------------------------------------------|------------------------------------------------------------------------|-------------------|---------------------------|
 | [@ammongit](https://github.com/ammongit)       | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
-| [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
 | [@stormbreath](https://github.com/stormbreath) | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
+| [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
 | [@danieltharp](https://github.com/danieltharp) | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
 
 ### Wikijump

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@ The Wikijump Team prioritizes security and will fix issues as soon as they are d
 
 If you discover a security vulnerability, please reach out to a member of the Wikijump Security Team, who may be contacted as follows:
 
-| GitHub       | Wikidot                                                                | Discord           | Email                     |
-|--------------|------------------------------------------------------------------------|-------------------|---------------------------|
-| @ammongit    | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
-| @rossjrw     | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
-| @stormbreath | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
-| @danieltharp | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
+| GitHub                                         | Wikidot                                                                | Discord           | Email                     |
+|------------------------------------------------|------------------------------------------------------------------------|-------------------|---------------------------|
+| [@ammongit](https://github.com/ammongit)       | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
+| [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | rossjrw@gmail.com         |
+| [@stormbreath](https://github.com/stormbreath) | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
+| [@danieltharp](https://github.com/danieltharp) | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |
 
 ### Wikijump
 


### PR DESCRIPTION
This document describes and documents our current procedures for handling security vulnerabilities in both Wikidot and Wikijump. Parts were based on [Sequelize's Security Policy](https://github.com/sequelize/sequelize/security/policy).

I'm interested in critique over wording and exact description of procedure, as this is a public document.

If you are a member of the Wikijump Security Team, and you feel comfortable publishing your Discord contact information in the document, mention it so I can add it. The emails listed are those publicly visible on each person's associated GitHub account, if you wish for it to be changed, please also mention it.