### PR TITLE
Replace is_null() with $x === null.

### DIFF
--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -195,7 +195,7 @@ final class FtmlFfi
     public static function string(?string $value): ?FFI\CData
     {
         // Check for null
-        if (is_null($value)) {
+        if ($value === null) {
             return null;
         }
 

--- a/web/app/Services/Wikitext/PageInfo.php
+++ b/web/app/Services/Wikitext/PageInfo.php
@@ -65,7 +65,7 @@ class PageInfo
 
     public function getPageSlug(): string
     {
-        $categoryPrefix = $this->category === null ? '' : $this->category . ':';
+        $categoryPrefix = ($this->category ?? '') . ':';
         return $categoryPrefix . $this->page;
     }
 

--- a/web/app/Services/Wikitext/PageInfo.php
+++ b/web/app/Services/Wikitext/PageInfo.php
@@ -65,7 +65,7 @@ class PageInfo
 
     public function getPageSlug(): string
     {
-        $categoryPrefix = is_null($this->category) ? '' : $this->category . ':';
+        $categoryPrefix = $this->category === null ? '' : $this->category . ':';
         return $categoryPrefix . $this->page;
     }
 

--- a/web/app/Services/Wikitext/TextWikiBackend.php
+++ b/web/app/Services/Wikitext/TextWikiBackend.php
@@ -19,7 +19,7 @@ class TextWikiBackend extends WikitextBackend
         $this->wt = new WikiTransformation();
 
         // Set page data
-        if (!is_null($pageInfo)) {
+        if ($pageInfo !== null) {
             $site = self::getSite($pageInfo->site);
             $page = self::getPage($site->getSiteId(), $pageInfo->page);
             $this->wt->setPage($page);

--- a/web/lib/date/Date.php
+++ b/web/lib/date/Date.php
@@ -199,7 +199,7 @@ class Date
     function __construct($date = null)
     {
         $this->tz = Date_TimeZone::getDefault();
-        if (is_null($date)) {
+        if ($date === null) {
             $this->setDate(date("Y-m-d H:i:s"));
         } elseif (is_a($date, 'Date')) {
             $this->copy($date);

--- a/web/lib/date/Date/Span.php
+++ b/web/lib/date/Date/Span.php
@@ -294,7 +294,7 @@ class Date_Span
      */
     function setFromString($time, $format = null)
     {
-        if (is_null($format)) {
+        if ($format === null) {
             $format = $GLOBALS['_DATE_SPAN_INPUT_FORMAT'];
         }
         // If format is a string, it parses the string format.
@@ -397,7 +397,7 @@ class Date_Span
             }
             $vals = sscanf($time, $str);
             foreach ($vals as $i => $val) {
-                if (is_null($val)) {
+                if ($val === null) {
                     return false;
                 }
                 $$vars[$i] = $val;
@@ -630,7 +630,7 @@ class Date_Span
      */
     function format($format = null)
     {
-        if (is_null($format)) {
+        if ($format === null) {
             $format = $GLOBALS['_DATE_SPAN_FORMAT'];
         }
         $output = '';

--- a/web/lib/h2o/h2o.php
+++ b/web/lib/h2o/h2o.php
@@ -172,7 +172,7 @@ class H2o {
     static function addTag($tag, $class = null) {
         $tags = array();
         if (is_string($tag)) {
-            if (is_null($class))
+            if ($class === null)
                 $class = ucwords("{$tag}_Tag");
             $tags[$tag] = $class;
         } elseif (is_array($tag)) {
@@ -216,7 +216,7 @@ class H2o {
             }
             return true;
         }
-        if (is_null($callback))
+        if ($callback === null)
             $callback = $filter;
 
         if (!is_callable($callback)) {

--- a/web/lib/h2o/h2o/context.php
+++ b/web/lib/h2o/h2o/context.php
@@ -9,21 +9,21 @@ class H2o_Context implements ArrayAccess {
     public $scopes;
     public $options;
     public $autoescape = true;
-    
+
     private $arrayMethods = array('first'=> 0, 'last'=> 1, 'length'=> 2, 'size'=> 3);
     static $lookupTable = array();
-    
+
     function __construct($context = array(), $options = array()){
         if (is_object($context))
            $context = get_object_vars($context);
         $this->scopes = array($context);
-        
-        if (isset($options['safeClass'])) 
+
+        if (isset($options['safeClass']))
             $this->safeClass = array_merge($this->safeClass, $options['safeClass']);
-            
-        if (isset($options['autoescape'])) 
+
+        if (isset($options['autoescape']))
             $this->autoescape = $options['autoescape'];
-            
+
         $this->options = $options;
     }
 
@@ -54,13 +54,13 @@ class H2o_Context implements ArrayAccess {
         }
         return;
     }
-    
+
     function offsetSet($key, $value) {
         if (strpos($key, '.') > -1)
             throw new Exception('cannot set non local variable');
         return $this->scopes[0][$key] = $value;
     }
-    
+
     function offsetUnset($key) {
         foreach ($this->scopes as $layer) {
             if (isset($layer[$key])) unset($layer[$key]);
@@ -83,11 +83,11 @@ class H2o_Context implements ArrayAccess {
         return $this->offsetExists($key);
     }
     /**
-     * 
-     * 
-     * 
+     *
+     *
+     *
      *  Variable name
-     * 
+     *
      * @param $var mixed variable name or array(0 => variable name, 'filters' => filters array)
      * @return mixed
      */
@@ -96,32 +96,32 @@ class H2o_Context implements ArrayAccess {
         # if $var is array - it contains filters to apply
         $filters = array();
         if ( is_array($var) ) {
-        	
+
             $name = array_shift($var);
             $filters = isset($var['filters'])? $var['filters'] : array();
-        
-        } 
+
+        }
         else $name = $var;
-        
+
         $result = null;
-	
+
         # Lookup basic types, null, boolean, numeric and string
         # Variable starts with : (:users.name) to short-circuit lookup
         if ($name[0] === ':') {
             $object =  $this->getVariable(substr($name, 1));
-            if (!is_null($object)) $result = $object;
+            if ($object !== null) $result = $object;
         } else {
             if ($name === 'true') {
                 $result = true;
             }
             elseif ($name === 'false') {
                 $result = false;
-            } 
+            }
             elseif (preg_match('/^-?\d+(\.\d+)?$/', $name, $matches)) {
                 $result = isset($matches[1])? floatval($name) : intval($name);
             }
             elseif (preg_match('/^"([^"\\\\]*(?:\\.[^"\\\\]*)*)"|' .
-                           '\'([^\'\\\\]*(?:\\.[^\'\\\\]*)*)\'$/', $name)) {            
+                           '\'([^\'\\\\]*(?:\\.[^\'\\\\]*)*)\'$/', $name)) {
                 $result = stripcslashes(substr($name, 1, -1));
             }
         }
@@ -131,7 +131,7 @@ class H2o_Context implements ArrayAccess {
         $result = $this->applyFilters($result,$filters);
         return $result;
     }
-        
+
     function getVariable($name) {
         # Local variables. this gives as a bit of performance improvement
         if (!strpos($name, '.'))
@@ -161,7 +161,7 @@ class H2o_Context implements ArrayAccess {
                 if (isset($object->$part))
                     $object = $object->$part;
                 elseif (is_callable(array($object, $part))) {
-                    $methodAllowed = in_array(get_class($object), $this->safeClass) || 
+                    $methodAllowed = in_array(get_class($object), $this->safeClass) ||
                         (isset($object->h2o_safe) && (
                             $object->h2o_safe === true || in_array($part, $object->h2o_safe)
                         )
@@ -176,12 +176,12 @@ class H2o_Context implements ArrayAccess {
     }
 
     function applyFilters($object, $filters) {
-        
+
         foreach ($filters as $filter) {
             $name = substr(array_shift($filter), 1);
             $args = $filter;
-            
-            if (isset(h2o::$filters[$name])) {                
+
+            if (isset(h2o::$filters[$name])) {
                 foreach ($args as $i => $argument) {
                     # name args
                     if (is_array($argument)) {
@@ -201,24 +201,24 @@ class H2o_Context implements ArrayAccess {
     }
 
     function escape($value, $var) {
-		
+
         $safe = false;
         $filters = (is_array($var) && isset($var['filters']))? $var['filters'] : array();
 
         foreach ( $filters as $filter ) {
-        	
+
             $name = substr(array_shift($filter), 1);
             $safe = !$safe && ($name === 'safe');
-        
+
             $escaped = $name === 'escape';
         }
-        
+
         $should_escape = $this->autoescape || isset($escaped) && $escaped;
-        
+
         if ( ($should_escape && !$safe)) {
             $value = htmlspecialchars($value);
-        }		
-        
+        }
+
         return $value;
 	}
 
@@ -238,7 +238,7 @@ class BlockContext {
     var $h2o_safe = array('name', 'depth', 'super');
     var $block, $index;
     private $context;
-    
+
     function __construct($block, $context, $index) {
         $this->block =& $block;
         $this->context = $context;
@@ -256,9 +256,9 @@ class BlockContext {
     function super() {
         $stream = new StreamWriter;
         $this->block->parent->render($this->context, $stream, $this->index+1);
-        return $stream->close(); 
+        return $stream->close();
     }
-    
+
     function __toString() {
         return "[BlockContext : {$this->block->name}, {$this->block->filename}]";
     }

--- a/web/lib/h2o/h2o/datatype.php
+++ b/web/lib/h2o/h2o/datatype.php
@@ -105,7 +105,7 @@ class TokenStream  {
     }
 
     function push($token) {
-        if (is_null($token))
+        if ($token === null)
             throw new Exception('cannot push NULL');
         if ($this->closed)
             $this->pushed[] = $token;
@@ -142,11 +142,11 @@ class H2o_Info {
     function filters() {
         return array_keys(h2o::$filters);
     }
-    
+
     function tags() {
         return array_keys(h2o::$tags);
     }
-    
+
     function extensions() {
         return array_keys(h2o::$extensions);
     }

--- a/web/lib/h2o/h2o/nodes.php
+++ b/web/lib/h2o/h2o/nodes.php
@@ -6,18 +6,18 @@
 class H2o_Node {
     var $position;
 	function __construct($argstring) {}
-	
+
 	function render($context, $stream) {}
 }
 
 class NodeList extends H2o_Node implements IteratorAggregate  {
 	var $parser;
 	var $list;
-	
+
 	function __construct(&$parser, $initial = null, $position = 0) {
 	    $this->parser = $parser;
-        if (is_null($initial))
-            $initial = array();
+        if ($initial === null)
+            $initial = [];
         $this->list = $initial;
         $this->position = $position;
 	}
@@ -27,7 +27,7 @@ class NodeList extends H2o_Node implements IteratorAggregate  {
 			$node->render($context, $stream);
 		}
 	}
-	
+
     function append($node) {
         array_push($this->list, $node);
     }
@@ -39,7 +39,7 @@ class NodeList extends H2o_Node implements IteratorAggregate  {
     function getLength() {
         return count($this->list);
     }
-    
+
     function getIterator() {
         return new ArrayIterator( $this->list );
     }
@@ -48,7 +48,7 @@ class NodeList extends H2o_Node implements IteratorAggregate  {
 class VariableNode extends H2o_Node {
     private $filters = array();
     var $variable;
-    
+
 	function __construct($variable, $filters, $position = 0) {
         if (!empty($filters))
             $this->filters = $filters;
@@ -70,11 +70,11 @@ class TextNode extends H2o_Node {
 		$this->content = $content;
 		$this->position = $position;
 	}
-	
+
 	function render($context, $stream) {
 		$stream->write($this->content);
 	}
-	
+
 	function is_blank() {
 	    return strlen(trim($this->content));
 	}

--- a/web/lib/h2o/h2o/parser.php
+++ b/web/lib/h2o/h2o/parser.php
@@ -198,8 +198,9 @@ class ArgumentLexer {
     );
 
     function __construct($source, $fpos = 0){
-        if (!is_null($source))
-          $this->source = $source;
+        if ($source !== null) {
+            $this->source = $source;
+        }
         $this->fpos=$fpos;
     }
 

--- a/web/lib/h2o/h2o/tags.php
+++ b/web/lib/h2o/h2o/tags.php
@@ -355,7 +355,8 @@ class Cycle_Tag extends H2o_Node {
     }
 
     function render($context, $stream) {
-        if (!is_null($item = $context->getVariable($this->uid))) {
+        $item = $context->getVariable($this->uid)
+        if ($item !== null) {
             $item = ($item + 1) % count($this->sequence);
         } else {
             $item = 0;

--- a/web/lib/smarty/libs/Smarty_Compiler.class.php
+++ b/web/lib/smarty/libs/Smarty_Compiler.class.php
@@ -1442,7 +1442,7 @@ class Smarty_Compiler extends Smarty {
         foreach ($attrs as $arg_name => $arg_value) {
             if (is_bool($arg_value))
                 $arg_value = $arg_value ? 'true' : 'false';
-            if (is_null($arg_value))
+            if ($arg_value === null)
                 $arg_value = 'null';
             if ($_cache_attrs && in_array($arg_name, $_cache_attrs)) {
                 $arg_list[] = "'$arg_name' => (\$this->_cache_including) ? \$_cache_attrs['$arg_name'] : (\$_cache_attrs['$arg_name']=$arg_value)";

--- a/web/lib/smarty/libs/plugins/block.textformat.php
+++ b/web/lib/smarty/libs/plugins/block.textformat.php
@@ -30,7 +30,7 @@
  */
 function smarty_block_textformat($params, $content, &$smarty)
 {
-    if (is_null($content)) {
+    if ($content === null) {
         return;
     }
 

--- a/web/lib/text_wiki/Text/Wiki.php
+++ b/web/lib/text_wiki/Text/Wiki.php
@@ -415,7 +415,7 @@ class Text_Wiki {
         }
 
         // no key requested, return the whole array
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->parseConf[$rule];
         }
 
@@ -493,7 +493,7 @@ class Text_Wiki {
         }
 
         // no key requested, return the whole array
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->renderConf[$rule];
         }
 
@@ -550,7 +550,7 @@ class Text_Wiki {
     function getFormatConf($key = null)
     {
         // no key requested, return the whole array
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->formatConf;
         }
 
@@ -769,7 +769,7 @@ class Text_Wiki {
     // Used by the Toc.php parse rule
     public function getTokens(?array $rules = null): array
     {
-        if (is_null($rules)) {
+        if ($rules === null) {
             return $this->tokens;
         } else {
             settype($rules, 'array');
@@ -1000,7 +1000,7 @@ class Text_Wiki {
 
     function getPath($type = null)
     {
-        if (is_null($type)) {
+        if ($type === null) {
             return $this->path;
         } elseif (! isset($this->path[$type])) {
             return array();


### PR DESCRIPTION
This replaces the PHP function `is_null()` with the direct equality check `$x === null` (or `$x !== null`, as appropriate).