### PR TITLE
Hotfix: PHP build failing, add allow-plugins

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -30,7 +30,8 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
This PR adds the `allow-plugins` configuration field to `composer.json`, which is needed as part of a Composer migration:

Composer is making a change where the current default value for this setting (`null`, meaning all plugins can be used) will be set to `{}`. This `allow-plugins` configuration field is an explicit list of all plugins which are permitted, so the new default is "no plugins" rather than "implicit all plugins".

Because composer wants people to make this `composer.json` change before they roll out the breaking change (changing the default behavior), they have a script which adds it to your `composer.json` for you. However, like any time you run PHP, it loads all the environment and other autoload stuff, which for us fails because not all of the source is in the image yet (and besides we have a bunch of extensions and dependencies that need to exist -- dependencies which aren't present yet because this occurs while we're installing dependencies!)