### PR TITLE
Use Ziggy to support using Laravel route names on the frontend

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -14,7 +14,8 @@
         "laravel/sanctum": "^2.6",
         "laravel/socialite": "^5.2",
         "laravel/tinker": "^2.6",
-        "league/flysystem-aws-s3-v3": "^1.0"
+        "league/flysystem-aws-s3-v3": "^1.0",
+        "tightenco/ziggy": "^1.4"
     },
     "require-dev": {
         "facade/ignition": "^2.8",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d772cbd0d468c029f1b8bd08382760a6",
+    "content-hash": "085fe6e493df6ea89027678c50a8b165",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8473,6 +8473,72 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "tightenco/ziggy",
+            "version": "v1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tighten/ziggy.git",
+                "reference": "620c135281062b9f6b53a75b07f99a4339267277"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tighten/ziggy/zipball/620c135281062b9f6b53a75b07f99a4339267277",
+                "reference": "620c135281062b9f6b53a75b07f99a4339267277",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": ">=5.4@dev"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^6.0",
+                "phpunit/phpunit": "^9.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Tightenco\\Ziggy\\ZiggyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Tightenco\\Ziggy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Coulbourne",
+                    "email": "daniel@tighten.co"
+                },
+                {
+                    "name": "Jake Bathman",
+                    "email": "jake@tighten.co"
+                },
+                {
+                    "name": "Jacob Baker-Kretzmar",
+                    "email": "jacob@tighten.co"
+                }
+            ],
+            "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
+            "homepage": "https://github.com/tighten/ziggy",
+            "keywords": [
+                "Ziggy",
+                "javascript",
+                "laravel",
+                "routes"
+            ],
+            "support": {
+                "issues": "https://github.com/tighten/ziggy/issues",
+                "source": "https://github.com/tighten/ziggy/tree/v1.4.2"
+            },
+            "time": "2021-10-01T13:55:26+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/web/config/ziggy.php
+++ b/web/config/ziggy.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'skip-route-function' => true,
+];

--- a/web/modules/api/package.json
+++ b/web/modules/api/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@wikijump/util": "workspace:*",
-    "svelte": "^3.44.3"
+    "svelte": "^3.44.3",
+    "ziggy-js": "^1.4.2"
   }
 }

--- a/web/modules/api/src/index.ts
+++ b/web/modules/api/src/index.ts
@@ -87,3 +87,4 @@ export type {
 } from "../vendor/api"
 export * from "./api"
 export * from "./asset"
+export * from "./route"

--- a/web/modules/api/src/route.ts
+++ b/web/modules/api/src/route.ts
@@ -1,9 +1,11 @@
-// apparently Ziggy isn't on NPM...
-// @ts-ignore
-import ziggyRoute from "@root/web/vendor/tightenco/ziggy/src/js/index.js"
-import type Router from "@root/web/vendor/tightenco/ziggy/src/js/Router.js"
+// organize-imports-ignore
 
-// Ziggy is actually typed, but its actual `route` function isn't.
+// @ts-ignore - untyped package for some reason
+import ziggyRoute from "ziggy-js"
+
+// weirdly this is the best way to get the types out of the ziggy-js module
+// @ts-ignore
+import type Router from "@root/web/vendor/tightenco/ziggy/src/js/Router.js"
 
 /** Gets the route state. */
 export function route(): Router

--- a/web/modules/api/src/route.ts
+++ b/web/modules/api/src/route.ts
@@ -1,0 +1,28 @@
+// apparently Ziggy isn't on NPM...
+// @ts-ignore
+import ziggyRoute from "@root/web/vendor/tightenco/ziggy/src/js/index.js"
+import type Router from "@root/web/vendor/tightenco/ziggy/src/js/Router.js"
+
+// Ziggy is actually typed, but its actual `route` function isn't.
+
+/** Gets the route state. */
+export function route(): Router
+/**
+ * Gets route's URL via its name.
+ *
+ * @param name - The route's name.
+ * @param params - The route's parameters, if any.
+ * @param absolute - If true, the route will be given as a full URL.
+ */
+export function route(
+  name: string,
+  params?: Record<string, number | string>,
+  absolute?: boolean
+): string
+export function route(
+  name?: string,
+  params?: Record<string, number | string>,
+  absolute = false
+) {
+  return ziggyRoute(name, params, absolute)
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -105,9 +105,11 @@ importers:
       '@wikijump/util': workspace:*
       svelte: ^3.44.3
       swagger-typescript-api: ^9.3.1
+      ziggy-js: ^1.4.2
     dependencies:
       '@wikijump/util': link:../util
       svelte: 3.44.3
+      ziggy-js: 1.4.2
     devDependencies:
       '@mockoon/cli': 1.4.0
       swagger-typescript-api: 9.3.1
@@ -6689,7 +6691,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
-    dev: true
 
   /qs/6.7.0:
     resolution: {integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==}
@@ -8433,6 +8434,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /ziggy-js/1.4.2:
+    resolution: {integrity: sha512-/7EJQvaOC1kVgp9szVCYXKEbYQkioGKfjK988DnmdMMswuvYLfqKrSgHqFs156U3uZZAzaQn9Phu6XqqKR2zeQ==}
+    dependencies:
+      qs: 6.10.1
+    dev: false
 
   github.com/glayzzle/php-parser/27abcb2337ac6450c068ef064982dfabf77916a5:
     resolution: {tarball: https://codeload.github.com/glayzzle/php-parser/tar.gz/27abcb2337ac6450c068ef064982dfabf77916a5}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -406,7 +406,6 @@ importers:
       '@wikijump/util': workspace:*
       include-media: ^1.4.10
       svelte: ^3.44.3
-      ziggy: ^2.4.0
     dependencies:
       '@wikijump/api': link:../modules/api
       '@wikijump/components': link:../modules/components
@@ -417,7 +416,6 @@ importers:
       '@wikijump/util': link:../modules/util
       include-media: 1.4.10
       svelte: 3.44.3
-      ziggy: 2.4.0
 
 packages:
 
@@ -2225,10 +2223,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
-
-  /abbrev/1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-    dev: false
 
   /accepts/1.3.7:
     resolution: {integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==}
@@ -4327,10 +4321,6 @@ packages:
       debug: 4.3.3
     dev: true
 
-  /foreach/2.0.5:
-    resolution: {integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=}
-    dev: false
-
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4801,10 +4791,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /indexof/0.0.1:
-    resolution: {integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=}
-    dev: false
-
   /inflation/2.0.0:
     resolution: {integrity: sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=}
     engines: {node: '>= 0.8.0'}
@@ -4863,11 +4849,6 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
     dev: true
-
-  /irc/0.3.6:
-    resolution: {integrity: sha1-6s/bCMV5ceqCwzEXjiqvNPG6swM=}
-    engines: {node: '>=0.4.0'}
-    dev: false
 
   /is-alphabetical/1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -4996,10 +4977,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  /is-object/0.1.2:
-    resolution: {integrity: sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=}
-    dev: false
-
   /is-observable/2.1.0:
     resolution: {integrity: sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==}
     engines: {node: '>=8'}
@@ -5098,10 +5075,6 @@ packages:
     dependencies:
       is-docker: 2.2.1
     dev: true
-
-  /is/0.2.7:
-    resolution: {integrity: sha1-OzSixI81mXLzUEKEkZOucmS2NWI=}
-    dev: false
 
   /isarray/0.0.1:
     resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
@@ -5874,13 +5847,6 @@ packages:
       es6-promise: 3.3.1
     dev: true
 
-  /nopt/2.1.2:
-    resolution: {integrity: sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=}
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
-    dev: false
-
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -5994,15 +5960,6 @@ packages:
 
   /object-inspect/1.11.0:
     resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
-
-  /object-keys/0.2.0:
-    resolution: {integrity: sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=}
-    deprecated: Please update to the latest object-keys
-    dependencies:
-      foreach: 2.0.5
-      indexof: 0.0.1
-      is: 0.2.7
-    dev: false
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -8378,14 +8335,6 @@ packages:
     resolution: {integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=}
     dev: true
 
-  /xtend/2.0.6:
-    resolution: {integrity: sha1-XqZXptukRwacLlnFihE4ywxebO4=}
-    engines: {node: '>=0.4'}
-    dependencies:
-      is-object: 0.1.2
-      object-keys: 0.2.0
-    dev: false
-
   /y18n/4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
     dev: true
@@ -8484,15 +8433,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-  /ziggy/2.4.0:
-    resolution: {integrity: sha1-Lglwd2AHyetcJ/9BSgb5s+jtFqo=}
-    hasBin: true
-    dependencies:
-      irc: 0.3.6
-      nopt: 2.1.2
-      xtend: 2.0.6
-    dev: false
 
   github.com/glayzzle/php-parser/27abcb2337ac6450c068ef064982dfabf77916a5:
     resolution: {tarball: https://codeload.github.com/glayzzle/php-parser/tar.gz/27abcb2337ac6450c068ef064982dfabf77916a5}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -406,6 +406,7 @@ importers:
       '@wikijump/util': workspace:*
       include-media: ^1.4.10
       svelte: ^3.44.3
+      ziggy: ^2.4.0
     dependencies:
       '@wikijump/api': link:../modules/api
       '@wikijump/components': link:../modules/components
@@ -416,6 +417,7 @@ importers:
       '@wikijump/util': link:../modules/util
       include-media: 1.4.10
       svelte: 3.44.3
+      ziggy: 2.4.0
 
 packages:
 
@@ -2223,6 +2225,10 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
+
+  /abbrev/1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: false
 
   /accepts/1.3.7:
     resolution: {integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==}
@@ -4321,6 +4327,10 @@ packages:
       debug: 4.3.3
     dev: true
 
+  /foreach/2.0.5:
+    resolution: {integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=}
+    dev: false
+
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4791,6 +4801,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /indexof/0.0.1:
+    resolution: {integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=}
+    dev: false
+
   /inflation/2.0.0:
     resolution: {integrity: sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=}
     engines: {node: '>= 0.8.0'}
@@ -4849,6 +4863,11 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
     dev: true
+
+  /irc/0.3.6:
+    resolution: {integrity: sha1-6s/bCMV5ceqCwzEXjiqvNPG6swM=}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /is-alphabetical/1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -4977,6 +4996,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  /is-object/0.1.2:
+    resolution: {integrity: sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=}
+    dev: false
+
   /is-observable/2.1.0:
     resolution: {integrity: sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==}
     engines: {node: '>=8'}
@@ -5075,6 +5098,10 @@ packages:
     dependencies:
       is-docker: 2.2.1
     dev: true
+
+  /is/0.2.7:
+    resolution: {integrity: sha1-OzSixI81mXLzUEKEkZOucmS2NWI=}
+    dev: false
 
   /isarray/0.0.1:
     resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
@@ -5847,6 +5874,13 @@ packages:
       es6-promise: 3.3.1
     dev: true
 
+  /nopt/2.1.2:
+    resolution: {integrity: sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+    dev: false
+
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -5960,6 +5994,15 @@ packages:
 
   /object-inspect/1.11.0:
     resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
+
+  /object-keys/0.2.0:
+    resolution: {integrity: sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=}
+    deprecated: Please update to the latest object-keys
+    dependencies:
+      foreach: 2.0.5
+      indexof: 0.0.1
+      is: 0.2.7
+    dev: false
 
   /object-keys/1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -8335,6 +8378,14 @@ packages:
     resolution: {integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=}
     dev: true
 
+  /xtend/2.0.6:
+    resolution: {integrity: sha1-XqZXptukRwacLlnFihE4ywxebO4=}
+    engines: {node: '>=0.4'}
+    dependencies:
+      is-object: 0.1.2
+      object-keys: 0.2.0
+    dev: false
+
   /y18n/4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
     dev: true
@@ -8433,6 +8484,15 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /ziggy/2.4.0:
+    resolution: {integrity: sha1-Lglwd2AHyetcJ/9BSgb5s+jtFqo=}
+    hasBin: true
+    dependencies:
+      irc: 0.3.6
+      nopt: 2.1.2
+      xtend: 2.0.6
+    dev: false
 
   github.com/glayzzle/php-parser/27abcb2337ac6450c068ef064982dfabf77916a5:
     resolution: {tarball: https://codeload.github.com/glayzzle/php-parser/tar.gz/27abcb2337ac6450c068ef064982dfabf77916a5}

--- a/web/resources/lib/components/UserInfo.svelte
+++ b/web/resources/lib/components/UserInfo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import WikijumpAPI, { identity as currentIdentity } from "@wikijump/api"
+  import WikijumpAPI, { route, identity as currentIdentity } from "@wikijump/api"
   import { Sprite } from "@wikijump/components"
   import type { UserIdentity } from "@wikijump/api"
 
@@ -37,7 +37,10 @@
 {#if identity}
   <span class="wj-user-info">
     {#if !nolink}
-      <a class="wj-user-info-link" href="">
+      <a
+        class="wj-user-info-link"
+        href={route("user.profile", { user: identity.username })}
+      >
         {#if !noavatar}
           {#if !nokarma}
             <span class="wj-karma" data-karma={identity.karma}>

--- a/web/resources/lib/components/account/ClientStatus.svelte
+++ b/web/resources/lib/components/account/ClientStatus.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import WikijumpAPI, { authed, identity } from "@wikijump/api"
+  import WikijumpAPI, { route, authed, identity } from "@wikijump/api"
   import { format as t } from "@wikijump/fluent"
   import { focusGroup } from "@wikijump/dom"
   import { toast, Sprite, Button, Card, DetailsMenu } from "@wikijump/components"
@@ -43,25 +43,25 @@
       <Card>
         <div class="account-control-menu" use:focusGroup={"vertical"}>
           <!-- TODO: proper links -->
-          <Button href="/account" tabindex="-1" baseline compact>
+          <Button href={route("account")} tabindex="-1" baseline compact>
             {t("account")}
           </Button>
 
-          <Button href="/user:info" tabindex="-1" baseline compact>
+          <Button href={route("account.profile")} tabindex="-1" baseline compact>
             {t("profile")}
           </Button>
 
-          <Button href="account/messages" tabindex="-1" baseline compact>
+          <Button href={route("account.messages")} tabindex="-1" baseline compact>
             {t("messages")}
           </Button>
 
           <hr />
 
-          <Button href="/docs" tabindex="-1" baseline compact>
+          <Button href={route("docs")} tabindex="-1" baseline compact>
             {t("help")}
           </Button>
 
-          <Button href="/account/settings" tabindex="-1" baseline compact>
+          <Button href={route("account.settings")} tabindex="-1" baseline compact>
             {t("settings")}
           </Button>
 

--- a/web/resources/lib/components/account/NotificationBell.svelte
+++ b/web/resources/lib/components/account/NotificationBell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import WikijumpAPI, { authed } from "@wikijump/api"
+  import WikijumpAPI, { route, authed } from "@wikijump/api"
   import Locale from "@wikijump/fluent"
   import { Button } from "@wikijump/components"
 
@@ -39,7 +39,7 @@
     i="octicon:bell-16"
     size="1em"
     baseline
-    href="/account/notifications"
+    href={route("account.notifications")}
     tip={hasNotifications ? $t("#-status.unread") : $t("#-status.read")}
   />
   {#if hasNotifications}

--- a/web/resources/lib/components/auth/LoginForm.svelte
+++ b/web/resources/lib/components/auth/LoginForm.svelte
@@ -2,7 +2,7 @@
   @component Login form.
 -->
 <script lang="ts">
-  import WikijumpAPI from "@wikijump/api"
+  import WikijumpAPI, { route } from "@wikijump/api"
   import { format as t } from "@wikijump/fluent"
   import { Button, TextInput, Toggle } from "@wikijump/components"
   import { createEventDispatcher } from "svelte"
@@ -87,7 +87,7 @@
 
   <div class="login-form-options">
     <Toggle bind:toggled={remember}>{t("remember-me")}</Toggle>
-    <a class="login-form-forgot" href="/user--services/forgot-password">
+    <a class="login-form-forgot" href={route("password.request")}>
       {t("forgot-password.question")}
     </a>
   </div>

--- a/web/resources/package.json
+++ b/web/resources/package.json
@@ -19,6 +19,7 @@
     "@wikijump/sheaf": "workspace:*",
     "@wikijump/util": "workspace:*",
     "include-media": "^1.4.10",
-    "svelte": "^3.44.3"
+    "svelte": "^3.44.3",
+    "ziggy": "^2.4.0"
   }
 }

--- a/web/resources/package.json
+++ b/web/resources/package.json
@@ -19,7 +19,6 @@
     "@wikijump/sheaf": "workspace:*",
     "@wikijump/util": "workspace:*",
     "include-media": "^1.4.10",
-    "svelte": "^3.44.3",
-    "ziggy": "^2.4.0"
+    "svelte": "^3.44.3"
   }
 }

--- a/web/resources/views/next/auth/confirm-password.blade.php
+++ b/web/resources/views/next/auth/confirm-password.blade.php
@@ -15,7 +15,7 @@
     <wj-component-loader load="ConfirmPasswordForm" back="{{ previousUrl() }}">
     </wj-component-loader>
 
-    <a id="auth_forgot_password" href="/user--services/forgot-password">
+    <a id="auth_forgot_password" href="{{ route("password.request") }}">
         {{ __("auth.FORGOT_PASSWORD") }}
     </a>
 @endsection

--- a/web/resources/views/next/auth/login.blade.php
+++ b/web/resources/views/next/auth/login.blade.php
@@ -11,7 +11,7 @@
     <wj-component-loader load="LoginForm" back="{{ previousUrl() }}">
     </wj-component-loader>
 
-    <a id="auth_create_account" href="/user--services/register">
+    <a id="auth_create_account" href="{{ route("register") }}">
         {{ __("auth.CREATE_ACCOUNT") }}
     </a>
 @endsection

--- a/web/resources/views/next/auth/register.blade.php
+++ b/web/resources/views/next/auth/register.blade.php
@@ -11,7 +11,7 @@
     <wj-component-loader load="RegisterForm" goto="{{ route("verification.notice") }}">
     </wj-component-loader>
 
-    <a id="auth_login" href="/user--services/login">
+    <a id="auth_login" href="{{ route("login") }}">
         {{ __("auth.LOGIN") }}
     </a>
 @endsection

--- a/web/resources/views/next/base.blade.php
+++ b/web/resources/views/next/base.blade.php
@@ -186,6 +186,9 @@
     @vite('index.scss')
     @stack('styles')
 
+    {{-- Ziggy Routes --}}
+    @routes
+
     {{-- Scripts --}}
     {{-- TODO: see if it's possible to make scripts load async --}}
     @vite('index.ts')

--- a/web/resources/views/next/components/footer.blade.php
+++ b/web/resources/views/next/components/footer.blade.php
@@ -23,11 +23,10 @@
                 {{ __('frame.footer.POWERED_BY', ['name' => 'Wikijump']) }}
             </a>
             <span class="footer-services-sep">&#8212;</span>
-            {{-- TODO: link to actual pages --}}
-            <a href="/terms">{{ __('frame.footer.TERMS') }}</a>
-            <a href="/privacy">{{ __('frame.footer.PRIVACY') }}</a>
-            <a href="/docs">{{ __('frame.footer.DOCS') }}</a>
-            <a href="/security">{{ __('frame.footer.SECURITY') }}</a>
+            <a href="{{ route("terms") }}">{{ __('frame.footer.TERMS') }}</a>
+            <a href="{{ route("privacy") }}">{{ __('frame.footer.PRIVACY') }}</a>
+            <a href="{{ route("docs") }}">{{ __('frame.footer.DOCS') }}</a>
+            <a href="{{ route("security") }}">{{ __('frame.footer.SECURITY') }}</a>
         </div>
 
         <div id="footer_actions">
@@ -36,7 +35,7 @@
             </a>
             @if (empty($plain) || !$plain)
                 {{-- TODO: Flag as objectionable functionality  --}}
-                <a href="/flag">
+                <a href="{{ route("report-flag") }}">
                     {{ __('frame.footer.REPORT_FLAG') }}
                 </a>
             @endif

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -123,6 +123,24 @@ Route::get('/user--avatar/{user}', function (User $user) {
 
 // -- WIKI
 
+// (names, not route paths)
+// TODO: account
+// TODO: account.profile
+// TODO: account.settings
+// TODO: account.messages
+// TODO: account.notifications
+// TODO: user.profile
+// TODO: docs
+
+// dummy routes so that these resolve on the frontend
+Route::view('--/account', 'next.test.page-test')->name('account');
+Route::view('--/profile', 'next.test.page-test')->name('account.profile');
+Route::view('--/settings', 'next.test.page-test')->name('account.settings');
+Route::view('--/messages', 'next.test.page-test')->name('account.messages');
+Route::view('--/notifications', 'next.test.page-test')->name('account.notifications');
+Route::view('--/u/{user}', 'next.test.page-test')->name('user.profile');
+Route::view('--/docs', 'next.test.page-test')->name('docs');
+
 if (GlobalProperties::$FEATURE_FRONTEND === 'next') {
     // Legacy special routes
     Route::any('/{special}:{path}', [OzoneController::class, 'handle'])

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -131,6 +131,10 @@ Route::get('/user--avatar/{user}', function (User $user) {
 // TODO: account.notifications
 // TODO: user.profile
 // TODO: docs
+// TODO: terms
+// TODO: security
+// TODO: privacy
+// TODO: report-flag
 
 // dummy routes so that these resolve on the frontend
 Route::view('--/account', 'next.test.page-test')->name('account');
@@ -140,6 +144,10 @@ Route::view('--/messages', 'next.test.page-test')->name('account.messages');
 Route::view('--/notifications', 'next.test.page-test')->name('account.notifications');
 Route::view('--/u/{user}', 'next.test.page-test')->name('user.profile');
 Route::view('--/docs', 'next.test.page-test')->name('docs');
+Route::view('--/terms', 'next.test.page-test')->name('terms');
+Route::view('--/security', 'next.test.page-test')->name('security');
+Route::view('--/privacy', 'next.test.page-test')->name('privacy');
+Route::view('--/report-flag', 'next.test.page-test')->name('report-flag');
 
 if (GlobalProperties::$FEATURE_FRONTEND === 'next') {
     // Legacy special routes


### PR DESCRIPTION
This PR adds Ziggy, which allows us to use Laravel's named routes on the frontend. Ziggy does this by sticking a global `Ziggy` object with named route information in it in a `<script>` tag.

Here is an example of the kind of thing it generates:
```js
const Ziggy = {"url":"http:\/\/www.wikijump.localhost","port":null,"defaults":{},"routes":{"ignition.healthCheck":{"uri":"_ignition\/health-check","methods":["GET","HEAD"]},"ignition.executeSolution":{"uri":"_ignition\/execute-solution","methods":["POST"]},"ignition.shareReport":{"uri":"_ignition\/share-report","methods":["POST"]},"ignition.scripts":{"uri":"_ignition\/scripts\/{script}","methods":["GET","HEAD"]},"ignition.styles":{"uri":"_ignition\/styles\/{style}","methods":["GET","HEAD"]},"telescope":{"uri":"telescope\/{view?}","methods":["GET","HEAD"]},"login":{"uri":"user--services\/login","methods":["GET","HEAD"]},"register":{"uri":"user--services\/register","methods":["GET","HEAD"]},"password.request":{"uri":"user--services\/forgot-password","methods":["GET","HEAD"]},"password.reset":{"uri":"user--services\/reset-password\/{token}","methods":["GET","HEAD"]},"password.update":{"uri":"user--services\/reset-password\/{token}","methods":["POST"]},"verification.notice":{"uri":"user--services\/verify-email","methods":["GET","HEAD"],"bindings":{"user":"id"}},"verification.verify":{"uri":"user--services\/verify-email\/{id}\/{hash}","methods":["POST"]},"logout":{"uri":"user--services\/logout","methods":["GET","HEAD"]},"password.confirm":{"uri":"user--services\/confirm-password","methods":["GET","HEAD"]},"socialite-callback":{"uri":"social--providers\/callback","methods":["GET","HEAD"]},"account":{"uri":"--\/account","methods":["GET","HEAD"]},"account.profile":{"uri":"--\/profile","methods":["GET","HEAD"]},"account.settings":{"uri":"--\/settings","methods":["GET","HEAD"]},"account.messages":{"uri":"--\/messages","methods":["GET","HEAD"]},"account.notifications":{"uri":"--\/notifications","methods":["GET","HEAD"]},"user.profile":{"uri":"--\/u\/{user}","methods":["GET","HEAD"]},"docs":{"uri":"--\/docs","methods":["GET","HEAD"]},"terms":{"uri":"--\/terms","methods":["GET","HEAD"]},"security":{"uri":"--\/security","methods":["GET","HEAD"]},"privacy":{"uri":"--\/privacy","methods":["GET","HEAD"]},"report-flag":{"uri":"--\/report-flag","methods":["GET","HEAD"]}}};
```

Then, using the new `route` function from `@wikijump/api`, you can do stuff like:
```ts
const url = route("user.profile", { user: username })
```

Also. I added a bunch of dummy routes for stuff that doesn't exist yet but that I'm still linking to.