### PR TITLE
Mark legacy directories as linguist-vendored

### DIFF
--- a/web/.gitattributes
+++ b/web/.gitattributes
@@ -1,6 +1,11 @@
 *                      text=auto
-web/**                 linguist-vendored
 pnpm-lock.yaml         binary linguist-vendored linguist-generated
 **/vendor/**           binary linguist-vendored linguist-generated
 *.json                 linguist-language=JSON-with-Comments
 CHANGELOG.md           export-ignore
+
+bin/**                 linguist-vendored
+lib/**                 linguist-vendored
+php/**                 linguist-vendored
+templates/**           linguist-vendored
+web/**                 linguist-vendored


### PR DESCRIPTION
I think it's a little unfair to include the ginormous pile of legacy Wikidot code in our project's linguist data. Vendored files will still get included in diffs, it's just that we won't see this anymore:
![image](https://user-images.githubusercontent.com/34875062/138369416-b3382ca4-5c6b-4bd1-8d9e-934665bcdad4.png)

Smarty is 6.8%. That's painful.