### PR TITLE
[WJ-471] Remove PHP ImageMagick extension

### DIFF
--- a/install/files/php-fpm/setup-php-extensions.sh
+++ b/install/files/php-fpm/setup-php-extensions.sh
@@ -17,7 +17,3 @@ docker-php-ext-install intl
 # Configure PHP Data Structures
 pecl install ds
 docker-php-ext-enable ds
-
-# Configure PHP Imagick (ImageMagick wrapper)
-pecl install imagick
-docker-php-ext-enable imagick

--- a/install/files/php-fpm/setup-system.sh
+++ b/install/files/php-fpm/setup-system.sh
@@ -3,13 +3,12 @@ set -eux
 
 apt update
 apt install -y \
-	git \
-	html2text \
-	imagemagick \
-	libfreetype6-dev \
 	libgd-dev \
 	libjpeg62-turbo-dev \
-	libmagickwand-dev \
-	libtidy-dev \
+	libfreetype6-dev \
+	imagemagick \
+	git \
+	zip \
+	html2text \
 	postgresql-common \
-	zip
+	libtidy-dev

--- a/install/files/php-fpm/setup-system.sh
+++ b/install/files/php-fpm/setup-system.sh
@@ -3,12 +3,12 @@ set -eux
 
 apt update
 apt install -y \
+	git \
+	html2text \
+	imagemagick \
+	libfreetype6-dev \
 	libgd-dev \
 	libjpeg62-turbo-dev \
-	libfreetype6-dev \
-	imagemagick \
-	git \
-	zip \
-	html2text \
+	libtidy-dev \
 	postgresql-common \
-	libtidy-dev
+	zip


### PR DESCRIPTION
Reverts scpwiki/wikijump#562

It turns out we don't actually need this extension to generate SVG MFA barcodes, and since we don't need imagemagick for other parts of the codebase, and every PHP extension we add massively slows down the build process, we should remove this.