### PR TITLE
[WJ-471] Add PHP ImageMagick extension

### DIFF
--- a/install/files/php-fpm/setup-php-extensions.sh
+++ b/install/files/php-fpm/setup-php-extensions.sh
@@ -17,3 +17,7 @@ docker-php-ext-install intl
 # Configure PHP Data Structures
 pecl install ds
 docker-php-ext-enable ds
+
+# Configure PHP Imagick (ImageMagick wrapper)
+pecl install imagick
+docker-php-ext-enable imagick

--- a/install/files/php-fpm/setup-system.sh
+++ b/install/files/php-fpm/setup-system.sh
@@ -3,12 +3,13 @@ set -eux
 
 apt update
 apt install -y \
+	git \
+	html2text \
+	imagemagick \
+	libfreetype6-dev \
 	libgd-dev \
 	libjpeg62-turbo-dev \
-	libfreetype6-dev \
-	imagemagick \
-	git \
-	zip \
-	html2text \
+	libmagickwand-dev \
+	libtidy-dev \
 	postgresql-common \
-	libtidy-dev
+	zip


### PR DESCRIPTION
This adds the PHP extension `imagick`, which is needed for MFA barcode generation. I also sort the list of `apt` dependencies for consistency.