### PR TITLE
[WJ-949] Add attributes to DEEPWELL's Fluent implementation

### DIFF
--- a/deepwell/src/locales/error.rs
+++ b/deepwell/src/locales/error.rs
@@ -59,4 +59,7 @@ pub enum LocalizationTranslateError {
 
     #[error("Message key was found, but has no value")]
     NoMessageValue,
+
+    #[error("Message key was found, but does not have this attribute")]
+    NoMessageAttribute,
 }

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -108,7 +108,7 @@ impl Localizations {
     ///
     /// Fluent does not permit multiple periods in a message key, having multiple
     /// is a logical error.
-    pub fn parse_selector<'a>(key: &'a str) -> (&'a str, Option<&'a str>) {
+    pub fn parse_selector(key: &str) -> (&str, Option<&str>) {
         match key.find('.') {
             None => (key, None),
             Some(idx) => {

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -119,9 +119,17 @@ impl Localizations {
     }
 
     pub fn has_message(&self, locale: &LanguageIdentifier, key: &str) -> bool {
+        let (path, attribute) = Self::parse_selector(key);
+
         self.bundles
             .get(locale)
-            .map(|bundle| bundle.has_message(key))
+            .map(|bundle| match attribute {
+                None => bundle.has_message(key),
+                Some(attribute) => bundle
+                    .get_message(path)
+                    .map(|message| message.get_attribute(attribute).is_some())
+                    .unwrap_or(false),
+            })
             .unwrap_or(false)
     }
 

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -112,7 +112,8 @@ impl Localizations {
         match key.find('.') {
             None => (key, None),
             Some(idx) => {
-                let (path, attribute) = key.split_at(idx);
+                let (path, rest) = key.split_at(idx);
+                let attribute = &rest[1..]; // This is safe because '.' is one byte
                 (path, Some(attribute))
             }
         }

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -104,6 +104,20 @@ impl Localizations {
         Ok(())
     }
 
+    /// Parses a message key to split the path from the attribute, if present.
+    ///
+    /// Fluent does not permit multiple periods in a message key, having multiple
+    /// is a logical error.
+    pub fn parse_selector<'a>(key: &'a str) -> (&'a str, Option<&'a str>) {
+        match key.find('.') {
+            None => (key, None),
+            Some(idx) => {
+                let (path, attribute) = key.split_at(idx);
+                (path, Some(attribute))
+            }
+        }
+    }
+
     pub fn has_message(&self, locale: &LanguageIdentifier, key: &str) -> bool {
         self.bundles
             .get(locale)

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -24,6 +24,7 @@ use async_std::path::{Path, PathBuf};
 use async_std::prelude::*;
 use fluent::{bundle, FluentArgs, FluentMessage, FluentResource};
 use intl_memoizer::concurrent::IntlLangMemoizer;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
 use unic_langid::LanguageIdentifier;
@@ -148,12 +149,12 @@ impl Localizations {
         }
     }
 
-    pub fn translate(
-        &self,
+    pub fn translate<'a>(
+        &'a self,
         locale: &LanguageIdentifier,
         key: &str,
-        args: &FluentArgs,
-    ) -> Result<String, LocalizationTranslateError> {
+        args: &'a FluentArgs<'a>,
+    ) -> Result<Cow<'a, str>, LocalizationTranslateError> {
         // Get appropriate message and bundle
         let (path, attribute) = Self::parse_selector(key);
         let (bundle, message) = self.get_message(locale, path)?;
@@ -199,9 +200,7 @@ impl Localizations {
         }
 
         // Done
-        //
-        // Passing as owned to avoid complicated FluentBundle lifetimes.
-        Ok(str!(output))
+        Ok(output)
     }
 }
 

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -138,12 +138,6 @@ impl Localizations {
         locale: &LanguageIdentifier,
         key: &str,
     ) -> Result<(&FluentBundle, FluentMessage), LocalizationTranslateError> {
-        tide::log::info!(
-            "Fetching translation for locale {}, message key {}",
-            locale,
-            key,
-        );
-
         match self.bundles.get(locale) {
             None => Err(LocalizationTranslateError::NoLocale),
             Some(bundle) => match bundle.get_message(key) {
@@ -162,6 +156,13 @@ impl Localizations {
         // Get appropriate message and bundle
         let (path, attribute) = Self::parse_selector(key);
         let (bundle, message) = self.get_message(locale, path)?;
+
+        tide::log::info!(
+            "Translating for locale {}, message path {}, attribute {}",
+            locale,
+            path,
+            attribute.unwrap_or("<none>"),
+        );
 
         // Get pattern from message
         let pattern = match attribute {

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -145,7 +145,7 @@ impl Localizations {
         tide::log::info!(
             "Fetching translation for locale {}, message key {}",
             locale,
-            key
+            key,
         );
 
         match self.bundles.get(locale) {

--- a/deepwell/src/methods/locales.rs
+++ b/deepwell/src/methods/locales.rs
@@ -81,7 +81,7 @@ pub async fn message_post(mut req: ApiRequest) -> ApiResponse {
         .translate(&locale, message_key, &arguments);
 
     match result {
-        Ok(message) => Ok(message.into()),
+        Ok(message) => Ok(message.as_ref().into()),
         Err(error) => Err(ServiceError::from(error).into_tide_error()),
     }
 }


### PR DESCRIPTION
Follow-up to #679 

This adds supports for attributes to DEEPWELL's `locales` module. This includes properly parsing them out and returning them if present, and a new error case for missing attributes (as opposed to missing values). (Though, if this error isn't useful being split from the value one, I could merge them).

The change was made for both `HEAD /message/:locale/:key` and `POST /message/:locale/:key`, checking the existence of a template and actually formatting. (The latter is `POST` instead of `GET` because it requires passing in a JSON body to specify variables).