### PR TITLE
Add read-only database user

### DIFF
--- a/install/files/postgres/pg_hba.conf
+++ b/install/files/postgres/pg_hba.conf
@@ -44,4 +44,6 @@ host    replication     all             ::1/128                 md5
 
 # Allow wikijump to connect from a container
 host    wikijump        wikijump        0.0.0.0/0               md5
+host    wikijump        wikijump_ro     0.0.0.0/0               md5
 host    wikijump        wikijump        ::/0                    md5
+host    wikijump        wikijump_ro     ::/0                    md5

--- a/install/files/postgres/seed.sql
+++ b/install/files/postgres/seed.sql
@@ -1,10 +1,12 @@
 SET default_transaction_read_only = off;
 
-CREATE ROLE wikijump;
-ALTER ROLE wikijump WITH INHERIT CREATEDB LOGIN REPLICATION NOBYPASSRLS PASSWORD 'wikijump';
+CREATE ROLE wikijump
+    WITH INHERIT NOSUPERUSER CREATEDB LOGIN REPLICATION NOBYPASSRLS PASSWORD 'wikijump';
+
+CREATE ROLE wikijump_ro
+    WITH INHERIT NOSUPERUSER NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'wikijump_ro';
 
 CREATE DATABASE wikijump ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';
-
 ALTER DATABASE wikijump OWNER TO wikijump;
 
 \connect wikijump
@@ -21,3 +23,8 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 GRANT ALL ON SCHEMA public TO wikijump;
+
+REVOKE ALL ON SCHEMA public FROM wikijump_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO wikijump_ro;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT ON TABLES TO wikijump_ro;

--- a/install/files/postgres/seed.sql
+++ b/install/files/postgres/seed.sql
@@ -22,20 +22,10 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
--- Since permissions are additive, and by default
--- everyone in public can create tables, we have
--- to revoke it from everyone so we can create a
--- read-only user.
---
--- The first 'public' is the schema,
--- the second 'PUBLIC' means "all users".
-REVOKE CREATE ON SCHEMA public FROM PUBLIC, wikijump_ro;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
--- Then we give all permissions to wikijump so it can do things.
 GRANT ALL ON SCHEMA public TO wikijump;
 
--- Revoke all permissions, except SELECT.
--- Also grant SELECT on any future tables that are made.
 REVOKE ALL ON SCHEMA public FROM wikijump_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO wikijump_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public

--- a/install/files/postgres/seed.sql
+++ b/install/files/postgres/seed.sql
@@ -22,9 +22,21 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- Since permissions are additive, and by default
+-- everyone in public can create tables, we have
+-- to revoke it from everyone so we can create a
+-- read-only user.
+--
+-- The first 'public' is the schema,
+-- the second 'PUBLIC' means "all users".
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- Then we give all permissions to wikijump so it can do things.
 GRANT ALL ON SCHEMA public TO wikijump;
 
+-- Revoke all permissions, except SELECT.
+-- Also grant SELECT on any future tables that are made.
 REVOKE ALL ON SCHEMA public FROM wikijump_ro;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO wikijump_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA publici TO wikijump_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT ON TABLES TO wikijump_ro;

--- a/install/files/postgres/seed.sql
+++ b/install/files/postgres/seed.sql
@@ -29,7 +29,7 @@ SET row_security = off;
 --
 -- The first 'public' is the schema,
 -- the second 'PUBLIC' means "all users".
-REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC, wikijump_ro;
 
 -- Then we give all permissions to wikijump so it can do things.
 GRANT ALL ON SCHEMA public TO wikijump;
@@ -37,6 +37,6 @@ GRANT ALL ON SCHEMA public TO wikijump;
 -- Revoke all permissions, except SELECT.
 -- Also grant SELECT on any future tables that are made.
 REVOKE ALL ON SCHEMA public FROM wikijump_ro;
-GRANT SELECT ON ALL TABLES IN SCHEMA publici TO wikijump_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO wikijump_ro;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT ON TABLES TO wikijump_ro;


### PR DESCRIPTION
This adds the database user `wikijump_ro`, which is like `wikijump` except it is read-only, and can make no changes to the database.

However, due to some technical nuisances with how permissions are inherited, despite a few hours of trying, I have not been able to revoke `CREATE` from the user (i.e., the ability to create and drop its own tables, independent of those belonging to `wikijump`).