### PR TITLE
Update PHP FFI for ftml

### DIFF
--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -30,7 +30,7 @@ final class LocalizationService
     public static function translate(string $key, array $values = []): string
     {
         if ($key === '') {
-            Log::error("Empty localization key given");
+            Log::error('Empty localization key given');
             return '';
         }
 

--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -29,6 +29,11 @@ final class LocalizationService
 
     public static function translate(string $key, array $values = []): string
     {
+        if ($key === '') {
+            Log::error("Empty localization key given");
+            return '';
+        }
+
         // Get message from translations file
         $locale = App::currentLocale();
         $translation = self::$translations->find(null, $key);

--- a/web/app/Services/Wikitext/Backlinks.php
+++ b/web/app/Services/Wikitext/Backlinks.php
@@ -11,50 +11,50 @@ use Text_Wiki;
  */
 class Backlinks
 {
-    public array $inclusionsPresent;
-    public array $inclusionsAbsent;
-    public array $internalLinksPresent;
-    public array $internalLinksAbsent;
-    public array $externalLinks;
+    public array $inclusions_present;
+    public array $inclusions_absent;
+    public array $internal_links_present;
+    public array $internal_links_absent;
+    public array $external_links;
 
     public function __construct(
-        array $inclusionsPresent,
-        array $inclusionsAbsent,
-        array $internalLinksPresent,
-        array $internalLinksAbsent,
-        array $externalLinks
+        array $inclusions_present,
+        array $inclusions_absent,
+        array $internal_links_present,
+        array $internal_links_absent,
+        array $external_links
     ) {
-        $this->inclusionsPresent = self::dedupeIds($inclusionsPresent);
-        $this->inclusionsAbsent = self::dedupeStrings($inclusionsAbsent);
-        $this->internalLinksPresent = self::dedupeIds($internalLinksPresent);
-        $this->internalLinksAbsent = self::dedupeStrings($internalLinksAbsent);
-        $this->externalLinks = self::dedupeStrings($externalLinks);
+        $this->inclusions_present = self::dedupeIds($inclusions_present);
+        $this->inclusions_absent = self::dedupeStrings($inclusions_absent);
+        $this->internal_links_present = self::dedupeIds($internal_links_present);
+        $this->internal_links_absent = self::dedupeStrings($internal_links_absent);
+        $this->external_links = self::dedupeStrings($external_links);
     }
 
-    private static function dedupeIds(array &$items): array
+    private static function dedupeIds(array $items): array
     {
         return array_unique($items, SORT_NUMERIC);
     }
 
-    private static function dedupeStrings(array &$items): array
+    private static function dedupeStrings(array $items): array
     {
         return array_unique($items, SORT_STRING);
     }
 
-    public static function fromWikiObject(Text_Wiki &$wiki): Backlinks
+    public static function fromWikiObject(Text_Wiki $wiki): Backlinks
     {
-        $inclusionsPresent = $wiki->vars['inclusions'] ?? [];
-        $inclusionsAbsent = $wiki->vars['inclusionsNotExist'] ?? [];
-        $internalLinksPresent = $wiki->vars['internalLinksExist'] ?? [];
-        $internalLinksAbsent = $wiki->vars['internalLinksNotExist'] ?? [];
-        $externalLinks = $wiki->vars['externalLinks'] ?? [];
+        $inclusions_present = $wiki->vars['inclusions'] ?? [];
+        $inclusions_absent = $wiki->vars['inclusionsNotExist'] ?? [];
+        $internal_links_present = $wiki->vars['internalLinksExist'] ?? [];
+        $internal_links_absent = $wiki->vars['internalLinksNotExist'] ?? [];
+        $external_links = $wiki->vars['externalLinks'] ?? [];
 
         return new Backlinks(
-            $inclusionsPresent,
-            $inclusionsAbsent,
-            $internalLinksPresent,
-            $internalLinksAbsent,
-            $externalLinks,
+            $inclusions_present,
+            $inclusions_absent,
+            $internal_links_present,
+            $internal_links_absent,
+            $external_links,
         );
     }
 }

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -30,11 +30,18 @@ final class FtmlFfi
     public static int $META_HTTP_EQUIV;
     public static int $META_PROPERTY;
 
+    public static int $WIKITEXT_MODE_PAGE;
+    public static int $WIKITEXT_MODE_DRAFT;
+    public static int $WIKITEXT_MODE_FORUM_POST;
+    public static int $WIKITEXT_MODE_DIRECT_MESSAGE;
+    public static int $WIKITEXT_MODE_LIST;
+
     public static FFI\CType $C_CHAR;
     public static FFI\CType $C_STRING;
     public static FFI\CType $FTML_PAGE_INFO;
     public static FFI\CType $FTML_HTML_OUTPUT;
     public static FFI\CType $FTML_TEXT_OUTPUT;
+    public static FFI\CType $FTML_WIKITEXT_SETTINGS;
 
     private function __construct()
     {
@@ -60,11 +67,18 @@ final class FtmlFfi
         self::$META_HTTP_EQUIV = self::$ffi->META_HTTP_EQUIV;
         self::$META_PROPERTY = self::$ffi->META_PROPERTY;
 
+        self::$WIKITEXT_MODE_PAGE = self::$ffi->WIKITEXT_MODE_PAGE;
+        self::$WIKITEXT_MODE_DRAFT = self::$ffi->WIKITEXT_MODE_DRAFT;
+        self::$WIKITEXT_MODE_FORUM_POST = self::$ffi->WIKITEXT_MODE_FORUM_POST;
+        self::$WIKITEXT_MODE_DIRECT_MESSAGE = self::$ffi->WIKITEXT_MODE_DIRECT_MESSAGE;
+        self::$WIKITEXT_MODE_LIST = self::$ffi->WIKITEXT_MODE_LIST;
+
         self::$C_CHAR = self::type('char');
         self::$C_STRING = self::type('char *');
         self::$FTML_PAGE_INFO = self::type('struct ftml_page_info');
         self::$FTML_HTML_OUTPUT = self::type('struct ftml_html_output');
         self::$FTML_TEXT_OUTPUT = self::type('struct ftml_text_output');
+        self::$FTML_WIKITEXT_SETTINGS = self::type('struct ftml_wikitext_settings');
     }
 
     // ftml export methods
@@ -115,6 +129,16 @@ final class FtmlFfi
     public static function freeTextOutput(FFI\CData $data)
     {
         self::$ffi->ftml_destroy_text_output(FFI::addr($data));
+    }
+
+    public static function settingsFromMode(int $c_mode): FFI\CData
+    {
+        $c_settings = self::make(self::$FTML_WIKITEXT_SETTINGS);
+        self::$ffi->ftml_wikitext_settings_from_mode(
+            FFI::addr($c_settings),
+            $c_mode,
+        );
+        return $c_settings;
     }
 
     public static function version(): string

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -98,7 +98,7 @@ final class FtmlFfi
         $c_settings = new WikitextSettings($settings);
         $output = self::make(self::$FTML_HTML_OUTPUT);
 
-        // Make render call
+        // Render call
         self::$ffi->ftml_render_html(
             FFI::addr($output),
             $wikitext,
@@ -112,15 +112,23 @@ final class FtmlFfi
 
     public static function renderText(
         string $wikitext,
-        Wikitext\PageInfo $page_info
+        Wikitext\PageInfo $page_info,
+        Wikitext\WikitextSetings $settings
     ): TextOutput {
+        // Convert objects
         $c_page_info = new PageInfo($page_info);
+        $c_settings = new WikitextSettings($settings);
         $output = self::make(self::$FTML_TEXT_OUTPUT);
+
+        // Render call
         self::$ffi->ftml_render_text(
             FFI::addr($output),
             $wikitext,
             $c_page_info->pointer(),
+            $c_settings->pointer(),
         );
+
+        // Convert result back to PHP
         return OutputConversion::makeTextOutput($output);
     }
 

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -156,7 +156,7 @@ final class FtmlFfi
     }
 
     /**
-     * Converts a FFI C string into a nullable PHP string.
+     * Converts an FFI C string into a nullable PHP string.
      * That is, it handles C NULL properly.
      */
     public static function nullableString(FFI\CData $data): ?string

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -145,10 +145,7 @@ final class FtmlFfi
     public static function settingsFromMode(int $c_mode): WikitextSettings
     {
         $c_settings = self::make(self::$FTML_WIKITEXT_SETTINGS);
-        self::$ffi->ftml_wikitext_settings_from_mode(
-            FFI::addr($c_settings),
-            $c_mode,
-        );
+        self::$ffi->ftml_wikitext_settings_from_mode(FFI::addr($c_settings), $c_mode);
         return new WikitextSettings($c_settings);
     }
 

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -142,14 +142,14 @@ final class FtmlFfi
         self::$ffi->ftml_destroy_text_output(FFI::addr($data));
     }
 
-    public static function settingsFromMode(int $c_mode): FFI\CData
+    public static function settingsFromMode(int $c_mode): WikitextSettings
     {
         $c_settings = self::make(self::$FTML_WIKITEXT_SETTINGS);
         self::$ffi->ftml_wikitext_settings_from_mode(
             FFI::addr($c_settings),
             $c_mode,
         );
-        return $c_settings;
+        return new WikitextSettings($c_settings);
     }
 
     public static function version(): string

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -84,7 +84,8 @@ final class FtmlFfi
     // ftml export methods
     public static function renderHtml(
         string $wikitext,
-        Wikitext\PageInfo $page_info
+        Wikitext\PageInfo $page_info,
+        Wikitext\WikitextSettings $settings
     ): HtmlOutput {
         $site_id = self::getSiteId($page_info->site);
         if ($site_id === null) {
@@ -94,6 +95,7 @@ final class FtmlFfi
 
         // Convert objects
         $c_page_info = new PageInfo($page_info);
+        $c_settings = new WikitextSettings($settings);
         $output = self::make(self::$FTML_HTML_OUTPUT);
 
         // Make render call
@@ -101,6 +103,7 @@ final class FtmlFfi
             FFI::addr($output),
             $wikitext,
             $c_page_info->pointer(),
+            $c_settings->pointer(),
         );
 
         // Convert result back to PHP

--- a/web/app/Services/Wikitext/FFI/OutputConversion.php
+++ b/web/app/Services/Wikitext/FFI/OutputConversion.php
@@ -28,7 +28,7 @@ final class OutputConversion
         return FtmlFfi::pointerToList(
             $pointer,
             $length,
-            fn(FFI\CData &$data) => self::makeHtmlMeta($data),
+            fn(FFI\CData $data) => self::makeHtmlMeta($data),
         );
     }
 
@@ -108,10 +108,10 @@ final class OutputConversion
     {
         $token = FFI::string($data->token);
         $rule = FFI::string($data->rule);
-        $spanStart = $data->span_start;
-        $spanEnd = $data->span_end;
+        $span_start = $data->span_start;
+        $span_end = $data->span_end;
         $kind = FFI::string($data->kind);
-        return new ParseWarning($token, $rule, $spanStart, $spanEnd, $kind);
+        return new ParseWarning($token, $rule, $span_start, $span_end, $kind);
     }
 
     // Backlinks

--- a/web/app/Services/Wikitext/FFI/OutputConversion.php
+++ b/web/app/Services/Wikitext/FFI/OutputConversion.php
@@ -23,7 +23,7 @@ final class OutputConversion
     }
 
     // HtmlMeta
-    public static function makeHtmlMetaArray(FFI\CData &$pointer, int $length): array
+    public static function makeHtmlMetaArray(FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
@@ -32,12 +32,12 @@ final class OutputConversion
         );
     }
 
-    public static function makeHtmlMeta(FFI\CData &$data): HtmlMeta
+    public static function makeHtmlMeta(FFI\CData $data): HtmlMeta
     {
-        $tagType = self::getTagType($data->tag_type);
+        $tag_type = self::getTagType($data->tag_type);
         $name = FFI::string($data->name);
         $value = FFI::string($data->value);
-        return new HtmlMeta($tagType, $name, $value);
+        return new HtmlMeta($tag_type, $name, $value);
     }
 
     private static function getTagType(int $tag): string
@@ -55,13 +55,13 @@ final class OutputConversion
     }
 
     // HtmlOutput
-    public static function makeHtmlOutput(string $siteId, FFI\CData &$data): HtmlOutput
+    public static function makeHtmlOutput(string $site_id, FFI\CData $data): HtmlOutput
     {
         $body = FFI::string($data->body);
         $styles = self::makeStylesArray($data->styles_list, $data->styles_len);
         $meta = self::makeHtmlMetaArray($data->meta_list, $data->meta_len);
         $warnings = self::makeParseWarningArray($data->warning_list, $data->warning_len);
-        $backlinks = self::makeBacklinks($siteId, $data->backlinks);
+        $backlinks = self::makeBacklinks($site_id, $data->backlinks);
 
         // Free original C data
         FtmlFfi::freeHtmlOutput($data);
@@ -71,7 +71,7 @@ final class OutputConversion
         return new HtmlOutput($body, $styles, $meta, $warnings, $backlinks);
     }
 
-    private static function makeStylesArray(FFI\CData &$pointer, int $length): array
+    private static function makeStylesArray(FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
@@ -81,7 +81,7 @@ final class OutputConversion
     }
 
     // TextOutput
-    public static function makeTextOutput(FFI\CData &$data): TextOutput
+    public static function makeTextOutput(FFI\CData $data): TextOutput
     {
         $text = FFI::string($data->text);
         $warnings = self::makeParseWarningArray($data->warning_list, $data->warning_len);
@@ -95,7 +95,7 @@ final class OutputConversion
     }
 
     // ParseWarning
-    public static function makeParseWarningArray(FFI\CData &$pointer, int $length): array
+    public static function makeParseWarningArray(FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
@@ -104,7 +104,7 @@ final class OutputConversion
         );
     }
 
-    public static function makeParseWarning(FFI\CData &$data): ParseWarning
+    public static function makeParseWarning(FFI\CData $data): ParseWarning
     {
         $token = FFI::string($data->token);
         $rule = FFI::string($data->rule);
@@ -115,40 +115,40 @@ final class OutputConversion
     }
 
     // Backlinks
-    public static function makeBacklinks(string $siteId, FFI\CData &$data): Backlinks
+    public static function makeBacklinks(string $site_id, FFI\CData $data): Backlinks
     {
         $inclusions = self::splitLinks(
             $data->included_pages_list,
             $data->included_pages_len,
-            $siteId,
+            $site_id,
         );
-        $inclusionsPresent = $inclusions['present'];
-        $inclusionsAbsent = $inclusions['absent'];
+        $inclusions_present = $inclusions['present'];
+        $inclusions_absent = $inclusions['absent'];
 
-        $internalLinks = self::splitLinks(
+        $internal_links = self::splitLinks(
             $data->internal_links_list,
             $data->internal_links_len,
-            $siteId,
+            $site_id,
         );
-        $internalLinksPresent = $internalLinks['present'];
-        $internalLinksAbsent = $internalLinks['absent'];
+        $internal_links_present = $internal_links['present'];
+        $internal_links_absent = $internal_links['absent'];
 
-        $externalLinks = FtmlFfi::pointerToList(
+        $external_links = FtmlFfi::pointerToList(
             $data->external_links_list,
             $data->external_links_len,
             fn(FFI\CData $data) => FFI::string($data),
         );
 
         return new Backlinks(
-            $inclusionsPresent,
-            $inclusionsAbsent,
-            $internalLinksPresent,
-            $internalLinksAbsent,
-            $externalLinks,
+            $inclusions_present,
+            $inclusions_absent,
+            $internal_links_present,
+            $internal_links_absent,
+            $external_links,
         );
     }
 
-    private static function makePageRef(FFI\CData &$data): PageRef
+    private static function makePageRef(FFI\CData $data): PageRef
     {
         $site = FtmlFfi::nullableString($data->site);
         $page = FFI::string($data->page);
@@ -157,20 +157,20 @@ final class OutputConversion
     }
 
     private static function splitLinks(
-        FFI\CData &$pointer,
+        FFI\CData $pointer,
         int $length,
-        string $siteId
+        string $site_id
     ): array {
         $present = [];
         $absent = [];
 
         // Convert items, placing in the appropriate list
         for ($i = 0; $i < $length; $i++) {
-            $pageRef = self::makePageRef($pointer[$i]);
-            $pageId = self::getPageId($siteId, $pageRef);
+            $page_ref = self::makePageRef($pointer[$i]);
+            $pageId = self::getPageId($site_id, $page_ref);
 
             if ($pageId === null) {
-                array_push($absent, $pageRef->pathRepr());
+                array_push($absent, $page_ref->pathRepr());
             } else {
                 array_push($present, $pageId);
             }
@@ -182,18 +182,18 @@ final class OutputConversion
         ];
     }
 
-    private static function getPageId(string $siteId, PageRef &$pageRef): ?string
+    private static function getPageId(string $site_id, PageRef $page_ref): ?string
     {
-        if ($pageRef->site !== null) {
-            $siteId = FtmlFfi::getSiteId($pageRef->site);
-            if ($siteId === null) {
+        if ($page_ref->site !== null) {
+            $site_id = FtmlFfi::getSiteId($page_ref->site);
+            if ($site_id === null) {
                 // Site not found, the page obviously doesn't exist
                 return null;
             }
         }
 
         // Find the page based on the contextual site ID
-        $page = PagePeer::instance()->selectByName($siteId, $pageRef->page);
+        $page = PagePeer::instance()->selectByName($site_id, $page_ref->page);
         return $page ? $page->getPageId() : null;
     }
 }

--- a/web/app/Services/Wikitext/FFI/PageInfo.php
+++ b/web/app/Services/Wikitext/FFI/PageInfo.php
@@ -10,30 +10,29 @@ use Wikijump\Services\Wikitext;
  * Class PageInfo, representing an input 'struct ftml_page_info' object.
  * See Wikijump\Services\Wikitext\PageInfo for a version of this class
  * intended for general, non-FFI consumption.
- *
  * @package Wikijump\Services\Wikitext\FFI
  */
 class PageInfo
 {
     private FFI\CData $c_data;
 
-    public function __construct(Wikitext\PageInfo $pageInfo)
+    public function __construct(Wikitext\PageInfo $page_info)
     {
         $tag_array = FtmlFfi::listToPointer(
             FtmlFfi::$C_STRING,
-            $pageInfo->tags,
+            $page_info->tags,
             fn(string $tag) => FtmlFfi::string($tag),
         );
 
         $this->c_data = FtmlFfi::make(FtmlFfi::$FTML_PAGE_INFO);
-        $this->c_data->page = FtmlFfi::string($pageInfo->page);
-        $this->c_data->category = FtmlFfi::string($pageInfo->category);
-        $this->c_data->site = FtmlFfi::string($pageInfo->site);
-        $this->c_data->title = FtmlFfi::string($pageInfo->title);
-        $this->c_data->alt_title = FtmlFfi::string($pageInfo->alt_title);
+        $this->c_data->page = FtmlFfi::string($page_info->page);
+        $this->c_data->category = FtmlFfi::string($page_info->category);
+        $this->c_data->site = FtmlFfi::string($page_info->site);
+        $this->c_data->title = FtmlFfi::string($page_info->title);
+        $this->c_data->alt_title = FtmlFfi::string($page_info->alt_title);
         $this->c_data->tags_list = $tag_array->pointer;
         $this->c_data->tags_len = $tag_array->length;
-        $this->c_data->language = FtmlFfi::string($pageInfo->language);
+        $this->c_data->language = FtmlFfi::string($page_info->language);
     }
 
     public function pointer(): FFI\CData

--- a/web/app/Services/Wikitext/FFI/PageInfo.php
+++ b/web/app/Services/Wikitext/FFI/PageInfo.php
@@ -30,7 +30,7 @@ class PageInfo
         $this->c_data->category = FtmlFfi::string($pageInfo->category);
         $this->c_data->site = FtmlFfi::string($pageInfo->site);
         $this->c_data->title = FtmlFfi::string($pageInfo->title);
-        $this->c_data->alt_title = FtmlFfi::string($pageInfo->altTitle);
+        $this->c_data->alt_title = FtmlFfi::string($pageInfo->alt_title);
         $this->c_data->tags_list = $tag_array->pointer;
         $this->c_data->tags_len = $tag_array->length;
         $this->c_data->language = FtmlFfi::string($pageInfo->language);

--- a/web/app/Services/Wikitext/FFI/WikitextSettings.php
+++ b/web/app/Services/Wikitext/FFI/WikitextSettings.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Wikijump\Services\Wikitext\FFI;
+
+use Wikijump\Services\Wikitext\ParseRenderMode;
+
+/**
+ * Class WikitextSettings, representing an input 'struct ftml_wikitext_settings' object.
+ * See Wikijump\Services\Wikitext\WikitextSettings for a version of this class
+ * intended for general, non-FFI consumption.
+ * @package Wikijump\Services\Wikitext\FFI
+ */
+class WikitextSettings
+{
+    private FFI\CData $c_data;
+
+    /**
+     * @param Wikitext\WikitextSettings|FFI\CData $settings
+     */
+    public function __construct($settings)
+    {
+        if (is_a($settings, 'FFI\CData')) {
+            $this->c_data = $settings;
+            return;
+        }
+
+        $this->c_data = FtmlFfi::make(FtmlFfi::$FTML_WIKITEXT_SETTINGS);
+        $this->c_data->mode = ParseRenderMode::toFfiMode($settings->mode);
+        $this->c_data->enable_page_syntax = $settings->enable_page_syntax;
+        $this->c_data->use_true_ids = $settings->use_true_ids;
+        $this->c_data->allow_local_paths = $settings->allow_local_paths;
+    }
+
+    public function pointer(): FFI\CData
+    {
+        return FFI::addr($this->c_data);
+    }
+
+    function __destruct()
+    {
+        FFI::free($this->c_data);
+    }
+}

--- a/web/app/Services/Wikitext/FFI/WikitextSettings.php
+++ b/web/app/Services/Wikitext/FFI/WikitextSettings.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Wikijump\Services\Wikitext\FFI;
 
+use FFI;
 use Wikijump\Services\Wikitext\ParseRenderMode;
 use Wikijump\Services\Wikitext;
 

--- a/web/app/Services/Wikitext/FFI/WikitextSettings.php
+++ b/web/app/Services/Wikitext/FFI/WikitextSettings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Wikijump\Services\Wikitext\FFI;
 
 use Wikijump\Services\Wikitext\ParseRenderMode;
+use Wikijump\Services\Wikitext;
 
 /**
  * Class WikitextSettings, representing an input 'struct ftml_wikitext_settings' object.
@@ -35,6 +36,16 @@ class WikitextSettings
     public function pointer(): FFI\CData
     {
         return FFI::addr($this->c_data);
+    }
+
+    public function toSettings(): Wikitext\WikitextSettings
+    {
+        return new Wikitext\WikitextSettings(
+            ParseRenderMode::toNativeMode($this->c_data->mode),
+            $this->c_data->enable_page_syntax,
+            $this->c_data->use_true_ids,
+            $this->c_data->allow_local_paths,
+        );
     }
 
     function __destruct()

--- a/web/app/Services/Wikitext/FtmlBackend.php
+++ b/web/app/Services/Wikitext/FtmlBackend.php
@@ -11,23 +11,23 @@ use Wikijump\Services\Wikitext\FFI\FtmlFfi;
  */
 class FtmlBackend extends WikitextBackend
 {
-    private PageInfo $pageInfo;
+    private PageInfo $page_info;
 
-    public function __construct(int $mode, ?PageInfo &$pageInfo)
+    public function __construct(int $mode, ?PageInfo $page_info)
     {
         // TODO mode
-        $this->pageInfo = $pageInfo ?? self::defaultPageInfo();
+        $this->page_info = $pageInfo ?? self::defaultPageInfo();
     }
 
     // Interface methods
     public function renderHtml(string $wikitext): HtmlOutput
     {
-        return FtmlFfi::renderHtml($wikitext, $this->pageInfo);
+        return FtmlFfi::renderHtml($wikitext, $this->page_info);
     }
 
     public function renderText(string $wikitext): TextOutput
     {
-        return FtmlFfi::renderText($wikitext, $this->pageInfo);
+        return FtmlFfi::renderText($wikitext, $this->page_info);
     }
 
     public function version(): string

--- a/web/app/Services/Wikitext/FtmlBackend.php
+++ b/web/app/Services/Wikitext/FtmlBackend.php
@@ -11,23 +11,24 @@ use Wikijump\Services\Wikitext\FFI\FtmlFfi;
  */
 class FtmlBackend extends WikitextBackend
 {
+    private WikitextSettings $settings;
     private PageInfo $page_info;
 
     public function __construct(int $mode, ?PageInfo $page_info)
     {
-        // TODO mode
+        $this->settings = WikitextSettings::fromMode($mode);
         $this->page_info = $pageInfo ?? self::defaultPageInfo();
     }
 
     // Interface methods
     public function renderHtml(string $wikitext): HtmlOutput
     {
-        return FtmlFfi::renderHtml($wikitext, $this->page_info);
+        return FtmlFfi::renderHtml($wikitext, $this->page_info, $this->settings);
     }
 
     public function renderText(string $wikitext): TextOutput
     {
-        return FtmlFfi::renderText($wikitext, $this->page_info);
+        return FtmlFfi::renderText($wikitext, $this->page_info, $this->settings);
     }
 
     public function version(): string

--- a/web/app/Services/Wikitext/FtmlBackend.php
+++ b/web/app/Services/Wikitext/FtmlBackend.php
@@ -11,13 +11,13 @@ use Wikijump\Services\Wikitext\FFI\FtmlFfi;
  */
 class FtmlBackend extends WikitextBackend
 {
-    private WikitextSettings $settings;
     private PageInfo $page_info;
+    private WikitextSettings $settings;
 
     public function __construct(int $mode, ?PageInfo $page_info)
     {
+        $this->page_info = $page_info ?? self::defaultPageInfo();
         $this->settings = WikitextSettings::fromMode($mode);
-        $this->page_info = $pageInfo ?? self::defaultPageInfo();
     }
 
     // Interface methods

--- a/web/app/Services/Wikitext/HtmlMeta.php
+++ b/web/app/Services/Wikitext/HtmlMeta.php
@@ -24,11 +24,8 @@ class HtmlMeta
      */
     public string $value;
 
-    public function __construct(
-        string $tag_type,
-        string $name,
-        string $value
-    ) {
+    public function __construct(string $tag_type, string $name, string $value)
+    {
         $this->tag_type = $tag_type;
         $this->name = $name;
         $this->value = $value;

--- a/web/app/Services/Wikitext/HtmlMeta.php
+++ b/web/app/Services/Wikitext/HtmlMeta.php
@@ -12,7 +12,7 @@ class HtmlMeta
     /**
      * @var string The kind of HTML meta tag. See HtmlMetaType for details.
      */
-    public string $tagType;
+    public string $tag_type;
 
     /**
      * @var string The HTML meta tag's key.
@@ -23,4 +23,14 @@ class HtmlMeta
      * @var string The HTML meta tag's value.
      */
     public string $value;
+
+    public function __construct(
+        string $tag_type,
+        string $name,
+        string $value
+    ) {
+        $this->tag_type = $tag_type;
+        $this->name = $name;
+        $this->value = $value;
+    }
 }

--- a/web/app/Services/Wikitext/HtmlOutput.php
+++ b/web/app/Services/Wikitext/HtmlOutput.php
@@ -34,19 +34,19 @@ class HtmlOutput
     /**
      * @var Backlinks Information about any links or includes in the page.
      */
-    public Backlinks $linkStats;
+    public Backlinks $link_stats;
 
     public function __construct(
         string $body,
         array $styles,
         array $meta,
         array $warnings,
-        Backlinks $linkStats
+        Backlinks $link_stats
     ) {
         $this->body = $body;
         $this->styles = $styles;
         $this->meta = $meta;
         $this->warnings = $warnings;
-        $this->linkStats = $linkStats;
+        $this->link_stats = $link_stats;
     }
 }

--- a/web/app/Services/Wikitext/PageInfo.php
+++ b/web/app/Services/Wikitext/PageInfo.php
@@ -24,7 +24,7 @@ class PageInfo
         ?string $category,
         string $site,
         string $title,
-        ?string $altTitle,
+        ?string $alt_title,
         array $tags,
         string $language
     ) {
@@ -32,7 +32,7 @@ class PageInfo
         $this->category = $category;
         $this->site = $site;
         $this->title = $title;
-        $this->alt_title = $altTitle;
+        $this->alt_title = $alt_title;
         $this->tags = $tags;
         $this->language = $language;
     }

--- a/web/app/Services/Wikitext/PageInfo.php
+++ b/web/app/Services/Wikitext/PageInfo.php
@@ -15,7 +15,7 @@ class PageInfo
     public ?string $category;
     public string $site;
     public string $title;
-    public ?string $altTitle;
+    public ?string $alt_title;
     public array $tags;
     public string $language;
 
@@ -32,27 +32,27 @@ class PageInfo
         $this->category = $category;
         $this->site = $site;
         $this->title = $title;
-        $this->altTitle = $altTitle;
+        $this->alt_title = $altTitle;
         $this->tags = $tags;
         $this->language = $language;
     }
 
     public static function fromPageObject(Page $page): PageInfo
     {
-        $pageSlug = $page->getUnixName();
-        $categorySlug = $page->getCategoryName();
-        $siteSlug = $page->getSite()->getUnixName();
+        $page_slug = $page->getUnixName();
+        $category_slug = $page->getCategoryName();
+        $site_slug = $page->getSite()->getUnixName();
         $title = $page->getTitle();
-        $altTitle = null;
+        $alt_title = null;
         $tags = $page->getTags();
         $language = 'default';
 
         return new PageInfo(
-            $pageSlug,
-            $categorySlug,
-            $siteSlug,
+            $page_slug,
+            $category_slug,
+            $site_slug,
             $title,
-            $altTitle,
+            $alt_title,
             $tags,
             $language,
         );
@@ -65,12 +65,8 @@ class PageInfo
 
     public function getPageSlug(): string
     {
-        $categoryPrefix = ($this->category ?? '') . ':';
-        return $categoryPrefix . $this->page;
-    }
-
-    public function getFullPageSlug(): string
-    {
-        return $this->getCategory() . ':' . $this->page;
+        return $this->category === null
+            ? $this->page
+            : $this->category . ':' . $this->page;
     }
 }

--- a/web/app/Services/Wikitext/ParseRenderMode.php
+++ b/web/app/Services/Wikitext/ParseRenderMode.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Wikijump\Services\Wikitext;
 
+use Exception;
 use Wikijump\Common\Enum;
 
 /**
@@ -28,7 +29,7 @@ final class ParseRenderMode extends Enum
     const LIST = 5;
     const TABLE_OF_CONTENTS = 6;
 
-    public static function to_ffi_mode(int $parse_render_mode): ?int
+    public static function toFfiMode(int $parse_render_mode): int
     {
         switch ($parse_render_mode) {
             case self::PAGE:
@@ -44,7 +45,7 @@ final class ParseRenderMode extends Enum
             case self::FEED:
             case self::TABLE_OF_CONTENTS:
             default:
-                return null;
+                throw new Exception("No corresponding wikitext mode for enum value $mode");
         }
     }
 }

--- a/web/app/Services/Wikitext/ParseRenderMode.php
+++ b/web/app/Services/Wikitext/ParseRenderMode.php
@@ -5,6 +5,7 @@ namespace Wikijump\Services\Wikitext;
 
 use Exception;
 use Wikijump\Common\Enum;
+use Wikijump\Services\Wikitext\FFI\FtmlFfi;
 
 /**
  * Enum ParseRenderMode, for representing the context in which parsing and rendering is being carried out.
@@ -32,15 +33,15 @@ final class ParseRenderMode extends Enum
     public static function toNativeMode(int $c_mode): int
     {
         switch ($c_mode) {
-            case FtmlFfi::WIKITEXT_MODE_PAGE:
+            case FtmlFfi::$WIKITEXT_MODE_PAGE:
                 return self::PAGE;
-            case FtmlFfi::WIKITEXT_MODE_DRAFT:
+            case FtmlFfi::$WIKITEXT_MODE_DRAFT:
                 return self::DRAFT;
-            case FtmlFfi::WIKITEXT_MODE_FORUM_POST:
+            case FtmlFfi::$WIKITEXT_MODE_FORUM_POST:
                 return self::FORUM_POST;
-            case FtmlFfi::WIKITEXT_MODE_DIRECT_MESSAGE:
+            case FtmlFfi::$WIKITEXT_MODE_DIRECT_MESSAGE:
                 return self::DIRECT_MESSAGE;
-            case FtmlFfi::WIKITEXT_MODE_LIST:
+            case FtmlFfi::$WIKITEXT_MODE_LIST:
                 return self::LIST;
             default:
                 throw new Exception("No corresponding enum mode for wikitext enum value $c_mode");
@@ -51,15 +52,15 @@ final class ParseRenderMode extends Enum
     {
         switch ($parse_render_mode) {
             case self::PAGE:
-                return FtmlFfi::WIKITEXT_MODE_PAGE;
+                return FtmlFfi::$WIKITEXT_MODE_PAGE;
             case self::DRAFT:
-                return FtmlFfi::WIKITEXT_MODE_DRAFT;
+                return FtmlFfi::$WIKITEXT_MODE_DRAFT;
             case self::FORUM_POST:
-                return FtmlFfi::WIKITEXT_MODE_FORUM_POST;
+                return FtmlFfi::$WIKITEXT_MODE_FORUM_POST;
             case self::DIRECT_MESSAGE:
-                return FtmlFfi::WIKITEXT_MODE_DIRECT_MESSAGE;
+                return FtmlFfi::$WIKITEXT_MODE_DIRECT_MESSAGE;
             case self::LIST:
-                return FtmlFfi::WIKITEXT_MODE_LIST;
+                return FtmlFfi::$WIKITEXT_MODE_LIST;
             case self::FEED:
             case self::TABLE_OF_CONTENTS:
             default:

--- a/web/app/Services/Wikitext/ParseRenderMode.php
+++ b/web/app/Services/Wikitext/ParseRenderMode.php
@@ -44,7 +44,9 @@ final class ParseRenderMode extends Enum
             case FtmlFfi::$WIKITEXT_MODE_LIST:
                 return self::LIST;
             default:
-                throw new Exception("No corresponding enum mode for wikitext enum value $c_mode");
+                throw new Exception(
+                    "No corresponding enum mode for wikitext enum value $c_mode",
+                );
         }
     }
 
@@ -64,7 +66,9 @@ final class ParseRenderMode extends Enum
             case self::FEED:
             case self::TABLE_OF_CONTENTS:
             default:
-                throw new Exception("No corresponding wikitext mode for enum value $parse_render_mode");
+                throw new Exception(
+                    "No corresponding wikitext mode for enum value $parse_render_mode",
+                );
         }
     }
 }

--- a/web/app/Services/Wikitext/ParseRenderMode.php
+++ b/web/app/Services/Wikitext/ParseRenderMode.php
@@ -27,4 +27,24 @@ final class ParseRenderMode extends Enum
     const FEED = 4;
     const LIST = 5;
     const TABLE_OF_CONTENTS = 6;
+
+    public static function to_ffi_mode(int $parse_render_mode): ?int
+    {
+        switch ($parse_render_mode) {
+            case self::PAGE:
+                return FtmlFfi::WIKITEXT_MODE_PAGE;
+            case self::DRAFT:
+                return FtmlFfi::WIKITEXT_MODE_DRAFT;
+            case self::FORUM_POST:
+                return FtmlFfi::WIKITEXT_MODE_FORUM_POST;
+            case self::DIRECT_MESSAGE:
+                return FtmlFfi::WIKITEXT_MODE_DIRECT_MESSAGE;
+            case self::LIST:
+                return FtmlFfi::WIKITEXT_MODE_LIST;
+            case self::FEED:
+            case self::TABLE_OF_CONTENTS:
+            default:
+                return null;
+        }
+    }
 }

--- a/web/app/Services/Wikitext/ParseRenderMode.php
+++ b/web/app/Services/Wikitext/ParseRenderMode.php
@@ -29,6 +29,24 @@ final class ParseRenderMode extends Enum
     const LIST = 5;
     const TABLE_OF_CONTENTS = 6;
 
+    public static function toNativeMode(int $c_mode): int
+    {
+        switch ($c_mode) {
+            case FtmlFfi::WIKITEXT_MODE_PAGE:
+                return self::PAGE;
+            case FtmlFfi::WIKITEXT_MODE_DRAFT:
+                return self::DRAFT;
+            case FtmlFfi::WIKITEXT_MODE_FORUM_POST:
+                return self::FORUM_POST;
+            case FtmlFfi::WIKITEXT_MODE_DIRECT_MESSAGE:
+                return self::DIRECT_MESSAGE;
+            case FtmlFfi::WIKITEXT_MODE_LIST:
+                return self::LIST;
+            default:
+                throw new Exception("No corresponding enum mode for wikitext enum value $c_mode");
+        }
+    }
+
     public static function toFfiMode(int $parse_render_mode): int
     {
         switch ($parse_render_mode) {
@@ -45,7 +63,7 @@ final class ParseRenderMode extends Enum
             case self::FEED:
             case self::TABLE_OF_CONTENTS:
             default:
-                throw new Exception("No corresponding wikitext mode for enum value $mode");
+                throw new Exception("No corresponding wikitext mode for enum value $parse_render_mode");
         }
     }
 }

--- a/web/app/Services/Wikitext/ParseWarning.php
+++ b/web/app/Services/Wikitext/ParseWarning.php
@@ -25,7 +25,7 @@ class ParseWarning
      * Together with $spanEnd, this represents the slice of the
      * original wikitext that this token corresponds to.
      */
-    public int $spanStart;
+    public int $span_start;
 
     /**
      * @var int The UTF-8 byte index representing the stop of the span.
@@ -33,10 +33,24 @@ class ParseWarning
      * Together with $spanEnd, this represents the slice of the
      * original wikitext that this token corresponds to.
      */
-    public int $spanEnd;
+    public int $span_end;
 
     /**
      * @var string The kind of warning this is.
      */
     public string $kind;
+
+    public function __construct(
+        string $token,
+        string $rule,
+        int $span_start,
+        int $span_end,
+        string $kind
+    ) {
+        $this->token = $token;
+        $this->rule = $rule;
+        $this->span_start = $span_start;
+        $this->span_end = $span_end;
+        $this->kind = $kind;
+    }
 }

--- a/web/app/Services/Wikitext/TextOutput.php
+++ b/web/app/Services/Wikitext/TextOutput.php
@@ -17,4 +17,12 @@ class TextOutput
      * @var array The list of ParseWarning objects, if any, generated during parsing.
      */
     public array $warnings;
+
+    public function __construct(
+        string $text,
+        array $warnings
+    ) {
+        $this->text = $text;
+        $this->warnings = $warnings;
+    }
 }

--- a/web/app/Services/Wikitext/TextOutput.php
+++ b/web/app/Services/Wikitext/TextOutput.php
@@ -18,10 +18,8 @@ class TextOutput
      */
     public array $warnings;
 
-    public function __construct(
-        string $text,
-        array $warnings
-    ) {
+    public function __construct(string $text, array $warnings)
+    {
         $this->text = $text;
         $this->warnings = $warnings;
     }

--- a/web/app/Services/Wikitext/TextWikiBackend.php
+++ b/web/app/Services/Wikitext/TextWikiBackend.php
@@ -53,13 +53,15 @@ class TextWikiBackend extends WikitextBackend
     public function renderHtml(string $wikitext): HtmlOutput
     {
         $html = $this->wt->processSource($wikitext);
-        $linkStats = Backlinks::fromWikiObject($this->wt->wiki);
-        return new HtmlOutput($html, [], [], [], $linkStats);
+        $link_stats = Backlinks::fromWikiObject($this->wt->wiki);
+        return new HtmlOutput($html, [], [], [], $link_stats);
     }
 
     public function renderText(string $wikitext): TextOutput
     {
-        throw new \Exception('Not implemented (legacy)');
+        $html = $this->wt->processSource($wikitext);
+        $text = strip_tags($html);
+        return new TextOutput($text, []);
     }
 
     public function version(): string
@@ -68,15 +70,15 @@ class TextWikiBackend extends WikitextBackend
     }
 
     // Helper methods
-    private static function getSite(string $siteSlug): Site
+    private static function getSite(string $site_slug): Site
     {
         $c = new Criteria();
-        $c->add('unix_name', $siteSlug);
+        $c->add('unix_name', $site_slug);
         return SitePeer::instance()->selectOne($c);
     }
 
-    private static function getPage(string $siteId, string $pageSlug): Page
+    private static function getPage(string $site_id, string $page_slug): Page
     {
-        return PagePeer::instance()->selectByName($siteId, $pageSlug);
+        return PagePeer::instance()->selectByName($site_id, $page_slug);
     }
 }

--- a/web/app/Services/Wikitext/TextWikiBackend.php
+++ b/web/app/Services/Wikitext/TextWikiBackend.php
@@ -14,14 +14,14 @@ class TextWikiBackend extends WikitextBackend
 {
     private WikiTransformation $wt;
 
-    public function __construct(int $mode, ?PageInfo &$pageInfo)
+    public function __construct(int $mode, ?PageInfo $page_info)
     {
         $this->wt = new WikiTransformation();
 
         // Set page data
-        if ($pageInfo !== null) {
-            $site = self::getSite($pageInfo->site);
-            $page = self::getPage($site->getSiteId(), $pageInfo->page);
+        if ($page_info !== null) {
+            $site = self::getSite($page_info->site);
+            $page = self::getPage($site->getSiteId(), $page_info->page);
             $this->wt->setPage($page);
         }
 

--- a/web/app/Services/Wikitext/WikitextBackend.php
+++ b/web/app/Services/Wikitext/WikitextBackend.php
@@ -17,6 +17,7 @@ abstract class WikitextBackend
      *
      * For the following ParseRenderModes, $page_info should be provided:
      * - PAGE
+     * - DRAFT
      * - LIST
      * Else, it should be null:
      * - FORUM_POST

--- a/web/app/Services/Wikitext/WikitextBackend.php
+++ b/web/app/Services/Wikitext/WikitextBackend.php
@@ -15,7 +15,7 @@ abstract class WikitextBackend
      * Gets the WikitextBackend interface to allow for parsing, rendering, and related
      * wikitext transformation.
      *
-     * For the following ParseRenderModes, $pageInfo should be provided:
+     * For the following ParseRenderModes, $page_info should be provided:
      * - PAGE
      * - LIST
      * Else, it should be null:
@@ -26,13 +26,13 @@ abstract class WikitextBackend
      *
      * @throws Exception if the feature flag value is invalid
      */
-    public static function make(int $mode, ?PageInfo &$pageInfo): WikitextBackend
+    public static function make(int $mode, ?PageInfo $page_info): WikitextBackend
     {
         switch (GlobalProperties::$FEATURE_WIKITEXT_BACKEND) {
             case 'text_wiki':
-                return new TextWikiBackend($mode, $pageInfo);
+                return new TextWikiBackend($mode, $page_info);
             case 'ftml':
-                return new FtmlBackend($mode, $pageInfo);
+                return new FtmlBackend($mode, $page_info);
             case 'dummy':
                 return new DummyBackend();
             default:

--- a/web/app/Services/Wikitext/WikitextSettings.php
+++ b/web/app/Services/Wikitext/WikitextSettings.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Wikijump\Services\Wikitext;
+
+use Exception;
+use Wikijump\Services\Wikitext\FFI\FtmlFfi;
+
+/**
+ * Class WikitextSettings, representing information that can influence a call to ftml.
+ * @package Wikijump\Services\Wikitext
+ */
+class WikitextSettings
+{
+    public int $mode;
+    public bool $enable_page_syntax;
+    public bool $use_true_ids;
+    public bool $allow_local_paths;
+
+    /**
+     * Creates a new instance of WikitextSettings.
+     *
+     * @param int $mode ParseRenderMode value to use
+     * @param bool $enable_page_syntax
+     * @param bool $use_true_ids
+     * @param bool $allow_local_paths
+     */
+    public function __construct(
+        int $mode,
+        bool $enable_page_syntax,
+        bool $use_true_ids,
+        bool $allow_local_paths
+    ) {
+        $this->mode = $mode;
+        $this->enable_page_syntax = $enable_page_syntax;
+        $this->use_true_ids = $use_true_ids;
+        $this->allow_local_paths = $allow_local_paths;
+    }
+
+    public static function from_mode(int $mode): WikitextSettings
+    {
+        $c_mode = ParseRenderMode::to_ffi_mode($mode);
+        if ($c_mode === null) {
+            throw new Exception("No corresponding wikitext mode for enum value $mode");
+        }
+
+        $c_settings = FtmlFfi::settingsFromMode($c_mode);
+        $enable_page_syntax = $c_settings->enable_page_syntax;
+        $use_true_ids = $c_settings->use_true_ids;
+        $allow_local_paths = $c_settings->allow_local_paths;
+        FFI::free($c_settings);
+        return new WikitextSettings($mode, $enable_page_syntax, $use_true_ids, $allow_local_paths);
+    }
+}

--- a/web/app/Services/Wikitext/WikitextSettings.php
+++ b/web/app/Services/Wikitext/WikitextSettings.php
@@ -39,11 +39,7 @@ class WikitextSettings
 
     public static function from_mode(int $mode): WikitextSettings
     {
-        $c_mode = ParseRenderMode::to_ffi_mode($mode);
-        if ($c_mode === null) {
-            throw new Exception("No corresponding wikitext mode for enum value $mode");
-        }
-
+        $c_mode = ParseRenderMode::toFfiMode($mode);
         $c_settings = FtmlFfi::settingsFromMode($c_mode);
         $enable_page_syntax = $c_settings->enable_page_syntax;
         $use_true_ids = $c_settings->use_true_ids;

--- a/web/app/Services/Wikitext/WikitextSettings.php
+++ b/web/app/Services/Wikitext/WikitextSettings.php
@@ -37,14 +37,9 @@ class WikitextSettings
         $this->allow_local_paths = $allow_local_paths;
     }
 
-    public static function from_mode(int $mode): WikitextSettings
+    public static function fromMode(int $mode): WikitextSettings
     {
         $c_mode = ParseRenderMode::toFfiMode($mode);
-        $c_settings = FtmlFfi::settingsFromMode($c_mode);
-        $enable_page_syntax = $c_settings->enable_page_syntax;
-        $use_true_ids = $c_settings->use_true_ids;
-        $allow_local_paths = $c_settings->allow_local_paths;
-        FFI::free($c_settings);
-        return new WikitextSettings($mode, $enable_page_syntax, $use_true_ids, $allow_local_paths);
+        return FtmlFfi::settingsFromMode($c_mode)->toSettings();
     }
 }

--- a/web/app/Services/Wikitext/WikitextSettings.php
+++ b/web/app/Services/Wikitext/WikitextSettings.php
@@ -37,6 +37,12 @@ class WikitextSettings
         $this->allow_local_paths = $allow_local_paths;
     }
 
+    /**
+     * Produces a default WikitextSettings object from the given mode.
+     *
+     * @param int $mode ParseRenderMode value to use
+     * @return WikitextSettings
+     */
     public static function fromMode(int $mode): WikitextSettings
     {
         $c_mode = ParseRenderMode::toFfiMode($mode);

--- a/web/php/Utils/Outdater.php
+++ b/web/php/Utils/Outdater.php
@@ -204,11 +204,11 @@ class Outdater
         $compiled->setDateCompiled(new ODate());
         $compiled->save();
 
-        $this->vars['linksExist'] = $result->linkStats->internalLinksPresent;
-        $this->vars['linksNotExist'] = $result->linkStats->internalLinksAbsent;
-        $this->vars['inclusions'] = $result->linkStats->inclusionsPresent;
-        $this->vars['inclusionsNotExist'] = $result->linkStats->inclusionsAbsent;
-        $this->vars['externalLinks'] = $result->linkStats->externalLinks;
+        $this->vars['linksExist'] = $result->link_stats->internal_links_present;
+        $this->vars['linksNotExist'] = $result->link_stats->internal_links_absent;
+        $this->vars['inclusions'] = $result->link_stats->inclusions_present;
+        $this->vars['inclusionsNotExist'] = $result->link_stats->inclusions_absent;
+        $this->vars['externalLinks'] = $result->link_stats->external_links;
     }
 
     /**


### PR DESCRIPTION
After wikitext settings were added to ftml, the PHP was not updated to pass in that information. This PR adds a PHP version of `WikitextSettings`, converts from `ParserRenderMode` to it, and passes that data to libftml. It also changes some variable names to `$snake_case`.

Side note: This is one of the things I don't like about PHP FFI. There's no way for the build to automatically fail if the C part of the FFI changes at all.