### PR TITLE
Hotfix: Legacy frontend

### DIFF
--- a/web/bin/job.php
+++ b/web/bin/job.php
@@ -24,12 +24,6 @@ $runData = new RunData();
 $runData->init();
 Ozone::setRunData($runData);
 
-// Set the text domain as 'messages'
-$gdomain = 'messages';
-bindtextdomain($gdomain, WIKIJUMP_ROOT.'/locale');
-textdomain($gdomain);
-
-
 $jobName = $argv[1];
 
 $classFile = WIKIJUMP_ROOT.'/php/Jobs/'.$jobName.'.php';

--- a/web/php/Utils/AjaxModuleWikiFlowController.php
+++ b/web/php/Utils/AjaxModuleWikiFlowController.php
@@ -118,11 +118,6 @@ class AjaxModuleWikiFlowController extends WebFlowController
             putenv("LANGUAGE=$glang");
             setlocale(LC_ALL, $glang.'.UTF-8');
 
-            // Set the text domain as 'messages'
-            $gdomain = 'messages';
-            bindtextdomain($gdomain, WIKIJUMP_ROOT.'/locale');
-            textdomain($gdomain);
-
             $settings = $site->getSettings();
             // handle SSL
             $sslMode = $settings->getSslMode();

--- a/web/php/Utils/WDDefaultFlowController.php
+++ b/web/php/Utils/WDDefaultFlowController.php
@@ -102,11 +102,6 @@ class WDDefaultFlowController extends WebFlowController
             putenv("LANGUAGE=$glang");
             setlocale(LC_ALL, $glang.'.UTF-8');
 
-            // Set the text domain as 'messages'
-            $gdomain = 'messages';
-            bindtextdomain($gdomain, WIKIJUMP_ROOT.'/locale');
-            textdomain($gdomain);
-
             $settings = $site->getSettings();
             // handle SSL
             $sslMode = $settings->getSslMode();

--- a/web/php/Utils/WikiFlowController.php
+++ b/web/php/Utils/WikiFlowController.php
@@ -131,11 +131,6 @@ class WikiFlowController extends WebFlowController
         putenv("LANGUAGE=$glang");
         setlocale(LC_ALL, $glang.'.UTF-8');
 
-        // Set the text domain as 'messages'
-        $gdomain = 'messages';
-        bindtextdomain($gdomain, WIKIJUMP_ROOT.'/locale');
-        textdomain($gdomain);
-
         $settings = $site->getSettings();
         // handle SSL
         $sslMode = $settings->getSslMode();


### PR DESCRIPTION
Not all of the old gettext functions were removed, which caused a Laravel error.