### PR TITLE
[WJ-938] Remove append mode

### DIFF
--- a/web/DEADCODE.md
+++ b/web/DEADCODE.md
@@ -255,3 +255,9 @@ If possible, add to this log in the same commit in which the code is removed.
 * Relevant Issues: [WJ-936](https://scuttle.atlassian.net/browse/WJ-936)
 * What it did: Allowed editing a portion of a page, separated by headings.
 * Why it was removed: As described in the issue, it was buggy, not frequently used, and removing it simplifies page edit lock significantly as we engage in further refactoring.
+
+## PHP: Append Editing
+* Where it was: Multiple files, see pull request
+* Relevant Issues: [WJ-938](https://scuttle.atlassian.net/browse/WJ-938)
+* What it did: Allowed editing by adding contents to the end of a page.
+* Why it was removed: It was frequently used, and with the removal of section editing, it made sense to simplify page edit code by removing it as well.

--- a/web/app/Helpers/LegacyTools.php
+++ b/web/app/Helpers/LegacyTools.php
@@ -458,7 +458,6 @@ final class LegacyTools
         $otext .= '<a href="javascript:;" id="more-options-button">+&nbsp;'._('options').'</a>
 </div>
 <div id="page-options-bottom-2" class="page-options-bottom" style="display:none">
-	<a href="javascript:;" id="edit-append-button">'._('append').'</a>
 	<a href="javascript:;" id="backlinks-button">'._('backlinks').'</a>
 	<a href="javascript:;" id="view-source-button">'._('view source').'</a>
 	<a href="javascript:;" id="parent-page-button">'._('parent').'</a>

--- a/web/database/migrations/2021_11_28_195440_remove_edit_lock_mode.php
+++ b/web/database/migrations/2021_11_28_195440_remove_edit_lock_mode.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveEditLockMode extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('page_edit_lock', function (Blueprint $table) {
+            $table->dropColumn('mode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('page_edit_lock', function (Blueprint $table) {
+            $table->string('mode', 10)->default('page');
+        });
+    }
+}

--- a/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Button.php
+++ b/web/lib/text_wiki/Text/Wiki/Render/Xhtml/Button.php
@@ -31,7 +31,6 @@ class Text_Wiki_Render_Xhtml_Button extends Text_Wiki_Render {
 
     	$allowedTypes = array(
     		'edit',
-    		'edit-append',
     		'history',
     		'print',
     		'files',
@@ -44,7 +43,6 @@ class Text_Wiki_Render_Xhtml_Button extends Text_Wiki_Render {
 
     	$defaultText = array(
     		'edit' => _('edit'),
-    		'edit-append' => _('append'),
     		'history' => _('history'),
     		'print' => _('print'),
     		'files' => _('files'),
@@ -57,7 +55,6 @@ class Text_Wiki_Render_Xhtml_Button extends Text_Wiki_Render {
 
     	$jsOnclick = array(
     		'edit' => 'WIKIDOT.page.listeners.editClick(event)',
-    		'edit-append' => 'WIKIDOT.page.listeners.append(event)',
     		'history' => ' WIKIDOT.page.listeners.historyClick(event)',
     		'print' => 'WIKIDOT.page.listeners.printClick(event)',
     		'files' => 'WIKIDOT.page.listeners.filesClick(event)',

--- a/web/php/Actions/WikiPageAction.php
+++ b/web/php/Actions/WikiPageAction.php
@@ -47,8 +47,6 @@ class WikiPageAction extends SmartyAction
         $pl = $runData->getParameterList();
         $pageId = $pl->getParameterValue("page_id");
 
-        $mode = $pl->getParameterValue("mode");
-
         if ($pl->getParameterValue("form")) {
             $data = [];
             foreach ($runData->getParameterList()->asArray() as $name => $val) {
@@ -338,7 +336,6 @@ class WikiPageAction extends SmartyAction
 
                 $lock->setDateStarted(new ODate());
                 $lock->setDateLastAccessed(new ODate());
-                $lock->setMode($mode);
                 $conflictLocks = $lock->getConflicts();
                 if ($conflictLocks == null) {
                     // safely recreate lock
@@ -379,10 +376,6 @@ class WikiPageAction extends SmartyAction
             $oldSourceText = $page->getSource();
             $sourceChanged = false;
 
-            if ($mode == "append") {
-                $source = $oldSourceText."\n\n".$source;
-            }
-
             if ($oldSourceText !== $source) {
                 $sourceChanged = true;
             }
@@ -394,13 +387,10 @@ class WikiPageAction extends SmartyAction
             // compare metadata
             $metadataChanged = false;
             $oldMetadata = $page->getMetadata();
-            // title
-            if ($mode === 'page') {
-                // check only if the whole page is edited
-                if ($title !== $oldMetadata->getTitle()) {
-                    $pageRevision->setFlagTitle(true);
-                    $metadataChanged = true;
-                }
+            // check only if the whole page is edited
+            if ($title !== $oldMetadata->getTitle()) {
+                $pageRevision->setFlagTitle(true);
+                $metadataChanged = true;
             }
 
             // and act accordingly to the situation
@@ -450,9 +440,7 @@ class WikiPageAction extends SmartyAction
 
             // update Page object
 
-            if ($mode === 'page') {
-                $page->setTitle($title);
-            }
+            $page->setTitle($title);
             $page->setDateLastEdited($nowDate);
             $page->setMetadataId($pageRevision->getMetadataId());
             $page->setRevisionNumber($pageRevision->getRevisionNumber());
@@ -505,7 +493,6 @@ class WikiPageAction extends SmartyAction
     {
         $pl = $runData->getParameterList();
         $pageId = $pl->getParameterValue("page_id");
-        $mode = $pl->getParameterValue("mode");
 
         $unixName = $pl->getParameterValue("wiki_page");
         $unixName = WDStringUtils::toUnixName($unixName); // purify! (for sure)
@@ -582,7 +569,6 @@ class WikiPageAction extends SmartyAction
 
                 $lock->setDateStarted($dateLastAccessed);
                 $lock->setDateLastAccessed($dateLastAccessed);
-                $lock->setMode($mode);
                 $conflictLocks = $lock->getConflicts();
                 if ($conflictLocks == null) {
                     // safely recreate lock
@@ -611,8 +597,6 @@ class WikiPageAction extends SmartyAction
     {
         $pl = $runData->getParameterList();
         $pageId = $pl->getParameterValue("page_id");
-
-        $mode = $pl->getParameterValue("mode");
 
         $unixName = $pl->getParameterValue("wiki_page");
         $unixName = WDStringUtils::toUnixName($unixName); // purify! (for sure)
@@ -667,7 +651,6 @@ class WikiPageAction extends SmartyAction
 
         $lock->setDateStarted(new ODate());
         $lock->setDateLastAccessed(new ODate());
-        $lock->setMode($mode);
         $secret = md5(time().rand(1000, 9999));
         $lock->setSecret($secret);
         $lock->setSessionId($runData->getSession()->getSessionId());

--- a/web/php/DB/PageEditLock.php
+++ b/web/php/DB/PageEditLock.php
@@ -47,24 +47,11 @@ class PageEditLock extends PageEditLockBase
             }
         } else {
             // now if the page exists.
-
-            if ($this->getMode() == "page") {
-                // conflicts with any other type of lock for this page...
-                $c = new Criteria();
-                $c->add("page_id", $this->getPageId());
-                if ($this->getLockId() != null) {
-                    $c->add("lock_id", $this->getLockId(), "!=");
-                }
-            }
-
-            if ($this->getMode() == "append") {
-                // conflicts only with "page" mode
-                $c = new Criteria();
-                $c->add("page_id", $this->getPageId());
-                if ($this->getLockId() != null) {
-                    $c->add("lock_id", $this->getLockId(), "!=");
-                }
-                $c->add("mode", "page");
+            // conflicts with any other type of lock for this page...
+            $c = new Criteria();
+            $c->add("page_id", $this->getPageId());
+            if ($this->getLockId() != null) {
+                $c->add("lock_id", $this->getLockId(), "!=");
             }
         }
         return $c;

--- a/web/php/DB/PageEditLockBase.php
+++ b/web/php/DB/PageEditLockBase.php
@@ -18,14 +18,8 @@ class PageEditLockBase extends BaseDBObject
         $this->tableName='page_edit_lock';
         $this->peerName = 'Wikidot\\DB\\PageEditLockPeer';
         $this->primaryKeyName = 'lock_id';
-        $this->fieldNames = array( 'lock_id' ,  'page_id' ,  'mode' ,   'page_unix_name' ,  'site_id' ,  'user_id' ,  'user_string' ,  'session_id' ,  'date_started' ,  'date_last_accessed' ,  'secret' );
-
-        //$this->fieldDefaultValues=
+        $this->fieldNames = array( 'lock_id' ,  'page_id' ,  'page_unix_name' ,  'site_id' ,  'user_id' ,  'user_string' ,  'session_id' ,  'date_started' ,  'date_last_accessed' ,  'secret' );
     }
-
-
-
-
 
 
     public function getLockId()
@@ -47,17 +41,6 @@ class PageEditLockBase extends BaseDBObject
     public function setPageId($v1, $raw = false)
     {
         $this->setFieldValue('page_id', $v1, $raw);
-    }
-
-
-    public function getMode()
-    {
-        return $this->getFieldValue('mode');
-    }
-
-    public function setMode($v1, $raw = false)
-    {
-        $this->setFieldValue('mode', $v1, $raw);
     }
 
 

--- a/web/php/DB/PageEditLockPeerBase.php
+++ b/web/php/DB/PageEditLockPeerBase.php
@@ -21,6 +21,7 @@ class PageEditLockPeerBase extends BaseDBPeer
         $this->primaryKeyName = 'lock_id';
         $this->fieldNames = array( 'lock_id' ,  'page_id' ,  'page_unix_name' ,  'site_id' ,  'user_id' ,  'user_string' ,  'session_id' ,  'date_started' ,  'date_last_accessed' ,  'secret' );
         $this->fieldTypes = array( 'lock_id' => 'serial',  'page_id' => 'int',   'page_unix_name' => 'varchar(100)',  'site_id' => 'int',  'user_id' => 'int',  'user_string' => 'varchar(80)',  'session_id' => 'varchar(60)',  'date_started' => 'timestamp',  'date_last_accessed' => 'timestamp',  'secret' => 'varchar(100)');
+        $this->defaultValues = array();
     }
 
     public static function instance()

--- a/web/php/DB/PageEditLockPeerBase.php
+++ b/web/php/DB/PageEditLockPeerBase.php
@@ -19,9 +19,8 @@ class PageEditLockPeerBase extends BaseDBPeer
         $this->tableName='page_edit_lock';
         $this->objectName='Wikidot\\DB\\PageEditLock';
         $this->primaryKeyName = 'lock_id';
-        $this->fieldNames = array( 'lock_id' ,  'page_id' ,  'mode' ,   'page_unix_name' ,  'site_id' ,  'user_id' ,  'user_string' ,  'session_id' ,  'date_started' ,  'date_last_accessed' ,  'secret' );
-        $this->fieldTypes = array( 'lock_id' => 'serial',  'page_id' => 'int',  'mode' => 'varchar(10)',  'page_unix_name' => 'varchar(100)',  'site_id' => 'int',  'user_id' => 'int',  'user_string' => 'varchar(80)',  'session_id' => 'varchar(60)',  'date_started' => 'timestamp',  'date_last_accessed' => 'timestamp',  'secret' => 'varchar(100)');
-        $this->defaultValues = array( 'mode' => 'page');
+        $this->fieldNames = array( 'lock_id' ,  'page_id' ,  'page_unix_name' ,  'site_id' ,  'user_id' ,  'user_string' ,  'session_id' ,  'date_started' ,  'date_last_accessed' ,  'secret' );
+        $this->fieldTypes = array( 'lock_id' => 'serial',  'page_id' => 'int',   'page_unix_name' => 'varchar(100)',  'site_id' => 'int',  'user_id' => 'int',  'user_string' => 'varchar(80)',  'session_id' => 'varchar(60)',  'date_started' => 'timestamp',  'date_last_accessed' => 'timestamp',  'secret' => 'varchar(100)');
     }
 
     public static function instance()

--- a/web/php/Modules/Edit/PageEditModule.php
+++ b/web/php/Modules/Edit/PageEditModule.php
@@ -32,10 +32,6 @@ class PageEditModule extends SmartyModule
 
         $pageId = $pl->getParameterValue("page_id");
 
-        $mode = $pl->getParameterValue("mode");
-
-        $runData->ajaxResponseAdd("mode", $mode);
-
         $user = $runData->getUser();
 
         $userId = $runData->getUserId();
@@ -51,8 +47,6 @@ class PageEditModule extends SmartyModule
             // means probably creating a new page
             // no context is needed
             $runData->sessionStart();
-            $mode = "page";
-            $runData->contextAdd("mode", $mode);
             $runData->contextAdd("newPage", true);
 
             // first create if a page not already exists!
@@ -230,7 +224,6 @@ class PageEditModule extends SmartyModule
 
         $lock->setDateStarted(new ODate());
         $lock->setDateLastAccessed(new ODate());
-        $lock->setMode($mode);
 
         // delete outdated...
         PageEditLockPeer::instance()->deleteOutdated($pageId);
@@ -263,17 +256,10 @@ class PageEditModule extends SmartyModule
         // keep the session - i.e. put an object into session storage not to delete it!!!
         $runData->sessionAdd("keep", true);
 
-        if ($mode == "page") {
-            $pageSource = $page->getSource();
-            $runData->contextAdd("source", $pageSource);
-        }
-        if ($mode == "append") {
-            $runData->contextAdd("source", ""); // source not required...
-        }
+        $pageSource = $page->getSource();
+        $runData->contextAdd("source", $pageSource);
         $runData->contextAdd("title", $page->getTitleRaw());
         $runData->contextAdd("pageId", $page->getPageId());
-
-        $runData->contextAdd("mode", $mode);
 
         $runData->ajaxResponseAdd("timeLeft", 15*60);
 

--- a/web/php/Modules/PageOptionsBottomModule.php
+++ b/web/php/Modules/PageOptionsBottomModule.php
@@ -91,7 +91,6 @@ class PageOptionsBottomModule extends Module
         $otext .= '<a href="javascript:;" id="more-options-button">+&nbsp;'._('options').'</a>
 </div>
 <div id="page-options-bottom-2" class="page-options-bottom" style="display:none">
-	<a href="javascript:;" id="edit-append-button">'._('append').'</a>
 	<a href="javascript:;" id="backlinks-button">'._('backlinks').'</a>
 	<a href="javascript:;" id="view-source-button">'._('view source').'</a>
 	<a href="javascript:;" id="parent-page-button">'._('parent').'</a>

--- a/web/resources/views/layouts/legacy.blade.php
+++ b/web/resources/views/layouts/legacy.blade.php
@@ -190,10 +190,6 @@
     <div id="edit-sections-button-hovertip">
         Click here to toggle editing of individual sections of the page (if possible).
         Watch headings for an "edit" link when available.
-    </div>
-    <div id="edit-append-button-hovertip">
-        Append content without editing the whole page source.
-    </div>
     <div id="history-button-hovertip">
         Check out how this page has evolved in the past.
     </div>

--- a/web/templates/layouts/WikiLayout.tpl
+++ b/web/templates/layouts/WikiLayout.tpl
@@ -191,9 +191,6 @@
 	 		{t}Click here to toggle editing of individual sections of the page (if possible).
 	 		Watch headings for an "edit" link when available.{/t}
  		</div>
- 		<div id="edit-append-button-hovertip">
- 			{t}Append content without editing the whole page source.{/t}
- 		</div>
  		<div id="history-button-hovertip">
  			{t}Check out how this page has evolved in the past.{/t}
  		</div>

--- a/web/templates/modules/Edit/LockExistsWinModule.tpl
+++ b/web/templates/modules/Edit/LockExistsWinModule.tpl
@@ -18,7 +18,6 @@
 		{foreach from=$locks item=lock}
 		<p>
 			{t}Locked by{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-			{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 			{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 			{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 		</p>

--- a/web/templates/modules/Edit/LockExpiredConflictWinModule.tpl
+++ b/web/templates/modules/Edit/LockExpiredConflictWinModule.tpl
@@ -16,7 +16,6 @@
 		{foreach from=$locks item=lock}
 		<p>
 			{t}Locked by{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-			{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 			{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 			{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 		</p>

--- a/web/templates/modules/Edit/LockInterceptedWinModule.tpl
+++ b/web/templates/modules/Edit/LockInterceptedWinModule.tpl
@@ -30,7 +30,6 @@
 			{foreach from=$locks item=lock}
 				<p>
 					{t}By{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-					{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 					{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 					{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 				</p>

--- a/web/templates/modules/Edit/NewPageLockedWinModule.tpl
+++ b/web/templates/modules/Edit/NewPageLockedWinModule.tpl
@@ -16,7 +16,6 @@
 		{foreach from=$locks item=lock}
 		<p>
 			{t}By{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-			{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 			{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 			{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 		</p>

--- a/web/templates/modules/Edit/PageEditModule.tpl
+++ b/web/templates/modules/Edit/PageEditModule.tpl
@@ -11,36 +11,32 @@
 
 		<form id="edit-page-form"{if $form} class="edit-with-form"{/if}>
 			<input type="hidden" name="page_id" value="{$pageId|escape}"/>
-			{if $mode=="page" || ($newPage && $templates)}
-				<table class="form" style="margin: 0.5em auto 1em 0">
-					{if $mode=="page"}
-						<tr>
-							<td>
-								{t}Title of the page{/t}:
-							</td>
-							<td>
-								<input class="text" id="edit-page-title" name="title" type="text" value="{$title|escape}" size="35" maxlength="128"
-									style="font-weight: bold; font-size: 130%;"/>
-							</td>
-						</tr>
-					{/if}
-					{if $newPage && $templates}
-						<tr>
-							<td>
-								{t}Initial content{/t}:
-							</td>
-							<td>
-								<select name="theme" id="page-templates" onchange="Wikijump.modules.PageEditModule.listeners.templateChange(event)">
-									<option value=""  style="padding: 0 1em">no template (blank page)</option>
-									{foreach from=$templates item=template}
-										<option value="{$template->getPageId()}"  style="padding: 0 1em" {if $template->getPageId() == $templateId}selected="selected"{/if}>{$template->getTitle()|escape}</option>
-									{/foreach}
-								</select>
-							</td>
-						</tr>
-					{/if}
-				</table>
-			{/if}
+			<table class="form" style="margin: 0.5em auto 1em 0">
+				<tr>
+					<td>
+						{t}Title of the page{/t}:
+					</td>
+					<td>
+						<input class="text" id="edit-page-title" name="title" type="text" value="{$title|escape}" size="35" maxlength="128"
+							style="font-weight: bold; font-size: 130%;"/>
+					</td>
+				</tr>
+				{if $newPage && $templates}
+					<tr>
+						<td>
+							{t}Initial content{/t}:
+						</td>
+						<td>
+							<select name="theme" id="page-templates" onchange="Wikijump.modules.PageEditModule.listeners.templateChange(event)">
+								<option value=""  style="padding: 0 1em">no template (blank page)</option>
+								{foreach from=$templates item=template}
+									<option value="{$template->getPageId()}"  style="padding: 0 1em" {if $template->getPageId() == $templateId}selected="selected"{/if}>{$template->getTitle()|escape}</option>
+								{/foreach}
+							</select>
+						</td>
+					</tr>
+				{/if}
+			</table>
             {if $form}
                 <input type="hidden" name="form" value="true"/>
                 <table class="form" style="margin: 0.5em auto 1em 0pt">
@@ -102,9 +98,9 @@
 
 			<div class="buttons alignleft">
 				<input type="button" name="cancel" id="edit-cancel-button" value="{t}cancel{/t}" onclick="Wikijump.modules.PageEditModule.listeners.cancel(event)"/>
-				{if !$newPage && $mode != "append"}<input type="button" name="diff" id="edit-diff-button" value="{t}view diff{/t}" onclick="Wikijump.modules.PageEditModule.listeners.viewDiff(event)"/>{/if}
+				{if !$newPage}<input type="button" name="diff" id="edit-diff-button" value="{t}view diff{/t}" onclick="Wikijump.modules.PageEditModule.listeners.viewDiff(event)"/>{/if}
 				<input type="button" name="preview" id="edit-preview-button" value="{t}preview{/t}" onclick="Wikijump.modules.PageEditModule.listeners.preview(event)"/>
-				{if !$newPage && $mode =="page"}<input type="button" name="save-continue" id="edit-save-continue-button"  value="{t escape=no}save &amp; continue{/t}" onclick="Wikijump.modules.PageEditModule.listeners.saveAndContinue(event)"/>{/if}
+				{if !$newPage}<input type="button" name="save-continue" id="edit-save-continue-button"  value="{t escape=no}save &amp; continue{/t}" onclick="Wikijump.modules.PageEditModule.listeners.saveAndContinue(event)"/>{/if}
 				<input type="button" name="save" id="edit-save-button"  value="{t}save{/t}" onclick="Wikijump.modules.PageEditModule.listeners.save(event)"/>
 			</div>
 		</form>

--- a/web/templates/modules/History/RevertPageLockedWin.tpl
+++ b/web/templates/modules/History/RevertPageLockedWin.tpl
@@ -11,7 +11,6 @@
 		{foreach from=$locks item=lock}
 			<p>
 				{t}Locked by{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-				{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 				{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 				{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 			</p>

--- a/web/templates/modules/Rename/PageLockedWin.tpl
+++ b/web/templates/modules/Rename/PageLockedWin.tpl
@@ -11,7 +11,6 @@
 		{foreach from=$locks item=lock}
 			<p>
 				{t}Locked by{/t}: {printuser user=$lock->getUserOrString() image="true"}<br/>
-				{t}Lock mode{/t}: {$lock->getMode()|escape}<br/>
 				{t}Started editing{/t}: <span class="odate">{$lock->getDateStarted()->getTimestamp()}</span> ({$lock->getStartedAgo()} {t}seconds ago{/t})<br/>
 				{t}Lock will expire in{/t}: {$lock->getExpireIn()} {t}seconds (if user remains inactive){/t}</br>
 			</p>

--- a/web/web/files--common/javascript/Wikijump/page.ts
+++ b/web/web/files--common/javascript/Wikijump/page.ts
@@ -36,15 +36,13 @@ export const page = {
         // editing old page
         parms = {
           page_id: pageId,
-          mode: 'page',
-          wiki_page: WIKIREQUEST.info.requestPageName
+          wiki_page: WIKIREQUEST.info.requestPageName,
         };
       } else {
         // means new page
         Wikijump.page.vars.newPage = true;
         parms = {
-          mode: 'page',
-          wiki_page: WIKIREQUEST.info.requestPageName
+          wiki_page: WIKIREQUEST.info.requestPageName,
         };
       }
       if (Wikijump.page.vars.forceLockFlag) {
@@ -57,7 +55,6 @@ export const page = {
     append: function (_event: Event): void {
       const parms: RequestModuleParameters = {
         page_id: WIKIREQUEST.info.pageId,
-        mode: 'append'
       };
       OZONE.ajax.requestModule("Edit/PageEditModule", parms, Wikijump.page.callbacks.editClick);
     },
@@ -261,9 +258,6 @@ export const page = {
       }
 
       // init
-      //@ts-expect-error Shouldn't need to attach to window
-      window.editMode = response.mode;
-
       if (response.locked) {
         // the page has a lock!
         Wikijump.page.vars.locked = true;
@@ -715,7 +709,6 @@ export const page = {
     YAHOO.util.Event.addListener("site-tools-button", "click", Wikijump.page.listeners.siteTools);
     YAHOO.util.Event.addListener("more-options-button", "click", Wikijump.page.listeners.moreOptionsClick);
 
-    YAHOO.util.Event.addListener("edit-append-button", "click", Wikijump.page.listeners.append);
     YAHOO.util.Event.addListener("backlinks-button", "click", Wikijump.page.listeners.backlinksClick);
     YAHOO.util.Event.addListener("parent-page-button", "click", Wikijump.page.listeners.parentClick);
 

--- a/web/web/files--common/modules/js/Edit/PageEditModule.js
+++ b/web/web/files--common/modules/js/Edit/PageEditModule.js
@@ -202,13 +202,12 @@ Wikijump.modules.PageEditModule.callbacks = {
 		var message = document.getElementById("preview-message").innerHTML;
 		OZONE.utils.setInnerHTMLContent("action-area-top", message);
 
-			var title = response.title;
-			OZONE.utils.setInnerHTMLContent("page-title", title);
-			OZONE.visuals.scrollTo("container");
-			$("page-content").innerHTML = response.body;
-			Wikijump.page.fixers.fixEmails($("page-content"));
+		var title = response.title;
+		OZONE.utils.setInnerHTMLContent("page-title", title);
+		OZONE.visuals.scrollTo("container");
+		$("page-content").innerHTML = response.body;
+		Wikijump.page.fixers.fixEmails($("page-content"));
 
-		}
 		Wikijump.modules.PageEditModule.utils.stripAnchors("page-content", "action-area");
 	},
 
@@ -396,7 +395,7 @@ Wikijump.modules.PageEditModule.utils = {
 
 	},
 	/**
-	 * Replaces anchors with dumb anchors in edit
+	 * Replaces anchors with dumb anchors when editing
 	 */
 	stripAnchorsAll: function(){
 		Wikijump.modules.PageEditModule.utils.stripAnchors("html-body", "action-area");

--- a/web/web/files--common/modules/js/Edit/PageEditModule.js
+++ b/web/web/files--common/modules/js/Edit/PageEditModule.js
@@ -3,7 +3,6 @@
 Wikijump.modules.PageEditModule = {};
 
 Wikijump.modules.PageEditModule.vars = {
-	editMode: 'page', // the default mode
 	stopCounterFlag: false,
 	inputFlag: false, // changed to true by any input
 	lastInput: (new Date()).getTime(), // last input.
@@ -31,7 +30,6 @@ Wikijump.modules.PageEditModule.listeners = {
 
 	preview: function(e){
 		var params = OZONE.utils.formToArray("edit-page-form");
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['revision_id'] = Wikijump.page.vars.editlock.revisionId;
 		params['page_unix_name'] = WIKIREQUEST.info.requestPageName;
 		if(WIKIREQUEST.info.pageId){
@@ -50,7 +48,6 @@ Wikijump.modules.PageEditModule.listeners = {
 		var params = OZONE.utils.formToArray("edit-page-form");
 		params['action'] = 'WikiPageAction';
 		params['event'] = 'savePage';
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['wiki_page'] = WIKIREQUEST.info.requestPageName;
 		params['lock_id'] = Wikijump.page.vars.editlock.id;
 		if( WIKIREQUEST.info.pageId) {params['page_id'] = WIKIREQUEST.info.pageId;}
@@ -76,7 +73,6 @@ Wikijump.modules.PageEditModule.listeners = {
 		var params = OZONE.utils.formToArray("edit-page-form");
 		params['action'] = 'WikiPageAction';
 		params['event'] = 'savePage';
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['wiki_page'] = WIKIREQUEST.info.requestPageName;
 		params['lock_id'] = Wikijump.page.vars.editlock.id;
 		if( WIKIREQUEST.info.pageId) {params['page_id'] = WIKIREQUEST.info.pageId;}
@@ -137,7 +133,6 @@ Wikijump.modules.PageEditModule.listeners = {
 		var params = new Object();
 		params['action'] = 'WikiPageAction';
 		params['event'] = 'forceLockIntercept';
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['wiki_page'] = WIKIREQUEST.info.requestPageName;
 		if(WIKIREQUEST.info.pageId) {params['page_id'] = WIKIREQUEST.info.pageId;}
 		params['lock_id'] = Wikijump.page.vars.editlock.id;
@@ -150,7 +145,6 @@ Wikijump.modules.PageEditModule.listeners = {
 		var params = new Object();
 		params['action'] = 'WikiPageAction';
 		params['event'] = 'recreateExpiredLock';
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['wiki_page'] = WIKIREQUEST.info.requestPageName;
 		params['lock_id'] = Wikijump.page.vars.editlock.id;
 		if(WIKIREQUEST.info.pageId) {params['page_id'] = WIKIREQUEST.info.pageId;}
@@ -186,7 +180,6 @@ Wikijump.modules.PageEditModule.listeners = {
 	},
 	viewDiff: function(e){
 		var params = OZONE.utils.formToArray("edit-page-form");
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['revision_id'] = Wikijump.page.vars.editlock.revisionId;
 		OZONE.ajax.requestModule("Edit/PageEditDiffModule",params,Wikijump.modules.PageEditModule.callbacks.viewDiff);
 
@@ -209,7 +202,6 @@ Wikijump.modules.PageEditModule.callbacks = {
 		var message = document.getElementById("preview-message").innerHTML;
 		OZONE.utils.setInnerHTMLContent("action-area-top", message);
 
-		if(Wikijump.modules.PageEditModule.vars.editMode == 'page'){
 			var title = response.title;
 			OZONE.utils.setInnerHTMLContent("page-title", title);
 			OZONE.visuals.scrollTo("container");
@@ -217,25 +209,6 @@ Wikijump.modules.PageEditModule.callbacks = {
 			Wikijump.page.fixers.fixEmails($("page-content"));
 
 		}
-		// put some notice that this is a preview only!
-
-		if(Wikijump.modules.PageEditModule.vars.editMode == 'append'){
-
-			var aDiv = $("append-preview-div");
-			if(!aDiv){
-				aDiv = document.createElement('div');
-				aDiv.id="append-preview-div";
-				$("page-content").appendChild(aDiv);
-			}
-
-			aDiv.innerHTML = response.body.replace(/id="/g, 'id="prev06-');
-
-			Wikijump.page.fixers.fixEmails($("append-preview-div"));
-			OZONE.visuals.scrollTo("append-preview-div");
-			// move the message box
-			YAHOO.util.Dom.setY("action-area-top", YAHOO.util.Dom.getY("append-preview-div"));
-		}
-
 		Wikijump.modules.PageEditModule.utils.stripAnchors("page-content", "action-area");
 	},
 
@@ -423,7 +396,7 @@ Wikijump.modules.PageEditModule.utils = {
 
 	},
 	/**
-	 * Replaces anchors with dumb anchors in edit mode
+	 * Replaces anchors with dumb anchors in edit
 	 */
 	stripAnchorsAll: function(){
 		Wikijump.modules.PageEditModule.utils.stripAnchors("html-body", "action-area");
@@ -520,7 +493,6 @@ Wikijump.modules.PageEditModule.utils = {
 		var params = new Object();
 		params['action'] = 'WikiPageAction';
 		params['event'] = 'updateLock';
-		params['mode']=Wikijump.modules.PageEditModule.vars.editMode;
 		params['wiki_page'] = WIKIREQUEST.info.requestPageName;
 		params['lock_id'] = Wikijump.page.vars.editlock.id;
 		if(WIKIREQUEST.info.pageId){	params['page_id'] = WIKIREQUEST.info.pageId;}
@@ -542,16 +514,11 @@ Wikijump.modules.PageEditModule.init = function(){
 	if(Wikijump.page.vars.locked == true){
 		OZONE.utils.formatDates();
 	} else {
-		Wikijump.modules.PageEditModule.vars.editMode = editMode;
-
 		/* attach listeners */
 
 		YAHOO.util.Event.addListener("update-lock", "click", Wikijump.modules.PageEditModule.utils.updateLock);
-
 		YAHOO.util.Event.addListener("edit-page-form", "keypress", Wikijump.modules.PageEditModule.listeners.changeInput);
 		YAHOO.util.Event.addListener("edit-page-textarea", "keydown", Wikijump.modules.PageEditModule.listeners.changeInput);
-//
-
 		YAHOO.util.Event.addListener(window, "beforeunload", Wikijump.modules.PageEditModule.listeners.leaveConfirm);
 		YAHOO.util.Event.addListener(window, "unload", Wikijump.modules.PageEditModule.listeners.leavePage);
 


### PR DESCRIPTION
This removes the Wikidot feature of editing pages in "append mode", where contents are simply added to the end. Similar to the remove of editing by sections, this reduces page edit complexity and a feature which is not well-used.

See also #624 	