### PR TITLE
Update nginx config for local and AWS dev

### DIFF
--- a/install/aws/dev/terraform/deploy/.gitignore
+++ b/install/aws/dev/terraform/deploy/.gitignore
@@ -5,6 +5,9 @@
 *.tfstate
 *.tfstate.*
 
+# Lock file
+.terraform.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -76,6 +76,13 @@ module "nginx" {
 
   links = ["php-fpm:php-fpm"]
 
+  extra_hosts = [
+    {
+      hostname  = "host.docker.internal"
+      ipAddress = "host-gateway"
+    }
+  ]
+
   docker_labels = {
     "traefik.enable"                                = "true"
     "traefik.http.routers.php-fpm.rule"             = "Host(`${var.web_domain}`,`www.${var.web_domain}`,`${var.files_domain}`,`www.${var.files_domain}`)"

--- a/install/local/dev/docker-compose.yaml
+++ b/install/local/dev/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
       dockerfile: install/local/dev/nginx/Dockerfile
     ports:
       - "80:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - php-fpm
 


### PR DESCRIPTION
This PR *does* fix nginx crashes on local builds for Linux, and *should* fix nginx crashes in AWS dev but needs to be run and verified there via TF Cloud.