### PR TITLE
Fix localization build

### DIFF
--- a/locales/messages/__init__.py
+++ b/locales/messages/__init__.py
@@ -6,7 +6,6 @@
 Parent file for the messages module.
 """
 
-from . import gettext, schema
+from . import catalog, gettext, schema
 from .path_loader import load
 from .schema import MessagesSchema
-from .messages import Messages, MessagesData, MessagesTree

--- a/locales/messages/__main__.py
+++ b/locales/messages/__main__.py
@@ -9,8 +9,8 @@ Executable file, permitting command-line building of messages files.
 import os
 import sys
 
+from .catalog import get_template_messages
 from .gettext import build_mo, generate_po
-from .messages import get_template_messages
 from .path_loader import OUTPUT_DIRECTORY, load
 from .schema import MAIN_MESSAGE_SCHEMA_NAME, validate_all
 

--- a/locales/messages/catalog.py
+++ b/locales/messages/catalog.py
@@ -1,9 +1,9 @@
 #
-# messages.py - Wikijump Locale Builder
+# catalog.py - Wikijump Locale Builder
 #
 
 """
-Represents a messages object, as loaded from configuration.
+Represents a message catalog object, as loaded from configuration.
 
 Includes any data loaded from parent object(s).
 

--- a/locales/messages/gettext.py
+++ b/locales/messages/gettext.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 from typing import Iterable, Optional
 
-from .messages import Messages
+from .catalog import Messages
 
 # For extracting individual comment lines:
 # - Ignore any lines not starting with '##'

--- a/locales/messages/path_loader.py
+++ b/locales/messages/path_loader.py
@@ -13,7 +13,7 @@ from graphlib import TopologicalSorter
 
 from ruamel.yaml import YAML
 
-from .messages import Messages, flatten
+from .catalog import Messages, flatten
 
 MESSAGE_FILENAME_REGEX = re.compile(r"(([a-z]+)(?:_([A-Z]+))?)\.ya?ml")
 


### PR DESCRIPTION
The `/locales` build [was failing](https://github.com/scpwiki/wikijump/runs/3850612773?check_suite_focus=true) because pylint thought that `messages/messages.py` referred to the head module `messages`, and could not resolve names properly. To avoid this disconnect between the runtime and the linter, I have renamed the file.