### PR TITLE
Tag Refactor Part III

### DIFF
--- a/web/DEADCODE.md
+++ b/web/DEADCODE.md
@@ -202,6 +202,12 @@ If possible, add to this log in the same commit in which the code is removed.
 * What it did: Allowed storing arbitrary data for use in miscellaneous parts of the code.
 * Why it was removed: Code smell, also only used by `MailForm` which is now gone (see above). Its corresponding database migrations were not in the code, so the table was non-functional.
 
+## PHP: `PageTags`
+* Where it was: [web/php/DB/PageTags](https://github.com/scpwiki/wikijump/blob/d9a414d9319477673e23f1bbe16ad780394b0bb7/web/php/DB/PageTag.php)
+* Relevant Issues: [WJ-755](https://scuttle.atlassian.net/browse/WJ-755)
+* What it did: Tag CRUD system, using the now-deprecated `page_tag` class.
+* Why it was removed: Tags have been transferred to the `page` table, and all operations on the tags are now handled by Laravel.
+
 ## PHP: `LogEvent`
 * Where it was: [web/php/DB/LogEvent](https://github.com/scpwiki/wikijump/blob/d9a414d9319477673e23f1bbe16ad780394b0bb7/web/php/DB/LogEvent.php)
 * Relevant Issues: [WJ-730](https://scuttle.atlassian.net/browse/WJ-730)

--- a/web/php/Modules/PageTags/PageTagsModule.php
+++ b/web/php/Modules/PageTags/PageTagsModule.php
@@ -34,16 +34,10 @@ class PageTagsModule extends SmartyModule
 
         WDPermissionManager::instance()->hasPagePermission('edit', $user, $category, $page);
 
-        // Receive taglist from ManageSite.
-
-        $siteId = $site->getSiteId();
-        $taglist = AllowedTags::getAllowedTags($siteId);
-
         // Fetch the tags and convert them to a string.
         $tags = PagePeer::getTags($pageId);
         $tags = implode(" ", $tags);
 
         $runData->contextAdd("tags", $tags);
-        $runData->contextAdd("taglist", $taglist);
     }
 }


### PR DESCRIPTION
This is the (current) final update to the tags for the time being. This removes a bit of extra code, and also updates DEADCODE.md with relevant information on the PageTag class that was removed.