### PR TITLE
[WJ-950] Change PHP to use Fluent localizations

### DIFF
--- a/deepwell/src/api/v0.rs
+++ b/deepwell/src/api/v0.rs
@@ -34,6 +34,7 @@ pub fn build(mut app: ApiServer) -> ApiServer {
     app.at("/ping").all(ping);
     app.at("/version").get(version);
     app.at("/version/full").get(full_version);
+    app.at("/ratelimit-exempt").all(ratelimit_exempt);
     app.at("/teapot")
         .get(|_| async { error_response(StatusCode::ImATeapot, "🫖") });
 

--- a/deepwell/src/methods/misc.rs
+++ b/deepwell/src/methods/misc.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::info;
+use crate::web::ratelimit::is_ratelimit_exempt;
 use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 
 pub async fn ping(req: ApiRequest) -> ApiResponse {
@@ -45,5 +46,9 @@ pub async fn full_version(_: ApiRequest) -> ApiResponse {
 }
 
 pub async fn ratelimit_exempt(req: ApiRequest) -> ApiResponse {
-    todo!()
+    if is_ratelimit_exempt(&req) {
+        Ok(Response::new(StatusCode::NoContent))
+    } else {
+        Ok(Response::new(StatusCode::Forbidden))
+    }
 }

--- a/deepwell/src/methods/misc.rs
+++ b/deepwell/src/methods/misc.rs
@@ -43,3 +43,7 @@ pub async fn version(_: ApiRequest) -> ApiResponse {
 pub async fn full_version(_: ApiRequest) -> ApiResponse {
     Ok(info::FULL_VERSION_WITH_NAME.as_str().into())
 }
+
+pub async fn ratelimit_exempt(req: ApiRequest) -> ApiResponse {
+    todo!()
+}

--- a/install/files/dev/wikijump.ini
+++ b/install/files/dev/wikijump.ini
@@ -144,6 +144,17 @@ host = database
 ; Default: 5432
 port = 5432
 
+;;;;
+; API Category
+
+[api]
+
+; [bypass-secret]
+; Purpose: Secret to permit bypassing DEEPWELL's normal rate-limit.
+; GlobalProperties Reference: $API_RATELIMIT_BYPASS
+; Default: ""
+bypass_secret = ""
+
 
 ;;;;
 ; Search Category

--- a/install/files/local/wikijump.ini
+++ b/install/files/local/wikijump.ini
@@ -144,6 +144,17 @@ host = database
 ; Default: 5432
 port = 5432
 
+;;;;
+; API Category
+
+[api]
+
+; [bypass-secret]
+; Purpose: Secret to permit bypassing DEEPWELL's normal rate-limit.
+; GlobalProperties Reference: $API_RATELIMIT_BYPASS
+; Default: ""
+bypass_secret = local_deploy_only_7uDCoVRgQtdzMIx4Y6VUQJKEOqtvBDhiYXmPD8xfODsxtQ
+
 
 ;;;;
 ; Search Category

--- a/install/files/prod/wikijump.ini
+++ b/install/files/prod/wikijump.ini
@@ -144,6 +144,16 @@ host = database
 ; Default: 5432
 port = 5432
 
+;;;;
+; API Category
+
+[api]
+
+; [bypass-secret]
+; Purpose: Secret to permit bypassing DEEPWELL's normal rate-limit.
+; GlobalProperties Reference: $API_RATELIMIT_BYPASS
+; Default: ""
+bypass_secret = ""
 
 ;;;;
 ; Search Category

--- a/install/local/dev/docker-compose.yaml
+++ b/install/local/dev/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - "2747:2747"
     environment:
       - "DATABASE_URL=postgres://wikijump:wikijump@database/wikijump"
+      - "RATE_LIMIT_SECRET=local_deploy_only_7uDCoVRgQtdzMIx4Y6VUQJKEOqtvBDhiYXmPD8xfODsxtQ"
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-i", "http://localhost:2747/api/v0/ping"]

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -121,7 +121,7 @@ RUN /src/setup-misc.sh
 COPY ./install/files/php-fpm/run.sh /app/run.sh
 
 # Cleanup
-RUN rm -rf /src /usr/bin/composer
+# Don't remove composer for the local container
 
 # We'll need to change the owner of the public directory,
 # so that the user www-data can write to it.

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -42,7 +42,10 @@ final class DeepwellService
 
     public function translate(string $locale, string $key, array $values = []): ?string
     {
-        $resp = $this->client->post("message/$locale/$key", ['json' => $values]);
+        $resp = $this->client->post("message/$locale/$key", [
+            'body' => json_encode($values, JSON_FORCE_OBJECT),
+        ]);
+
         if ($resp->getStatusCode() !== 200) {
             return null;
         }

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -28,7 +28,7 @@ final class DeepwellService
     {
         $this->client = new Client([
             'base_uri' => 'http://api:2747/api/v0/',
-            'timeout' => 1.0,
+            'timeout' => 0.5,
             'headers' => [
                 'User-Agent' => 'wikijump-php',
                 'X-Exempt-RateLimit' => GlobalProperties::$API_RATELIMIT_BYPASS,

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -34,6 +34,8 @@ final class DeepwellService
                 'X-Exempt-RateLimit' => GlobalProperties::$API_RATELIMIT_BYPASS,
             ],
         ]);
+
+        $this->checkRatelimitExempt();
     }
 
     // Localization
@@ -114,6 +116,11 @@ final class DeepwellService
     {
         $method = $full ? 'version/full' : 'version';
         return (string) $this->client->get($method)->getBody();
+    }
+
+    public function checkRatelimitExempt(): void
+    {
+        $this->client->get('ratelimit-exempt');
     }
 
     // Helper functions

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -29,6 +29,27 @@ final class DeepwellService
         ]);
     }
 
+    // Localization
+    public function parseLocale(string $locale): ?object
+    {
+        $resp = $this->client->get("locale/$locale");
+        if ($resp->getStatusCode() === 400) {
+            return null;
+        }
+
+        return self::readJson($resp);
+    }
+
+    public function translate(string $locale, string $key, array $values = []): ?string
+    {
+        $resp = $this->client->post("message/$locale/$key", ['json' => $values]);
+        if ($resp->getStatusCode() !== 200) {
+            return null;
+        }
+
+        return (string) $resp->getBody();
+    }
+
     // User
     public function getUserById(int $id): ?object
     {

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Wikijump\Services\DEEPWELL;
+namespace Wikijump\Services\Deepwell;
 
 use Carbon\Carbon;
 use GuzzleHttp\Client;

--- a/web/app/Services/Deepwell/DeepwellService.php
+++ b/web/app/Services/Deepwell/DeepwellService.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Facades\Log;
+use Wikidot\Utils\GlobalProperties;
 
 final class DeepwellService
 {
@@ -28,6 +29,10 @@ final class DeepwellService
         $this->client = new Client([
             'base_uri' => 'http://api:2747/api/v0/',
             'timeout' => 1.0,
+            'headers' => [
+                'User-Agent' => 'wikijump-php',
+                'X-Exempt-RateLimit' => GlobalProperties::$API_RATELIMIT_BYPASS,
+            ],
         ]);
     }
 

--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -15,7 +15,7 @@ final class LocalizationService
     public static function translate(string $key, array $values = []): string
     {
         if ($key === '') {
-            Log::error('Empty localization key given');
+            Log::error('Empty localization key');
             return '';
         }
 

--- a/web/app/Services/Localization/LocalizationService.php
+++ b/web/app/Services/Localization/LocalizationService.php
@@ -5,48 +5,27 @@ namespace Wikijump\Services\Localization;
 
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
-use Gettext\Loader\MoLoader;
-use Gettext\Translations;
-use MessageFormatter;
+use Wikijump\Services\Deepwell\DeepwellService;
 
 /**
  * Service to provide formatted translated messages depending on the current locale.
  */
 final class LocalizationService
 {
-    public const LOCALES_DIRECTORY = WIKIJUMP_ROOT . '/public/files--built/locales/';
-    private static ?Translations $translations = null;
-
-    private static function loadTranslations(): void
-    {
-        if (self::$translations === null) {
-            $locale = App::currentLocale();
-            $loader = new MoLoader();
-            $path = self::LOCALES_DIRECTORY . $locale . '.mo';
-            self::$translations = $loader->loadFile($path);
-        }
-    }
-
     public static function translate(string $key, array $values = []): string
     {
-        self::loadTranslations();
-
         if ($key === '') {
             Log::error('Empty localization key given');
             return '';
         }
 
-        // Get message from translations file
         $locale = App::currentLocale();
-        $translation = self::$translations->find(null, $key);
+        $translation = DeepwellService::getInstance()->translate($locale, $key, $values);
         if ($translation === null) {
             Log::warning('Unable to find message', ['key' => $key, 'locale' => $locale]);
             return $key;
         }
 
-        // Format ICU localization message
-        $message = $translation->getTranslation();
-        $output = MessageFormatter::formatMessage($locale, $message, $values);
-        return $output;
+        return $translation;
     }
 }

--- a/web/composer.json
+++ b/web/composer.json
@@ -7,7 +7,6 @@
         "ezyang/htmlpurifier": "^4.13",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
-        "gettext/gettext": "^5.5",
         "guzzlehttp/guzzle": "^7.3",
         "innocenzi/laravel-vite": "^0.1.14",
         "laravel/framework": "^8.37",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "085fe6e493df6ea89027678c50a8b165",
+    "content-hash": "3b07eabe6915d5d8c654fb14625ee0d9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -114,16 +114,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.208.3",
+            "version": "3.208.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c9ccf6705fe41e53f23dac7e0573e3f79d70bcde"
+                "reference": "41a800dd7cf5c4ac0ef9bf8db01e838ab6a3698c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c9ccf6705fe41e53f23dac7e0573e3f79d70bcde",
-                "reference": "c9ccf6705fe41e53f23dac7e0573e3f79d70bcde",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/41a800dd7cf5c4ac0ef9bf8db01e838ab6a3698c",
+                "reference": "41a800dd7cf5c4ac0ef9bf8db01e838ab6a3698c",
                 "shasum": ""
             },
             "require": {
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.208.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.208.7"
             },
-            "time": "2021-12-08T19:30:07+00:00"
+            "time": "2021-12-21T19:16:39+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -1514,154 +1514,6 @@
             "time": "2021-04-26T11:24:25+00:00"
         },
         {
-            "name": "gettext/gettext",
-            "version": "v5.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "017e249601d32b9a88c2eb4c10eac89bf582a7d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/017e249601d32b9a88c2eb4c10eac89bf582a7d3",
-                "reference": "017e249601d32b9a88c2eb4c10eac89bf582a7d3",
-                "shasum": ""
-            },
-            "require": {
-                "gettext/languages": "^2.3",
-                "php": "^7.2|^8.0"
-            },
-            "require-dev": {
-                "brick/varexporter": "^0.3.5",
-                "friendsofphp/php-cs-fixer": "^3.2",
-                "oscarotero/php-cs-fixer-config": "^2.0",
-                "phpunit/phpunit": "^8.0|^9.0",
-                "squizlabs/php_codesniffer": "^3.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Gettext\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Oscar Otero",
-                    "email": "oom@oscarotero.com",
-                    "homepage": "http://oscarotero.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP gettext manager",
-            "homepage": "https://github.com/php-gettext/Gettext",
-            "keywords": [
-                "JS",
-                "gettext",
-                "i18n",
-                "mo",
-                "po",
-                "translation"
-            ],
-            "support": {
-                "email": "oom@oscarotero.com",
-                "issues": "https://github.com/php-gettext/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v5.6.1"
-            },
-            "funding": [
-                {
-                    "url": "https://paypal.me/oscarotero",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/oscarotero",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/misteroom",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2021-12-04T11:33:21+00:00"
-        },
-        {
-            "name": "gettext/languages",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
-            },
-            "bin": [
-                "bin/export-plural-rules"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Gettext\\Languages\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michele Locati",
-                    "email": "mlocati@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "gettext languages with plural rules",
-            "homepage": "https://github.com/php-gettext/Languages",
-            "keywords": [
-                "cldr",
-                "i18n",
-                "internationalization",
-                "l10n",
-                "language",
-                "languages",
-                "localization",
-                "php",
-                "plural",
-                "plural rules",
-                "plurals",
-                "translate",
-                "translations",
-                "unicode"
-            ],
-            "support": {
-                "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://paypal.me/mlocati",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/mlocati",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-11-11T17:30:39+00:00"
-        },
-        {
             "name": "graham-campbell/result-type",
             "version": "v1.0.4",
             "source": {
@@ -2125,16 +1977,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v8.76.2",
+            "version": "v8.77.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c67acfdc968f487b6235435080eef62a7e2ed055"
+                "reference": "994dbac5c6da856c77c81a411cff5b7d31519ca8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c67acfdc968f487b6235435080eef62a7e2ed055",
-                "reference": "c67acfdc968f487b6235435080eef62a7e2ed055",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/994dbac5c6da856c77c81a411cff5b7d31519ca8",
+                "reference": "994dbac5c6da856c77c81a411cff5b7d31519ca8",
                 "shasum": ""
             },
             "require": {
@@ -2152,7 +2004,7 @@
                 "opis/closure": "^3.6",
                 "php": "^7.3|^8.0",
                 "psr/container": "^1.0",
-                "psr/log": "^1.0 || ^2.0",
+                "psr/log": "^1.0|^2.0",
                 "psr/simple-cache": "^1.0",
                 "ramsey/uuid": "^4.2.2",
                 "swiftmailer/swiftmailer": "^6.3",
@@ -2293,7 +2145,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-12-15T14:02:14+00:00"
+            "time": "2021-12-21T20:22:29+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -3193,9 +3045,6 @@
             },
             "require": {
                 "php": "^7.1 || ^8.0"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
@@ -6099,16 +5948,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.9.2",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "f710fe196c126fb9e0aee67eb5af49ad8f13f528"
+                "reference": "97c24d0bc58e04d55e4a6a7b6d6102cb45b75789"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/f710fe196c126fb9e0aee67eb5af49ad8f13f528",
-                "reference": "f710fe196c126fb9e0aee67eb5af49ad8f13f528",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/97c24d0bc58e04d55e4a6a7b6d6102cb45b75789",
+                "reference": "97c24d0bc58e04d55e4a6a7b6d6102cb45b75789",
                 "shasum": ""
             },
             "require": {
@@ -6117,8 +5966,8 @@
             },
             "require-dev": {
                 "mockery/mockery": "^1.4",
-                "orchestra/testbench": "^5.0|^6.0",
-                "phpunit/phpunit": "^9.3",
+                "orchestra/testbench": "^5.0|^6.23",
+                "phpunit/phpunit": "^9.4",
                 "spatie/test-time": "^1.2"
             },
             "type": "library",
@@ -6147,7 +5996,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.9.2"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.10.0"
             },
             "funding": [
                 {
@@ -6155,7 +6004,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-21T13:06:51+00:00"
+            "time": "2021-12-18T20:33:51+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -8874,16 +8723,16 @@
         },
         {
             "name": "facade/ignition",
-            "version": "2.17.2",
+            "version": "2.17.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition.git",
-                "reference": "af3cd70d58ca3ef5189ff0e59efbe5a5c043e2d2"
+                "reference": "29f1be7f45f6fe4ffcf59a1c87bb469d47f1d227"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition/zipball/af3cd70d58ca3ef5189ff0e59efbe5a5c043e2d2",
-                "reference": "af3cd70d58ca3ef5189ff0e59efbe5a5c043e2d2",
+                "url": "https://api.github.com/repos/facade/ignition/zipball/29f1be7f45f6fe4ffcf59a1c87bb469d47f1d227",
+                "reference": "29f1be7f45f6fe4ffcf59a1c87bb469d47f1d227",
                 "shasum": ""
             },
             "require": {
@@ -8948,7 +8797,7 @@
                 "issues": "https://github.com/facade/ignition/issues",
                 "source": "https://github.com/facade/ignition"
             },
-            "time": "2021-11-29T14:04:22+00:00"
+            "time": "2021-12-23T13:28:01+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -9429,5 +9278,5 @@
         "php": "^7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/web/php/Utils/GlobalProperties.php
+++ b/web/php/Utils/GlobalProperties.php
@@ -37,6 +37,9 @@ class GlobalProperties
     public static $DATABASE_PASSWORD;
     public static $DATABASE_NAME;
 
+    // api settings
+    public static $API_RATELIMIT_BYPASS;
+
     // search settings
     public static $SEARCH_LUCENE_INDEX;
     public static $SEARCH_LUCENE_QUEUE;
@@ -183,6 +186,9 @@ class GlobalProperties
         self::$DATABASE_NAME            = $_ENV["WIKIJUMP_DATABASE_NAME"] ?? self::fromIni("db", "database", "postgres");        // no default!
         self::$DATABASE_SERVER          = $_ENV["WIKIJUMP_DATABASE_SERVER"] ?? self::fromIni("db", "host", "127.0.0.1");
         self::$DATABASE_PORT            = $_ENV["WIKIJUMP_DATABASE_PORT"] ?? self::fromIni("db", "port", "5432");
+
+        // api settings
+        self::$API_RATELIMIT_BYPASS     = $_ENV["WIKIJUMP_API_RATELIMIT_BYPASS"] ?? self::fromIni("api", "bypass_secret", "");
 
         // search settings
         self::$SEARCH_LUCENE_INDEX      = $_ENV["WIKIJUMP_SEARCH_LUCENE_INDEX"] ?? self::fromIni("search", "lucene_index", WIKIJUMP_ROOT . "/tmp/lucene_index");


### PR DESCRIPTION
This sets up PHP to call DEEPWELL for its translations instead of using the old ICU setup. The PHP Fluent library is too immature to use directly, and DEEPWELL works fine here. I also had to set up the ratelimit bypass secret in PHP since otherwise it would hit HTTP 429s and rendering any page would fail.