### PR TITLE
Add ds (data structures) extension for PHP.

### DIFF
--- a/install/files/php-fpm/setup-php-extensions.sh
+++ b/install/files/php-fpm/setup-php-extensions.sh
@@ -13,3 +13,7 @@ docker-php-ext-install ffi
 apt install -y libicu-dev
 docker-php-ext-configure intl
 docker-php-ext-install intl
+
+# Configure PHP Data Structures
+pecl install ds
+docker-php-ext-enable ds


### PR DESCRIPTION
This PR splits out the specific changes that add the [`ds`](https://www.php.net/manual/en/book.ds.php) extension to PHP into its own set of changes. This is part of the work @Yossipossi1 is doing regarding tags.