### PR TITLE
[WJ-925] Build 'default' locale

### DIFF
--- a/locales/messages/__main__.py
+++ b/locales/messages/__main__.py
@@ -26,8 +26,10 @@ if __name__ == "__main__":
     print()
 
     # Add default messages
-    print("Creating default localization...")
+    print("Adding default localization...")
     add_default_messages(messages_map)
+    print("+ default")
+    print()
 
     # Validate schemas
     invalid = validate_all(messages_map)

--- a/locales/messages/__main__.py
+++ b/locales/messages/__main__.py
@@ -9,7 +9,7 @@ Executable file, permitting command-line building of messages files.
 import os
 import sys
 
-from .catalog import get_template_messages
+from .catalog import add_default_messages, get_template_messages
 from .gettext import build_mo, generate_po
 from .path_loader import OUTPUT_DIRECTORY, load
 from .schema import MAIN_MESSAGE_SCHEMA_NAME, validate_all
@@ -24,6 +24,10 @@ if __name__ == "__main__":
     directory = sys.argv[1]
     messages_map = load(directory)
     print()
+
+    # Add default messages
+    print("Creating default localization...")
+    add_default_messages(messages_map)
 
     # Validate schemas
     invalid = validate_all(messages_map)

--- a/locales/messages/catalog.py
+++ b/locales/messages/catalog.py
@@ -16,7 +16,7 @@ from typing import Iterable, Optional, Tuple, Union
 
 from ruamel.yaml.compat import ordereddict
 
-from .schema import MessagesSchema
+from .schema import MAIN_MESSAGE_SCHEMA_NAME, MessagesSchema
 
 CommentData = dict[str, Optional[str]]
 MessagesData = dict[str, str]
@@ -74,6 +74,19 @@ def flatten(tree: MessagesTree) -> Tuple[MessagesData, CommentData]:
 
     sub_flatten(None, tree)
     return flattened, comments
+
+
+def add_default_messages(messages_map: dict[str, Messages]):
+    """
+    Add a 'default' Messages object that has each message as its key.
+    """
+
+    main = messages_map[MAIN_MESSAGE_SCHEMA_NAME]
+    message_data = {path: path for path in main.schema}
+    comment_data = {path: main.comment_data[path] for path in main.schema}
+
+    default_messages = Messages("default", "default", None, message_data, comment_data)
+    messages_map["default"] = default_messages
 
 
 def get_template_messages(schema: Iterable[str]) -> Messages:


### PR DESCRIPTION
The "default" locale is one where each translation message is just the message key. It is similar to the template in this way, but is usable as an actual localization in various debugging situations. This PR adds automatic generation of the default locale to the `locales` build.