### PR TITLE
Set locales builder encoding to UTF-8 explicitly

### DIFF
--- a/locales/.pylintrc
+++ b/locales/.pylintrc
@@ -52,8 +52,7 @@ confidence=
 enable=
 disable=missing-docstring,
         invalid-name,
-        no-else-return,
-        unspecified-encoding
+        no-else-return
 
 
 [TYPECHECK]

--- a/locales/messages/__main__.py
+++ b/locales/messages/__main__.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     def write_file(filename, contents):
         print(f"+ {filename}")
         path = get_path(filename)
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             file.write(contents)
 
     print(f"Generating {len(messages_map) + 1} localization files...")

--- a/locales/messages/path_loader.py
+++ b/locales/messages/path_loader.py
@@ -70,7 +70,7 @@ def load(directory: str, log=True) -> dict[str, Messages]:
             print(f"+ {name}")
 
         stub = stubs[name]
-        with open(stub.path) as file:
+        with open(stub.path, encoding="utf-8") as file:
             tree = yaml.load(file)
 
         # Get path -> message mapping


### PR DESCRIPTION
Previously this service had a disabled lint for setting encoding. Given that this handles international characters, and an assumption that UTF-8 will be used is not portable, this PR changes it to explicitly specify the encoding for all file I/O.