### PR TITLE
Adjustments to S3 and ECS

### DIFF
--- a/install/aws/dev/terraform/deploy/elb.tf
+++ b/install/aws/dev/terraform/deploy/elb.tf
@@ -14,7 +14,7 @@ resource "aws_lb" "wikijump_elb" {
 
   access_logs {
     bucket  = aws_s3_bucket.elb_logs.bucket
-    prefix  = var.environment
+    prefix  = "elb"
     enabled = true
   }
 }

--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -79,7 +79,7 @@ module "nginx" {
   extra_hosts = [
     {
       hostname  = "host.docker.internal"
-      ipAddress = "host-gateway"
+      ipAddress = "169.254.172.1" # https://github.com/aws/containers-roadmap/issues/165#issuecomment-527449161
     }
   ]
 


### PR DESCRIPTION
The S3 bucket for logs from the load balancer is already per-environment so it does not need an environment prefix.
The host change for ECS is worth a try but if it doesn't do it, we'll break the nginx.conf out per-environment so the dev build doesn't need these features.