### PR TITLE
Add message about asset bundles after startup

### DIFF
--- a/web/app/Services/Nginx/Nginx.php
+++ b/web/app/Services/Nginx/Nginx.php
@@ -49,6 +49,7 @@ final class Nginx
         } catch (Exception $err) {
             Log::error("Could not fetch asset contents: {$url}");
             Log::error($err->getMessage());
+            Log::info("(Note: If the instance is still starting up, this error can likely be ignored)");
             return null;
         }
     }

--- a/web/app/Services/Nginx/Nginx.php
+++ b/web/app/Services/Nginx/Nginx.php
@@ -49,7 +49,7 @@ final class Nginx
         } catch (Exception $err) {
             Log::error("Could not fetch asset contents: {$url}");
             Log::error($err->getMessage());
-            Log::info("(Note: If the instance is still starting up, this error can likely be ignored)");
+            Log::notice("(Note: If the instance is still starting up, this error can likely be ignored)");
             return null;
         }
     }


### PR DESCRIPTION
As discussed in chat, since this is not an error if it's occurring during startup, then it's probably not an issue because nginx is still initializing.

I explored using health checks to avoid the issue in container startup, but because nginx depends on php-fpm, we can't have php-fpm also depend on nginx.