### PR TITLE
Hotfix for dev/prod: use full ASSET_URL urls (UGH)

### DIFF
--- a/install/files/dev/env
+++ b/install/files/dev/env
@@ -3,7 +3,7 @@ APP_ENV=dev
 APP_DEBUG=false
 APP_KEY=
 APP_URL=https://www.wikijump.dev/wikijump--next
-ASSET_URL=
+ASSET_URL=https://www.wikijump.dev
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=debug

--- a/install/files/env
+++ b/install/files/env
@@ -3,7 +3,7 @@ APP_ENV=%%APP_ENV%%
 APP_KEY=
 APP_DEBUG=true
 APP_URL=https://www.wikijump.dev/wikijump--next
-ASSET_URL=
+ASSET_URL=https://www.wikijump.dev
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=debug

--- a/install/files/local/env
+++ b/install/files/local/env
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=
 APP_URL=http://www.wikijump.localhost/wikijump--next
-ASSET_URL=/files--built
+ASSET_URL=http://www.wikijump.localhost
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=debug

--- a/install/files/prod/env
+++ b/install/files/prod/env
@@ -3,7 +3,7 @@ APP_ENV=prod
 APP_DEBUG=false
 APP_KEY=
 APP_URL=https://www.wikijump.com/wikijump--next
-ASSET_URL=
+ASSET_URL=https://www.wikijump.com
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=debug

--- a/web/.env.example
+++ b/web/.env.example
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=https://www.wikijump.dev/wikijump--next
-ASSET_URL=
+ASSET_URL=https://www.wikijump.dev
 
 LOG_CHANNEL=stderr
 LOG_LEVEL=debug


### PR DESCRIPTION
Apparently, an `ASSET_URL` of `/` doesn't work! And leaving `ASSET_URL` blank will emit the wrong protocols! Let's just hope this works, it seems to work locally.