### PR TITLE
[WJ-931] [WJ-932] Generic MJML message template, email and password email messages

### DIFF
--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -82,6 +82,8 @@ email:
   SUBSCRIBED: You received this email because you are subscribed.
   UNSUBSCRIBE: Unsubscribe
   UNSUBSCRIBE_TEXT: "If you wish to unsubscribe, go here:"
+  SUBCOPY: >
+    If you are having trouble clicking the ''{action}'' button, copy paste the URL below into your web browser:
 
 # Generic UI components
 components:

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -85,6 +85,27 @@ email:
   SUBCOPY: >
     If you are having trouble clicking the ''{action}'' button, copy paste the URL below into your web browser:
 
+  verify_email:
+    SUBJECT: Verify Email Address
+    GREETING: Verify your email address
+    INTRO: Please verify your email address by clicking the button below.
+    ACTION: Verify Email Address
+    OUTRO: If you did not create an account, no further action is required.
+
+  reset_password:
+    SUBJECT: Password Reset Requested
+    GREETING: Resetting your password
+    INTRO: >
+      You are receiving this email because we received a password reset request for your account. Click the button below to reset your password.
+    ACTION: Reset Password
+    EXPIRES: >
+      This password reset link will expire in {count, number} {count, plural,
+        =1 {minute.}
+        other {minutes.}
+      }
+    OUTRO: If you did not request a password reset, no further action is required.
+
+
 # Generic UI components
 components:
   spinny:

--- a/web/app/Mail/MJMLMailable.php
+++ b/web/app/Mail/MJMLMailable.php
@@ -10,7 +10,7 @@ use Wikijump\Services\MJML\MJML;
 /**
  * Mailable that supports using MJML.
  *
- * Use the `mjml` method to set the MJML content.
+ * Use the `mjml` method to set the MJML view.
  */
 class MJMLMailable extends Mailable
 {

--- a/web/app/Mail/MJMLMessage.php
+++ b/web/app/Mail/MJMLMessage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wikijump\Mail;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Wikijump\Services\MJML\MJML;
+
+/**
+ * MailMessage that supports using MJML.
+ *
+ * Use the `mjml` method to set the MJML view.
+ */
+class MJMLMessage extends MailMessage
+{
+    /** MJML template path. */
+    protected string $mjml = 'emails.message.mjml';
+
+    /**
+     * Sets the MJML template to use. This template has the highest priority.
+     * Templates will be rendered by Blade first, and then by MJML.
+     *
+     * @param string $mjml Path to the MJML template, in Blade template syntax.
+     * @param array $data Data to pass to the template.
+     * @return $this
+     */
+    public function mjml(string $mjml, array $data = [])
+    {
+        $this->mjml = $mjml;
+        $this->viewData = array_merge($this->viewData, $data);
+
+        return $this;
+    }
+
+    public function render(): string
+    {
+        if (isset($this->mjml)) {
+            return MJML::render($this->mjml, $this->data())->toHtml();
+        }
+
+        return parent::render();
+    }
+}

--- a/web/app/Mail/MJMLMessage.php
+++ b/web/app/Mail/MJMLMessage.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Wikijump\Mail;
 
+use Illuminate\Container\Container;
 use Illuminate\Notifications\Messages\MailMessage;
 use Wikijump\Services\MJML\MJML;
 
 /**
- * MailMessage that supports using MJML.
+ * MailMessage that supports using MJML, and text fallbacks.
  *
- * Use the `mjml` method to set the MJML view.
+ * Use the `mjml` method to set the MJML view, and likewise for `text`.
  */
 class MJMLMessage extends MailMessage
 {
     /** MJML template path. */
     protected string $mjml = 'emails.message.mjml';
+
+    /** Text fallback template path. */
+    protected string $text = 'emails.message.text';
 
     /**
      * Sets the MJML template to use. This template has the highest priority.
@@ -33,10 +37,55 @@ class MJMLMessage extends MailMessage
         return $this;
     }
 
+    /**
+     * Sets the text fallback template to use.
+     *
+     * @param string $text Path to the text template.
+     * @param array $data Data to pass to the template.
+     * @return $this
+     */
+    public function text(string $text, array $data = [])
+    {
+        $this->text = $text;
+        $this->viewData = array_merge($this->viewData, $data);
+
+        return $this;
+    }
+
+    /**
+     * Renders the notification message into an HTML string.
+     */
     public function render(): string
     {
+        // I'm really not quite sure how this all works
+        // honestly the way Laravel has this set up is bizarre
+        // and really hard to follow
+
         if (isset($this->mjml)) {
-            return MJML::render($this->mjml, $this->data())->toHtml();
+            if (isset($this->text)) {
+                $data = $this->data();
+
+                $html = MJML::render($this->mjml, $data);
+                $text = $this->text;
+
+                /** @var \Illuminate\Mail\Mailer $mailer */
+                $mailer = Container::getInstance()->make('mailer');
+
+                // it's important that the `html` property is Htmlable
+                // and that the `text` property is just a template identifier
+
+                return $mailer->render(['html' => $html, 'text' => $text], $data);
+            } else {
+                return MJML::render($this->mjml, $this->data())->toHtml();
+            }
+        }
+
+        // normal MailMessage supports text fallback, but differently.
+        // it makes the $view property an array, so before we go back to
+        // the parent method we need to make sure $view is setup correctly
+
+        if (isset($this->view, $this->text) && !is_array($this->view)) {
+            $this->view = [$this->view, $this->text];
         }
 
         return parent::render();

--- a/web/app/Mail/PasswordResetMessage.php
+++ b/web/app/Mail/PasswordResetMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wikijump\Mail;
+
+/**
+ * Generic password reset message.
+ */
+class PasswordResetMessage extends MJMLMessage
+{
+    /**
+     * Constructs a new password reset message.
+     *
+     * @param string $url The URL to the password reset page.
+     * @param int $expires The number of minutes until the password reset expires.
+     */
+    public function __construct(string $url, int $expires)
+    {
+        $this->subject(__('email.reset_password.SUBJECT'))
+            ->greeting(__('email.reset_password.GREETING'))
+            ->line(__('email.reset_password.INTRO'))
+            ->action(__('email.reset_password.ACTION'), $url)
+            ->line(__('email.reset_password.EXPIRES', ['count' => $expires]))
+            ->line(__('email.reset_password.OUTRO'));
+    }
+}

--- a/web/app/Mail/VerifyEmailMessage.php
+++ b/web/app/Mail/VerifyEmailMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wikijump\Mail;
+
+/**
+ * Generic message for email verification.
+ */
+class VerifyEmailMessage extends MJMLMessage
+{
+    /**
+     * Constructs a new email verification message.
+     *
+     * @param string $url The url to the email verification page.
+     */
+    public function __construct(string $url)
+    {
+        $this->subject(__('email.verify_email.SUBJECT'))
+            ->greeting(__('email.verify_email.GREETING'))
+            ->line(__('email.verify_email.INTRO'))
+            ->action(__('email.verify_email.ACTION'), $url)
+            ->line(__('email.verify_email.OUTRO'));
+    }
+}

--- a/web/app/Services/MJML/MJML.php
+++ b/web/app/Services/MJML/MJML.php
@@ -48,8 +48,9 @@ final class MJML
         // command has a 5 second timeout
         // if rendering takes longer than that, something is very wrong
         // average render time should be in milliseconds
-        $proc = Process::fromShellCommandline('mrml render', null, null, $mjml, 5);
-
+        $proc = new Process(['mrml', 'render']);
+        $proc->setInput($mjml);
+        $proc->setTimeout(5);
         $proc->run();
 
         if (!$proc->isSuccessful()) {

--- a/web/app/Services/MJML/MJML.php
+++ b/web/app/Services/MJML/MJML.php
@@ -22,14 +22,22 @@ final class MJML
      * @param string $template_path Blade template path.
      * @param array $data Data to be passed to the template.
      */
-    public static function render(string $template_path, array $data = []): HtmlString
+    public static function render(string $template_path, array $data = []): MJMLString
     {
         $view = view($template_path, $data);
-        $raw_mjml = $view->render();
+        return new MJMLString($view->render());
+    }
 
+    /**
+     * Compiles a MJML template into HTML.
+     *
+     * @param string $mjml MJML to compile.
+     */
+    public static function compile(string $mjml): string
+    {
         // we use the hash of the raw MJML, because Blade templates already
         // have caching built in, so we'll reuse that machinery rather than remaking it
-        $hash = hash('sha256', $raw_mjml);
+        $hash = hash('sha256', $mjml);
 
         // cache hit, return the cached HTML
         if (Cache::has($hash)) {
@@ -40,7 +48,7 @@ final class MJML
         // command has a 5 second timeout
         // if rendering takes longer than that, something is very wrong
         // average render time should be in milliseconds
-        $proc = Process::fromShellCommandline('mrml render', null, null, $raw_mjml, 5);
+        $proc = Process::fromShellCommandline('mrml render', null, null, $mjml, 5);
 
         $proc->run();
 
@@ -55,6 +63,17 @@ final class MJML
         // caching is mostly for caching repeated emails, like marketing emails
         Cache::put($hash, $html, now()->addMinutes(5));
 
-        return new HtmlString($html);
+        return $html;
+    }
+}
+
+/**
+ * A fragment of MJML, that when unwrapped, will be rendered as HTML.
+ */
+class MJMLString extends HtmlString
+{
+    public function toHtml(): string
+    {
+        return MJML::compile($this->html);
     }
 }

--- a/web/resources/views/emails/base-mjml.blade.php
+++ b/web/resources/views/emails/base-mjml.blade.php
@@ -77,6 +77,7 @@
                     <mj-text align="center" font-size="10px" line-height="12px">
                         {{ __('email.SUBSCRIBED') }}
                         <br />
+                        <br />
                         <a href="{{ $unsubscribe_url }}">
                             {{ __('email.UNSUBSCRIBE') }}
                         </a>

--- a/web/resources/views/emails/base-mjml.blade.php
+++ b/web/resources/views/emails/base-mjml.blade.php
@@ -10,7 +10,6 @@
     sections:
         content
 
-    The very first mj-section should have its padding-top set to 10px.
     All content sections should have their background-color set to #fff.
 --}}
 
@@ -32,7 +31,7 @@
         </mj-section>
 
         {{-- Header --}}
-        <mj-section background-color="#fff">
+        <mj-section background-color="#fff" padding-bottom="0">
             <mj-column>
                 <mj-image width="400px"
                           src="{{ $HTTP_SCHEMA }}://{{ $URL_HOST }}/files--static/media/logo.png"
@@ -40,7 +39,7 @@
                           alt="{{ __('email.GOTO_SITE') }}"
                 />
                 <mj-divider border-width="2px"
-                            border-color="#aaa"
+                            border-color="#eee"
                             padding-bottom="0"
                             padding-top="20px"
                 />

--- a/web/resources/views/emails/message/mjml.blade.php
+++ b/web/resources/views/emails/message/mjml.blade.php
@@ -44,7 +44,6 @@
     @endisset
 
     {{-- Action Button --}}
-    {{-- TODO: set color of button depending on $level --}}
     @isset($actionText, $actionUrl)
         <mj-section background-color="#fff" padding="5px 20px">
             <mj-column>

--- a/web/resources/views/emails/message/mjml.blade.php
+++ b/web/resources/views/emails/message/mjml.blade.php
@@ -94,7 +94,7 @@
         <mj-section background-color="#fff">
             <mj-column>
                 <mj-text align="center" font-size="10px">
-                    {{ __('email.SUBCOPY', ['action' => $actiontext]) }}
+                    {{ __('email.SUBCOPY', ['action' => $actionText]) }}
                     <br />
                     <br />
                     <a href="{{ $actionUrl }}">

--- a/web/resources/views/emails/message/mjml.blade.php
+++ b/web/resources/views/emails/message/mjml.blade.php
@@ -1,0 +1,107 @@
+{{--
+    data:
+        $level (unused)
+        $subject (unused)
+        $greeting
+        $salutation
+        $introLines
+        $outroLines
+        $actionText
+        $actionUrl
+        $displayableActionUrl
+
+    Uses the same data as MailMessage.
+--}}
+
+@extends('emails.base-mjml', [
+    'title' => $subject,
+    'preview' => $greeting ?? ($introLines ? $introLines[0] : null),
+])
+
+@section('content')
+    {{-- Greetings --}}
+    @isset($greeting)
+        <mj-section background-color="#fff" padding="0">
+            <mj-column>
+                <mj-text align="center">
+                    <h1 style="padding-bottom: 0;">
+                        {{ $greeting }}
+                    </h1>
+                </mj-text>
+            </mj-column>
+        </mj-section>
+    @endisset
+
+    {{-- Intro Lines --}}
+    @isset($introLines)
+        <mj-section background-color="#fff" padding="0 20px">
+            <mj-column>
+                @foreach ($introLines as $line)
+                    <mj-text align="center" font-size="14px">{{ $line }}</mj-text>
+                @endforeach
+            </mj-column>
+        </mj-section>
+    @endisset
+
+    {{-- Action Button --}}
+    {{-- TODO: set color of button depending on $level --}}
+    @isset($actionText, $actionUrl)
+        <mj-section background-color="#fff" padding="5px 20px">
+            <mj-column>
+                <mj-button href="{{ $actionUrl }}"
+                           background-color="#3869D4"
+                           inner-padding="10px 45px"
+                           font-size="16px"
+                >
+                    {{ $actionText }}
+                </mj-button>
+            </mj-column>
+        </mj-section>
+    @endisset
+
+    {{-- Outro Lines --}}
+    @isset($outroLines)
+        <mj-section background-color="#fff" padding="20px 20px 0 20px">
+            <mj-column>
+                @foreach ($outroLines as $line)
+                    <mj-text align="center" font-size="12px">{{ $line }}</mj-text>
+                @endforeach
+            </mj-column>
+        </mj-section>
+    @endisset
+
+    {{-- Salutation --}}
+    @isset($salutation)
+        <mj-section background-color="#fff" padding="0 20px">
+            <mj-column>
+                <mj-text font-size="14px">{{ $salutation }}</mj-text>
+            </mj-column>
+        </mj-section>
+    @endisset
+
+    {{-- Subcopy --}}
+    @isset($actionText, $actionUrl)
+        <mj-section background-color="#fff" padding-bottom="0">
+            <mj-column>
+                <mj-divider border-width="2px"
+                            border-color="#eee"
+                            padding-top="0"
+                            padding-bottom="0"
+                />
+            </mj-column>
+        </mj-section>
+
+        <mj-section background-color="#fff">
+            <mj-column>
+                <mj-text align="center" font-size="10px">
+                    {{ __('email.SUBCOPY', ['action' => $actiontext]) }}
+                    <br />
+                    <br />
+                    <a href="{{ $actionUrl }}">
+                        {{ isset($displayableActionUrl) ? $displayableActionUrl : $actionUrl }}
+                    </a>
+                </mj-text>
+            </mj-column>
+        </mj-section>
+    @endisset
+@endsection

--- a/web/resources/views/emails/message/text.blade.php
+++ b/web/resources/views/emails/message/text.blade.php
@@ -1,0 +1,36 @@
+{{--
+    data:
+        $level (unused)
+        $subject (unused)
+        $greeting
+        $salutation
+        $introLines
+        $outroLines
+        $actionText
+        $actionUrl
+        $displayableActionUrl (unused)
+
+    Uses the same data as MailMessage.
+--}}
+@extends('emails.base-text')
+@section('content')
+@isset($greeting)
+{{ $greeting }}
+@endisset
+
+@foreach($introLines as $line)
+{{ $line }}
+@endforeach
+
+@isset($actionText, $actionUrl)
+{{ $actionText }}: {{ $actionUrl }}
+@endisset
+
+@foreach($outroLines as $line)
+{{ $line }}
+@endforeach
+
+@isset($salutation)
+{{ $salutation }}
+@endisset
+@endsection

--- a/web/resources/views/emails/test/mjml.blade.php
+++ b/web/resources/views/emails/test/mjml.blade.php
@@ -1,7 +1,7 @@
 @extends('emails.base-mjml')
 
 @section('content')
-    <mj-section background-color="#fff" padding-top="10px">
+    <mj-section background-color="#fff">
         <mj-column>
             <mj-text>
                 This is a test email, using MJML.

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -10,6 +10,7 @@ use Wikidot\Utils\GlobalProperties;
 use Wikijump\Http\Controllers\AuthController;
 use Wikijump\Http\Controllers\OzoneController;
 use Wikijump\Http\Controllers\PageController;
+use Wikijump\Mail\MJMLMessage;
 use Wikijump\Mail\MJMLTest;
 use Wikijump\Models\User;
 
@@ -70,6 +71,15 @@ Route::get('email-markdown--test', function () {
 
 Route::get('email-text--test', function () {
     return new MJMLTest('text');
+});
+
+Route::get('email-message--test', function () {
+    return (new MJMLMessage())
+        ->subject('Verify Email Address')
+        ->greeting('Verify your email address')
+        ->line('Please verify your email address by clicking the button below.')
+        ->action('Verify Email Address', 'https://example.com/test-action')
+        ->line('If you did not create an account, no further action is required.');
 });
 
 /**

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -10,8 +10,9 @@ use Wikidot\Utils\GlobalProperties;
 use Wikijump\Http\Controllers\AuthController;
 use Wikijump\Http\Controllers\OzoneController;
 use Wikijump\Http\Controllers\PageController;
-use Wikijump\Mail\MJMLMessage;
 use Wikijump\Mail\MJMLTest;
+use Wikijump\Mail\PasswordResetMessage;
+use Wikijump\Mail\VerifyEmailMessage;
 use Wikijump\Models\User;
 
 use const Wikijump\Helpers\LegacyTools;
@@ -73,13 +74,12 @@ Route::get('email-text--test', function () {
     return new MJMLTest('text');
 });
 
-Route::get('email-message--test', function () {
-    return (new MJMLMessage())
-        ->subject('Verify Email Address')
-        ->greeting('Verify your email address')
-        ->line('Please verify your email address by clicking the button below.')
-        ->action('Verify Email Address', 'https://example.com/test-action')
-        ->line('If you did not create an account, no further action is required.');
+Route::get('email-reset-password--test', function () {
+    return new PasswordResetMessage('https://example.com/reset-password', 5);
+});
+
+Route::get('email-verify-email--test', function () {
+    return new VerifyEmailMessage('https://example.com/verify-email');
 });
 
 /**


### PR DESCRIPTION
This PR adds quite a few things, but all of them are related to the new `MJMLMessage` class. This is an extension of the `MailMessage` class, which is used by Laravel to construct generic emails without needing an all new template. `MJMLMessage` does the same thing, except with our own customized template.

This was surprisingly complicated to do, mainly because I think Laravel's mailing code is weirdly hard-coded and complex.

Screenies:
![image](https://user-images.githubusercontent.com/34875062/145695112-6f709b82-9ca6-4b54-9f00-654e6b022310.png)
![image](https://user-images.githubusercontent.com/34875062/145695127-5761d3b6-7afe-4db7-af50-ff0febd9586d.png)
