### PR TITLE
Hotfix: APP_DEBUG on dev

### DIFF
--- a/install/files/dev/env
+++ b/install/files/dev/env
@@ -1,6 +1,6 @@
 APP_NAME=Wikijump
 APP_ENV=dev
-APP_DEBUG=true
+APP_DEBUG=false
 APP_KEY=
 APP_URL=https://www.wikijump.dev/wikijump--next
 ASSET_URL=https://www.wikijump.dev/wikijump--next/assets


### PR DESCRIPTION
`APP_DEBUG` and non-local environments are incompatible. This produces a warning in Laravel on our dev deployment.