### PR TITLE
[WJ-899] Remove star dependency from ftml

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.12.2"
+version = "1.12.3"
 dependencies = [
  "built",
  "cbindgen",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = []
 exclude = [".gitignore", ".github"]
 
-version = "1.12.2"
+version = "1.12.3"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2018" # this refers to the Cargo.toml version
 

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -63,7 +63,7 @@ sloggers = "2"
 termcolor = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "*", features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }
 self_cell = "0.9"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["console"] }


### PR DESCRIPTION
This will permit us to publish the latest version of `ftml` as a crate on [crates.io](https://crates.io).