### PR TITLE
Fix debug segfault in PHP-FFI for ftml

### DIFF
--- a/ftml/src/ffi/vec.rs
+++ b/ftml/src/ffi/vec.rs
@@ -27,6 +27,13 @@ pub unsafe fn cptr_to_slice<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
 }
 
 pub fn vec_to_cptr<T>(vec: Vec<T>) -> (*mut T, usize) {
+    // Special handling for empty lists:
+    // Always report pointer as NULL, discard vector like normal.
+    if vec.is_empty() {
+        return (ptr::null_mut(), 0);
+    }
+
+    // Otherwise, get raw aspects of Vec for export
     let mut slice = vec.into_boxed_slice(); // shrinks capacity to len
     let ptr = slice.as_mut_ptr();
     let len = slice.len();
@@ -42,6 +49,12 @@ pub unsafe fn drop_cptr<T, F>(ptr: *mut T, len: usize, drop: F)
 where
     F: FnMut(T),
 {
+    // Special handling for empty lists,
+    // since it's always (NULL, 0).
+    if ptr.is_null() {
+        return;
+    }
+
     Vec::from_raw_parts(ptr, len, len).drain(..).for_each(drop);
 }
 

--- a/install/files/php-fpm/setup-memcached.sh
+++ b/install/files/php-fpm/setup-memcached.sh
@@ -35,14 +35,11 @@ phpize
 make "-j$cores"
 make install
 
-# Install xdebug
-pecl install xdebug
-
 # Uninstall temporary dependencies
 apt remove -y "${dependencies[@]}"
 
 # Enable PHP extensions and clean up
-docker-php-ext-enable igbinary memcached memcache xdebug
+docker-php-ext-enable igbinary memcached memcache
 docker-php-ext-install \
 	"-j$cores" \
 		opcache \

--- a/install/files/php-fpm/setup-xdebug.sh
+++ b/install/files/php-fpm/setup-xdebug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eux
+
+pecl install xdebug
+docker-php-ext-enable igbinary memcached xdebug

--- a/install/files/php-fpm/setup-xdebug.sh
+++ b/install/files/php-fpm/setup-xdebug.sh
@@ -2,4 +2,4 @@
 set -eux
 
 pecl install xdebug
-docker-php-ext-enable igbinary memcached xdebug
+docker-php-ext-enable xdebug

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -21,6 +21,9 @@ COPY ./install/files/php-fpm/setup*.sh /src/
 # Install system dependencies
 RUN /src/setup-system.sh
 
+# !! Add debug utilities
+RUN apt install -y gdb valgrind vim
+
 # !! Configure xdebug
 RUN /src/setup-xdebug.sh
 ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -22,6 +22,7 @@ COPY ./install/files/php-fpm/setup*.sh /src/
 RUN /src/setup-system.sh
 
 # !! Configure xdebug
+RUN /src/setup-xdebug.sh
 ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # !! Put your IP for debugging here.

--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -38,14 +38,14 @@ final class LocalizationService
         $locale = App::currentLocale();
         $translation = self::$translations->find(null, $key);
         if ($translation === null) {
-            Log::warning("Unable to find message '$key' in locale '$locale'");
+            Log::warning('Unable to find message', ['key' => $key, 'locale' => $locale]);
             return $key;
         }
 
         // Format ICU localization message
         $message = $translation->getTranslation();
         $output = MessageFormatter::formatMessage($locale, $message, $values);
-        Log::debug("Translated message: $key -> $output"); // TODO: remove this
+        Log::debug('Translated message', ['key' => $key, 'output' => $output]); // TODO: remove this
         return $output;
     }
 }

--- a/web/app/Services/Wikitext/FFI/FtmlFfi.php
+++ b/web/app/Services/Wikitext/FFI/FtmlFfi.php
@@ -191,9 +191,9 @@ final class FtmlFfi
      * Converts an FFI C string into a nullable PHP string.
      * That is, it handles C NULL properly.
      */
-    public static function nullableString(FFI\CData $data): ?string
+    public static function nullableString(?FFI\CData $data): ?string
     {
-        if (FFI::isNull($data)) {
+        if ($data === null || FFI::isNull($data)) {
             return null;
         } else {
             return FFI::string($data);
@@ -315,7 +315,7 @@ final class FtmlFfi
      * @returns array with the converted objects
      */
     public static function pointerToList(
-        FFI\CData $pointer,
+        ?FFI\CData $pointer,
         int $length,
         callable $convert_fn
     ): array {

--- a/web/app/Services/Wikitext/FFI/OutputConversion.php
+++ b/web/app/Services/Wikitext/FFI/OutputConversion.php
@@ -23,7 +23,7 @@ final class OutputConversion
     }
 
     // HtmlMeta
-    public static function makeHtmlMetaArray(FFI\CData $pointer, int $length): array
+    public static function makeHtmlMetaArray(?FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
@@ -71,7 +71,7 @@ final class OutputConversion
         return new HtmlOutput($body, $styles, $meta, $warnings, $backlinks);
     }
 
-    private static function makeStylesArray(FFI\CData $pointer, int $length): array
+    private static function makeStylesArray(?FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,
@@ -95,7 +95,7 @@ final class OutputConversion
     }
 
     // ParseWarning
-    public static function makeParseWarningArray(FFI\CData $pointer, int $length): array
+    public static function makeParseWarningArray(?FFI\CData $pointer, int $length): array
     {
         return FtmlFfi::pointerToList(
             $pointer,


### PR DESCRIPTION
Previously, xdebug would try to access invalid memory when ftml calls were made (even though the FFI calls themselves don't do anything unsafe). This was determined to be an artifact of how Rust allocates zero-length vectors. Since a `NULL` pointer isn't used, xdebug felt it was okay to read through the pointer, unaware that it was meant to have a length of zero (i.e. has no valid elements). By changing the FFI handling to always emit `(NULL, 0)` for zero-length vectors, this crash no longer occurs.

This PR also changes some other things, such as only installing xdebug on local, and adding some helpful debug utilities in the local containers.