### PR TITLE
Create files--built directory on startup

### DIFF
--- a/install/files/php-fpm/setup-php-create.sh
+++ b/install/files/php-fpm/setup-php-create.sh
@@ -8,6 +8,7 @@ mkdir -p \
 	bootstrap \
 	conf \
 	logs \
+	public/files--built \
 	storage/framework/cache \
 	storage/framework/sessions \
 	storage/framework/views \
@@ -24,6 +25,7 @@ chown -R www-data:www-data \
 	bootstrap/ \
 	conf/ \
 	logs/ \
+	public/ \
 	storage/ \
 	tmp/ \
 	vendor/


### PR DESCRIPTION
Locally I've been encountering an issue where the `public/files--built` directory hadn't yet been created. This is a simple fix by simply creating the directory in `php-fpm` container setup.