### PR TITLE
Add preload directive to Blade templates

### DIFF
--- a/web/app/Providers/ViewServiceProvider.php
+++ b/web/app/Providers/ViewServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Wikijump\View\Composers\BaseComposer;
 use Wikijump\View\Composers\PageMockedComposer;
+use Wikijump\View\Directives\PreloadDirective;
 
 class ViewServiceProvider extends ServiceProvider
 {
@@ -29,5 +30,7 @@ class ViewServiceProvider extends ServiceProvider
     {
         View::composer('next.base', BaseComposer::class);
         View::composer('next.test.page-test', PageMockedComposer::class);
+
+        PreloadDirective::register();
     }
 }

--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -47,7 +47,6 @@ final class LocalizationService
         // Format ICU localization message
         $message = $translation->getTranslation();
         $output = MessageFormatter::formatMessage($locale, $message, $values);
-        Log::debug('Translated message', ['key' => $key, 'output' => $output]); // TODO: remove this
         return $output;
     }
 }

--- a/web/app/View/Directives/PreloadDirective.php
+++ b/web/app/View/Directives/PreloadDirective.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wikijump\View\Directives;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Str;
+use Innocenzi\Vite\Vite;
+
+final class PreloadDirective
+{
+    private function __construct()
+    {
+    }
+
+    public static function register()
+    {
+        Blade::directive('preload', function ($expression) {
+            $namespace = '\Wikijump\View\Directives\PreloadDirective';
+            return "<?php echo $namespace::preload({$expression}); ?>";
+        });
+    }
+
+    public static function preloadTag(
+        string $href,
+        string $as,
+        string $type = '',
+        bool $crossorigin = false
+    ): string {
+        $crossorigin = $crossorigin ? 'crossorigin' : '';
+        $type = $type ? "type=\"{$type}\"" : '';
+        $rel = Str::endsWith($href, ['.js', '.ts']) ? 'modulepreload' : 'preload';
+        return "<link rel=\"$rel\" href=\"$href\" as=\"$as\" $type $crossorigin />\n";
+    }
+
+    public static function preload(string $path): string
+    {
+        $urls = [];
+
+        // if the URL doesn't start with a slash, we'll retrieve it from the manifest
+        if (!Str::startsWith($path, '/')) {
+            $vite = App::make(Vite::class);
+
+            // generate from development url
+            if (App::environment('local') && $vite->isDevelopmentServerRunning()) {
+                $urls[] = config('vite.dev_url') . '/' . $path;
+            }
+            // generate from a manifest entry
+            else {
+                $entry = $vite->getEntries()->get($path);
+                if ($entry) {
+                    $urls[] = asset(
+                        sprintf('/%s/%s', config('vite.build_path'), $entry->file),
+                    );
+
+                    // TODO: preload imports, too
+                    // laravel-vite doesn't keep track of imports from the manifest,
+                    // so this isn't possible yet
+
+                    // preload imported CSS
+                    $entry->css->each(function (string $path) use (&$urls) {
+                        $urls[] = asset(
+                            sprintf('/%s/%s', config('vite.build_path'), $path),
+                        );
+                    });
+                }
+            }
+        } else {
+            $urls[] = $path;
+        }
+
+        $html = '';
+
+        foreach ($urls as $url) {
+            // file extension (no . at the beginning)
+            $ext = pathinfo($url, PATHINFO_EXTENSION);
+
+            // prettier-ignore
+            switch ($ext) {
+                case 'ts':    $html .= self::preloadTag($url, 'script'); break;
+                case 'js':    $html .= self::preloadTag($url, 'script'); break;
+                case 'scss':  $html .= self::preloadTag($url, 'style'); break;
+                case 'css':   $html .= self::preloadTag($url, 'style'); break;
+                case 'woff2': $html .= self::preloadTag($url, 'font', 'font/woff2', true); break;
+            }
+        }
+
+        return $html;
+    }
+}

--- a/web/app/View/Directives/PreloadDirective.php
+++ b/web/app/View/Directives/PreloadDirective.php
@@ -15,6 +15,7 @@ final class PreloadDirective
     {
     }
 
+    /** Registers the `@preload` directive. */
     public static function register()
     {
         Blade::directive('preload', function ($expression) {
@@ -23,6 +24,14 @@ final class PreloadDirective
         });
     }
 
+    /**
+     * Returns an HTML tag for a preload link.
+     *
+     * @param string $href The URL to preload.
+     * @param string $as The type of resource to preload.
+     * @param string $type The MIME type to preload. (optional)
+     * @param bool $crossorigin Whether to allow crossorigin requests. (optional)
+     */
     public static function preloadTag(
         string $href,
         string $as,
@@ -35,6 +44,12 @@ final class PreloadDirective
         return "<link rel=\"$rel\" href=\"$href\" as=\"$as\" $type $crossorigin />\n";
     }
 
+    /**
+     * Returns a string of potentially multiple link preload tags,
+     * depending on the path given.
+     *
+     * @param string $path The path to preload.
+     */
     public static function preload(string $path): string
     {
         $urls = [];

--- a/web/resources/views/next/auth/confirm-password.blade.php
+++ b/web/resources/views/next/auth/confirm-password.blade.php
@@ -12,10 +12,10 @@
 @endpush
 
 @section('content')
-<h2 id="auth_confirm_password">
-  {{ __('account_panel.CONFIRM_PASSWORD') }}
-</h2>
+    <h2 id="auth_confirm_password">
+    {{ __('account_panel.CONFIRM_PASSWORD') }}
+    </h2>
 
-<div id="auth_form_container">
-</div>
+    <div id="auth_form_container">
+    </div>
 @endsection

--- a/web/resources/views/next/auth/confirm-password.blade.php
+++ b/web/resources/views/next/auth/confirm-password.blade.php
@@ -7,6 +7,10 @@
     'title' => __('account_panel.CONFIRM_PASSWORD')
 ])
 
+@push('preloads')
+    @preload('resources/scripts/auth-confirm.ts')
+@endpush
+
 @push('scripts')
     @vite('auth-confirm.ts')
 @endpush

--- a/web/resources/views/next/auth/login.blade.php
+++ b/web/resources/views/next/auth/login.blade.php
@@ -12,10 +12,10 @@
 @endpush
 
 @section('content')
-<div id="auth_form_container">
-</div>
+    <div id="auth_form_container">
+    </div>
 
-<a id="auth_create_account" href="/user--services/register">
-    {{ __("account_panel.CREATE_ACCOUNT") }}
-</a>
+    <a id="auth_create_account" href="/user--services/register">
+        {{ __("account_panel.CREATE_ACCOUNT") }}
+    </a>
 @endsection

--- a/web/resources/views/next/auth/login.blade.php
+++ b/web/resources/views/next/auth/login.blade.php
@@ -7,6 +7,10 @@
     'title' => __('account_panel.LOGIN')
 ])
 
+@push('preloads')
+    @preload('resources/scripts/auth-login.ts')
+@endpush
+
 @push('scripts')
     @vite('auth-login.ts')
 @endpush

--- a/web/resources/views/next/auth/register.blade.php
+++ b/web/resources/views/next/auth/register.blade.php
@@ -12,10 +12,10 @@
 @endpush
 
 @section('content')
-<div id="auth_form_container">
-</div>
+    <div id="auth_form_container">
+    </div>
 
-<a id="auth_login" href="/user--services/login">
-    {{ __("account_panel.LOGIN") }}
-</a>
+    <a id="auth_login" href="/user--services/login">
+        {{ __("account_panel.LOGIN") }}
+    </a>
 @endsection

--- a/web/resources/views/next/auth/register.blade.php
+++ b/web/resources/views/next/auth/register.blade.php
@@ -7,6 +7,10 @@
     'title' => __('account_panel.REGISTER')
 ])
 
+@push('preloads')
+    @preload('resources/scripts/auth-register.ts')
+@endpush
+
 @push('scripts')
     @vite('auth-register.ts')
 @endpush

--- a/web/resources/views/next/base.blade.php
+++ b/web/resources/views/next/base.blade.php
@@ -71,17 +71,9 @@
     > --}}
 
     {{-- Preloads, Preconnects --}}
-    {{-- TODO: figure out how to properly preload these:
-        <link rel="preload" href="{{ vite_asset('resources/css/base.scss') }}" as="style">
-        <link rel="preload" href="{{ vite_asset('resources/scripts/index.ts') }}"
-              as="script">
-        <link rel="preload"
-            href="{{ vite_asset('resources/fonts/variable/PublicSans-VariableFont.woff2') }}"
-            as="font" type="font/woff2" crossorigin>
-        <link rel="preload"
-            href="{{ vite_asset('resources/fonts/variable/Exo2-VariableFont.woff2') }}"
-            as="font" type="font/woff2" crossorigin>
-    - --}}
+    @preload('/files--static/fonts/variable/PublicSans-VariableFont.woff2')
+    @preload('/files--static/fonts/variable/RedHatDisplayVF.woff2')
+    @preload('resources/scripts/index.ts')
     {{-- TODO: preload the user's locale file --}}
     @stack('preloads')
 

--- a/web/resources/views/next/wiki/page.blade.php
+++ b/web/resources/views/next/wiki/page.blade.php
@@ -20,6 +20,10 @@
 
 @extends('next.frame')
 
+@push('preloads')
+    @preload('resources/scripts/wiki.ts')
+@endpush
+
 @push('scripts')
     @vite('wiki.ts')
 @endpush


### PR DESCRIPTION
This was surprisingly complicated...

This PR adds the `@preload('path')` directive. This directive automagically generates preload tags, handling both static assets and Vite generated ones.