### PR TITLE
Use direct CSS imports and preloads in templates

### DIFF
--- a/web/resources/scripts/auth-confirm.ts
+++ b/web/resources/scripts/auth-confirm.ts
@@ -1,5 +1,4 @@
 import ConfirmForm from "../lib/components/ConfirmPasswordForm.svelte"
-import "./auth.scss"
 
 window.addEventListener("DOMContentLoaded", () => {
   const container = document.getElementById("auth_form_container")

--- a/web/resources/scripts/auth-login.ts
+++ b/web/resources/scripts/auth-login.ts
@@ -1,5 +1,4 @@
 import LoginForm from "../lib/components/LoginForm.svelte"
-import "./auth.scss"
 
 window.addEventListener("DOMContentLoaded", () => {
   const container = document.getElementById("auth_form_container")

--- a/web/resources/scripts/auth-register.ts
+++ b/web/resources/scripts/auth-register.ts
@@ -1,5 +1,4 @@
 import RegisterForm from "../lib/components/RegisterForm.svelte"
-import "./auth.scss"
 
 window.addEventListener("DOMContentLoaded", () => {
   const container = document.getElementById("auth_form_container")

--- a/web/resources/scripts/index.ts
+++ b/web/resources/scripts/index.ts
@@ -1,13 +1,4 @@
 // organize-imports-ignore
-
-// TODO: remove this stupid hack, along with the other places where it's used
-// Vite doesn't handle CSS/SCSS files being entrypoints AT ALL
-// they simply won't get emitted to the manifest and are otherwise
-// completely broken. the only way to get this to work is via this type of import.
-// thankfully, when emitted for production, an actual stylesheet link is used
-// so JS isn't needed.
-import "./index.scss"
-
 import "@wikijump/ftml-components"
 import "../lib/account-panel"
 import "../lib/elements/nav-dropdown"

--- a/web/resources/scripts/wiki.ts
+++ b/web/resources/scripts/wiki.ts
@@ -1,1 +1,0 @@
-import "./wiki.scss"

--- a/web/resources/views/next/auth/auth.blade.php
+++ b/web/resources/views/next/auth/auth.blade.php
@@ -8,6 +8,14 @@
 
 @extends('next.base')
 
+@push('preloads')
+    @preload('resources/scripts/auth.scss')
+@endpush
+
+@push('styles')
+    @vite('auth.scss')
+@endpush
+
 @section('app')
     <div id="app_auth" data-back-url="{{ previousUrl() }}">
         <div id="auth_panel" class="light">

--- a/web/resources/views/next/base.blade.php
+++ b/web/resources/views/next/base.blade.php
@@ -73,6 +73,7 @@
     {{-- Preloads, Preconnects --}}
     @preload('/files--static/fonts/variable/PublicSans-VariableFont.woff2')
     @preload('/files--static/fonts/variable/RedHatDisplayVF.woff2')
+    @preload('resources/scripts/index.scss')
     @preload('resources/scripts/index.ts')
     {{-- TODO: preload the user's locale file --}}
     @stack('preloads')
@@ -182,6 +183,7 @@
     @endif
 
     {{-- Styles --}}
+    @vite('index.scss')
     @stack('styles')
 
     {{-- Scripts --}}

--- a/web/resources/views/next/wiki/page.blade.php
+++ b/web/resources/views/next/wiki/page.blade.php
@@ -21,11 +21,11 @@
 @extends('next.frame')
 
 @push('preloads')
-    @preload('resources/scripts/wiki.ts')
+    @preload('resources/scripts/wiki.scss')
 @endpush
 
-@push('scripts')
-    @vite('wiki.ts')
+@push('styles')
+    @vite('wiki.scss')
 @endpush
 
 @php


### PR DESCRIPTION
The workaround I contributed to `laravel-vite` now allows for directly using a CSS import in a Blade template. I've converted the old JS-based CSS imports to direct imports and preloads from the templates.