### PR TITLE
Fix lints

### DIFF
--- a/web/app/Services/Nginx/Nginx.php
+++ b/web/app/Services/Nginx/Nginx.php
@@ -49,7 +49,9 @@ final class Nginx
         } catch (Exception $err) {
             Log::error("Could not fetch asset contents: {$url}");
             Log::error($err->getMessage());
-            Log::notice("(Note: If the instance is still starting up, this error can likely be ignored)");
+            Log::notice(
+                '(Note: If the instance is still starting up, this error can likely be ignored)',
+            );
             return null;
         }
     }

--- a/web/modules/sheaf/src/components/SettingsMenu.svelte
+++ b/web/modules/sheaf/src/components/SettingsMenu.svelte
@@ -63,10 +63,10 @@
 
   .sheaf-settings-menu-sep {
     display: flex;
+    column-gap: 0.5rem;
     align-items: center;
     justify-content: space-between;
     margin-top: 0.75rem;
-    column-gap: 0.5rem;
 
     &:first-child {
       margin-top: 0;
@@ -74,16 +74,16 @@
   }
 
   .sheaf-settings-menu-title {
+    font-family: var(--font-display);
     font-size: 0.875rem;
     font-weight: bold;
-    font-family: var(--font-display);
     color: var(--col-text-subtle);
   }
 
   .sheaf-settings-menu-sep-line {
-    height: 0.175rem;
-    border-radius: 0.5rem;
-    background-color: var(--col-border);
     flex-grow: 1;
+    height: 0.175rem;
+    background-color: var(--col-border);
+    border-radius: 0.5rem;
   }
 </style>


### PR DESCRIPTION
Needed to run `pnpm lint:fix`, other builds were failing due to this unrelated lint breakage.