### PR TITLE
Migrate PHP-side localization strings

### DIFF
--- a/locales/fluent/base/en.ftl
+++ b/locales/fluent/base/en.ftl
@@ -21,6 +21,7 @@ about = About
 account = Account
 breadcrumbs = Breadcrumbs
 close = Close
+docs = Docs
 download = Download
 editor = Editor
 footer = Page Footer

--- a/locales/fluent/emails/en.ftl
+++ b/locales/fluent/emails/en.ftl
@@ -1,5 +1,10 @@
 ### Emails
 
+emails-subscribed = You recieved this email because you are subscribed to { -service-name }.
+emails-unsubscribe = Unsubscribe
+  .text = If you wish to unsubscribe, please click on the link below.
+  .copy = If you are having trouble clicking the '{ $action }' button, copy and paste the following URL into your browser:
+
 emails-verify-email =
   .subject = Verify Email Address
   .greeting = Verify your email address

--- a/locales/fluent/emails/en.ftl
+++ b/locales/fluent/emails/en.ftl
@@ -20,7 +20,7 @@ emails-reset-password =
     request for your account. Click the button below to reset your password.
   .action = Reset Password
   .expires = This password reset link will expire in { $count ->
-    [1] = 1 minute.
-    *[other] = { $count } minutes.
+    [1] 1 minute.
+    *[other] { $count } minutes.
   }
   .outro = If you did not request a password reset, no further action is required.

--- a/locales/fluent/emails/en.ftl
+++ b/locales/fluent/emails/en.ftl
@@ -19,4 +19,8 @@ emails-reset-password =
     You are receiving this email because we received a password reset
     request for your account. Click the button below to reset your password.
   .action = Reset Password
+  .expires = This password reset link will expire in { $count ->
+    [1] = 1 minute.
+    *[other] = { $count } minutes.
+  }
   .outro = If you did not request a password reset, no further action is required.

--- a/locales/fluent/wiki-page/en.ftl
+++ b/locales/fluent/wiki-page/en.ftl
@@ -7,5 +7,5 @@ wiki-page-revision = revision: { $revision }
 wiki-page-last-edit = last-edited: { $date } ({ $days ->
   [0] today
   [1] yesterday
-  *[other] days ago
+  *[other] { $days } days ago
 })

--- a/web/app/Mail/PasswordResetMessage.php
+++ b/web/app/Mail/PasswordResetMessage.php
@@ -19,11 +19,11 @@ class PasswordResetMessage extends MJMLMessage
     {
         parent::__construct();
 
-        $this->subject(__('email.reset_password.SUBJECT'))
-            ->greeting(__('email.reset_password.GREETING'))
-            ->line(__('email.reset_password.INTRO'))
-            ->action(__('email.reset_password.ACTION'), $url)
-            ->line(__('email.reset_password.EXPIRES', ['count' => $expires]))
-            ->line(__('email.reset_password.OUTRO'));
+        $this->subject(__('emails-reset-password.subject'))
+            ->greeting(__('emails-reset-password.greeting'))
+            ->line(__('emails-reset-password.intro'))
+            ->action(__('emails-reset-password.action'), $url)
+            ->line(__('emails-reset-password.expires', ['count' => $expires]))
+            ->line(__('emails-reset-password.outro'));
     }
 }

--- a/web/app/Mail/VerifyEmailMessage.php
+++ b/web/app/Mail/VerifyEmailMessage.php
@@ -18,10 +18,10 @@ class VerifyEmailMessage extends MJMLMessage
     {
         parent::__construct();
 
-        $this->subject(__('email.verify_email.SUBJECT'))
-            ->greeting(__('email.verify_email.GREETING'))
-            ->line(__('email.verify_email.INTRO'))
-            ->action(__('email.verify_email.ACTION'), $url)
-            ->line(__('email.verify_email.OUTRO'));
+        $this->subject(__('emails-verify-email.subject'))
+            ->greeting(__('emails-verify-email.greeting'))
+            ->line(__('emails-verify-email.intro'))
+            ->action(__('emails-verify-email.action'), $url)
+            ->line(__('emails-verify-email.outro'));
     }
 }

--- a/web/resources/lib/components/auth/ForgotPasswordForm.svelte
+++ b/web/resources/lib/components/auth/ForgotPasswordForm.svelte
@@ -73,7 +73,7 @@
   <FormError {error} />
 {:else}
   <div class="password-recovery-email-sent">
-    <p>{$t("#-password-recovery.email-sent")}</p>
+    <p>{$t("password-recovery.email-sent")}</p>
   </div>
 {/if}
 

--- a/web/resources/views/emails/base-mjml.blade.php
+++ b/web/resources/views/emails/base-mjml.blade.php
@@ -75,11 +75,11 @@
             <mj-section padding-top="0">
                 <mj-column>
                     <mj-text align="center" font-size="10px" line-height="12px">
-                        {{ __('email.SUBSCRIBED') }}
+                        {{ __('emails-subscribed') }}
                         <br />
                         <br />
                         <a href="{{ $unsubscribe_url }}">
-                            {{ __('email.UNSUBSCRIBE') }}
+                            {{ __('emails-unsubscribe') }}
                         </a>
                     </mj-text>
                 </mj-column>

--- a/web/resources/views/emails/base-mjml.blade.php
+++ b/web/resources/views/emails/base-mjml.blade.php
@@ -36,7 +36,7 @@
                 <mj-image width="400px"
                           src="{{ $HTTP_SCHEMA }}://{{ $URL_HOST }}/files--static/media/logo.png"
                           href="{{$HTTP_SCHEMA}}://{{$URL_HOST}}"
-                          alt="{{ __('email.GOTO_SITE') }}"
+                          alt="{{ __('goto-service') }}"
                 />
                 <mj-divider border-width="2px"
                             border-color="#eee"

--- a/web/resources/views/emails/base-text.blade.php
+++ b/web/resources/views/emails/base-text.blade.php
@@ -14,7 +14,7 @@
 
 -------------------------------------------------------------------------------
 
-{{ __('email.SUBSCRIBED') }}
-{{ __('email.UNSUBSCRIBE_TEXT') }}
+{{ __('emails-subscribed') }}
+{{ __('emails-unsubscribe.text') }}
 {!! $unsubscribe_url !!}
 @endif

--- a/web/resources/views/emails/message/mjml.blade.php
+++ b/web/resources/views/emails/message/mjml.blade.php
@@ -93,7 +93,7 @@
         <mj-section background-color="#fff">
             <mj-column>
                 <mj-text align="center" font-size="10px">
-                    {{ __('email.SUBCOPY', ['action' => $actionText]) }}
+                    {{ __('emails-unsubscribe.copy', ['action' => $actionText]) }}
                     <br />
                     <br />
                     <a href="{!! $actionUrl !!}">

--- a/web/resources/views/next/auth/auth.blade.php
+++ b/web/resources/views/next/auth/auth.blade.php
@@ -19,7 +19,7 @@
 @section('app')
     <div id="app_auth">
         <div id="auth_panel" class="light">
-            <a href="/" title="{{ __('frame.GOTO_HOME_PAGE') }}">
+            <a href="/" title="{{ __('goto-home') }}">
                 <img src="/files--static/media/logo.min.svg">
             </a>
             <hr>
@@ -28,11 +28,10 @@
 
             {{-- gets placed _outside_ of the panel via styling --}}
             <div id="auth_links">
-                {{-- TODO: link to actual pages --}}
-                <a href="/terms">{{ __('frame.footer.TERMS') }}</a>
-                <a href="/privacy">{{ __('frame.footer.PRIVACY') }}</a>
-                <a href="/docs">{{ __('frame.footer.DOCS') }}</a>
-                <a href="/security">{{ __('frame.footer.SECURITY') }}</a>
+                <a href="{{ route("terms") }}">{{ __('terms') }}</a>
+                <a href="{{ route("privacy") }}">{{ __('privacy') }}</a>
+                <a href="{{ route("docs") }}">{{ __('docs') }}</a>
+                <a href="{{ route("security") }}">{{ __('security') }}</a>
             </div>
         </div>
     </div>

--- a/web/resources/views/next/auth/confirm-password.blade.php
+++ b/web/resources/views/next/auth/confirm-password.blade.php
@@ -4,18 +4,18 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.CONFIRM_PASSWORD')
+    'title' => __('confirm-password')
 ])
 
 @section('content')
     <h1 id="auth_title">
-        {{ __('auth.CONFIRM_PASSWORD') }}
+        {{ __('confirm-password') }}
     </h1>
 
     <wj-component-loader load="ConfirmPasswordForm" back="{{ previousUrl() }}">
     </wj-component-loader>
 
     <a id="auth_forgot_password" href="{{ route("password.request") }}">
-        {{ __("auth.FORGOT_PASSWORD") }}
+        {{ __("forgot-password.question") }}
     </a>
 @endsection

--- a/web/resources/views/next/auth/forgot-password.blade.php
+++ b/web/resources/views/next/auth/forgot-password.blade.php
@@ -4,12 +4,12 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.password_recovery.FORGOT_PASSWORD'),
+    'title' => __('forgot-password'),
 ])
 
 @section('content')
     <h1 id="auth_title">
-        {{ __('auth.password_recovery.FORGOT_PASSWORD') }}
+        {{ __('forgot-password') }}
     </h1>
 
     <wj-component-loader load="ForgotPasswordForm">

--- a/web/resources/views/next/auth/login.blade.php
+++ b/web/resources/views/next/auth/login.blade.php
@@ -4,7 +4,7 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.LOGIN')
+    'title' => __('login')
 ])
 
 @section('content')
@@ -12,6 +12,6 @@
     </wj-component-loader>
 
     <a id="auth_create_account" href="{{ route("register") }}">
-        {{ __("auth.CREATE_ACCOUNT") }}
+        {{ __("create-account") }}
     </a>
 @endsection

--- a/web/resources/views/next/auth/register.blade.php
+++ b/web/resources/views/next/auth/register.blade.php
@@ -4,7 +4,7 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.REGISTER')
+    'title' => __('register')
 ])
 
 @section('content')
@@ -12,6 +12,6 @@
     </wj-component-loader>
 
     <a id="auth_login" href="{{ route("login") }}">
-        {{ __("auth.LOGIN") }}
+        {{ __("login") }}
     </a>
 @endsection

--- a/web/resources/views/next/auth/reset-password.blade.php
+++ b/web/resources/views/next/auth/reset-password.blade.php
@@ -4,12 +4,12 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.password_recovery.RESET_PASSWORD'),
+    'title' => __('reset-password'),
 ])
 
 @section('content')
     <h1 id="auth_title">
-        {{ __('auth.password_recovery.RESET_PASSWORD') }}
+        {{ __('reset-password') }}
     </h1>
 
     <wj-component-loader load="ResetPasswordForm" goto="{{ route('login') }}">

--- a/web/resources/views/next/auth/verify-email-link.blade.php
+++ b/web/resources/views/next/auth/verify-email-link.blade.php
@@ -12,7 +12,7 @@
         <meta name="referrer" content="no-referrer">
         <meta name="csrf-token" content="{{ csrf_token() }}" />
 
-        <title>{{ __('auth.verify_email.VERIFY_EMAIL') }}</title>
+        <title>{{ __('wiki-auth-verify-email-link') }}</title>
 
         @inline('resources/css/pages/verify-email-link.scss')
         @inline('resources/lib/verify-email-link.ts')
@@ -21,21 +21,21 @@
     </head>
     <body>
         <div id="verify_waiting">
-            <h1>{{ __('auth.verify_email_link.WAITING') }}</h1>
+            <h1>{{ __('wiki-auth-verify-email-link.waiting') }}</h1>
         </div>
 
         <div id="verify_please_interact" style="display: none;">
             <div id="verify_robot">🤖</div>
-            <h1>{{ __('auth.verify_email_link.PLEASE_INTERACT') }}</h1>
-            <p>{{ __('auth.verify_email_link.INSTRUCTIONS') }}</p>
+            <h1>{{ __('wiki-auth-verify-email-link.please-interact') }}</h1>
+            <p>{{ __('wiki-auth-verify-email-link.instructions') }}</p>
         </div>
 
         <div id="verify_success" style="display: none;">
-            <h1>{{ __('auth.verify_email_link.SUCCESS') }}</h1>
+            <h1>{{ __('wiki-auth-verify-email-link.success') }}</h1>
         </div>
 
         <div id="verify_failure" style="display: none;">
-            <h1>{{ __('auth.errors.INTERNAL_ERROR') }}</h1>
+            <h1>{{ __('error-api.internal') }}</h1>
         </div>
     </body>
 </html>

--- a/web/resources/views/next/auth/verify-email.blade.php
+++ b/web/resources/views/next/auth/verify-email.blade.php
@@ -4,13 +4,13 @@
 --}}
 
 @extends('next.auth.auth', [
-    'title' => __('auth.verify_email.VERIFY_EMAIL')
+    'title' => __('wiki-auth-verify-email')
 ])
 
 
 @section('content')
     <p id="auth_verify_email">
-        {{ __('auth.verify_email.INTRO') }}
+        {{ __('wiki-auth-verify-email.intro') }}
     </p>
     <br />
 

--- a/web/resources/views/next/components/footer.blade.php
+++ b/web/resources/views/next/components/footer.blade.php
@@ -6,7 +6,7 @@
         $license (see `config/licenses.php` and `App/Services/License`)
  --}}
 
-<footer id="footer" aria-label="{{ __('frame.aria.FOOTER') }}">
+<footer id="footer" aria-label="{{ __('footer') }}">
     <div id="footer_main">
         <div id="footer_services">
             @if ($SERVICE_NAME != "")

--- a/web/resources/views/next/components/footer.blade.php
+++ b/web/resources/views/next/components/footer.blade.php
@@ -13,30 +13,30 @@
                 <a class="footer-services-partof"
                     href="{{$HTTP_SCHEMA}}://{{$URL_HOST}}"
                 >
-                    {{ __('frame.footer.PART_OF', ['name' => $SERVICE_NAME]) }}
+                    {{ __('footer-part-of', ['name' => $SERVICE_NAME]) }}
                 </a>
                 <span class="footer-services-sep">&#8212;</span>
             @endif
             <a class="footer-services-poweredby"
                 href="https://github.com/scpwiki/wikijump"
             >
-                {{ __('frame.footer.POWERED_BY', ['name' => 'Wikijump']) }}
+                {{ __('footer-powered-by') }}
             </a>
             <span class="footer-services-sep">&#8212;</span>
-            <a href="{{ route("terms") }}">{{ __('frame.footer.TERMS') }}</a>
-            <a href="{{ route("privacy") }}">{{ __('frame.footer.PRIVACY') }}</a>
-            <a href="{{ route("docs") }}">{{ __('frame.footer.DOCS') }}</a>
-            <a href="{{ route("security") }}">{{ __('frame.footer.SECURITY') }}</a>
+            <a href="{{ route("terms") }}">{{ __('terms') }}</a>
+            <a href="{{ route("privacy") }}">{{ __('privacy') }}</a>
+            <a href="{{ route("docs") }}">{{ __('docs') }}</a>
+            <a href="{{ route("security") }}">{{ __('security') }}</a>
         </div>
 
         <div id="footer_actions">
             <a href="https://scuttle.atlassian.net/servicedesk/customer/portal/2">
-                {{ __('frame.footer.REPORT_BUG') }}
+                {{ __('footer-menu.report-bug') }}
             </a>
             @if (empty($plain) || !$plain)
                 {{-- TODO: Flag as objectionable functionality  --}}
                 <a href="{{ route("report-flag") }}">
-                    {{ __('frame.footer.REPORT_FLAG') }}
+                    {{ __('footer-menu.report-flag') }}
                 </a>
             @endif
         </div>
@@ -44,12 +44,12 @@
 
     @if (empty($plain) || !$plain)
         @isset($license)
-            <div id="footer_license" aria-label="{{ __('frame.aria.LICENSE') }}">
+            <div id="footer_license" aria-label="{{ __('license') }}">
                 <a href="{{ $license->url() }}">
                     @if ($license->unless())
-                        {{ __('frame.LICENSE_UNLESS', ['license' => $license->name()]) }}
+                        {{ __('footer-license-unless', ['license' => $license->name()]) }}
                     @else
-                        {{  __('frame.LICENSE', ['license' => $license->name()]) }}
+                        {{  __('footer-license', ['license' => $license->name()]) }}
                     @endif
                 </a>
             </div>

--- a/web/resources/views/next/components/header.blade.php
+++ b/web/resources/views/next/components/header.blade.php
@@ -7,9 +7,9 @@
         $header_subtitle
  --}}
 
-<header id="header" aria-label="{{ __('frame.aria.HEADER') }}">
+<header id="header" aria-label="{{ __('header') }}">
     @if (isset($header_img_url) || isset($header_title))
-        <a id="header_logo" href="/" title="{{ __('frame.GOTO_HOME_PAGE') }}">
+        <a id="header_logo" href="/" title="{{ __('goto-home') }}">
             @isset($header_img_url)
                 <img id="header_logo_img"
                       src="{{ $header_img_url }}"

--- a/web/resources/views/next/components/navbar.blade.php
+++ b/web/resources/views/next/components/navbar.blade.php
@@ -20,7 +20,7 @@
 {{-- TODO: Page search widget --}}
 {{-- TODO: Locale selector--}}
 {{-- TODO: Dark/light mode selector --}}
-<nav id="navbar" aria-label="{{ __('frame.aria.NAVIGATION') }}">
+<nav id="navbar" aria-label="{{ __('navigation') }}">
     @includeWhen(isset($sidebar_content), 'next.components.sidebar-button')
 
     @includeWhen(isset($navbar_items), 'next.components.navbar-elements', [

--- a/web/resources/views/next/components/sidebar-button.blade.php
+++ b/web/resources/views/next/components/sidebar-button.blade.php
@@ -1,5 +1,5 @@
 <wj-sidebar-button id="sidebar_button"
-                   aria-label="{{ __('frame.aria.SIDEBAR_BUTTON') }}"
+                   aria-label="{{ __('reveal-sidebar') }}"
                    aria-controls="sidebar"
 >
     @include('next.components.ui-svg', ['sprite' => 'wj-hamburger'])

--- a/web/resources/views/next/components/sidebar.blade.php
+++ b/web/resources/views/next/components/sidebar.blade.php
@@ -5,7 +5,7 @@
 
 <wj-sidebar id="sidebar"
             role="complementary"
-            aria-label="{{ __('frame.aria.SIDEBAR') }}"
+            aria-label="{{ __('sidebar') }}"
 >
     <div id="sidebar_sticky" role="presentation">
         {!! $sidebar_content !!}

--- a/web/resources/views/next/frame.blade.php
+++ b/web/resources/views/next/frame.blade.php
@@ -40,7 +40,7 @@
 
             @includeWhen(isset($sidebar_content), 'next.components.sidebar')
 
-            <main id="main" aria-label="{{ __('frame.aria.MAIN') }}">
+            <main id="main" aria-label="{{ __('main-content') }}">
                 @yield('content')
             </main>
 
@@ -51,7 +51,7 @@
 
             @include('next.components.header')
 
-            <main id="main" aria-label="{{ __('frame.aria.MAIN') }}">
+            <main id="main" aria-label="{{ __('main-content') }}">
                 @yield('content')
             </main>
 

--- a/web/resources/views/next/wiki/page.blade.php
+++ b/web/resources/views/next/wiki/page.blade.php
@@ -44,7 +44,7 @@
         @endisset
 
         @if (isset($page_breadcrumbs) && count($page_breadcrumbs) > 0)
-            <div id="page_breadcrumbs" aria-label="{{ __('wiki.page.aria.BREADCRUMBS') }}">
+            <div id="page_breadcrumbs" aria-label="{{ __('breadcrumbs') }}">
                 <ul>
                     @foreach ($page_breadcrumbs as $breadcrumb)
                         <li class="page-breadcrumb">
@@ -76,13 +76,13 @@
                 {{-- This is to preserve the layout needed for styling --}}
                 <h4 id="page_info_tags_header" aria-hidden="true">
                     @if (isset($page_tags) && count($page_tags) > 0)
-                        {{ __('wiki.page.TAGS') }}
+                        {{ __('tags') }}
                     @endif
                 </h4>
 
                 @isset($page_category)
                     <span id="page_info_category">
-                        {{ __('wiki.page.CATEGORY', ['category' => $page_category]) }}
+                        {{ __('wiki-page-category', ['category' => $page_category]) }}
                     </span>
 
                     <span class="page-info-sep">|</span>
@@ -91,7 +91,7 @@
 
                 @isset($page_revision)
                     <span id="page_info_revision">
-                        {{ __('wiki.page.REVISION', ['revision' => $page_revision]) }}
+                        {{ __('wiki-page-revision', ['revision' => $page_revision]) }}
                     </span>
 
                     <span class="page-info-sep">|</span>
@@ -104,7 +104,7 @@
                         $days_ago = floor((time() - $ts) / (60 * 60 * 24));
                     @endphp
                     <span id="page_info_last_edit">
-                        {{ __('wiki.page.LAST_EDIT', [
+                        {{ __('wiki-page-last-edit', [
                             'date' => $date_formatted,
                             'days' => $days_ago,
                         ]) }}
@@ -116,7 +116,7 @@
         <hr>
 
         @if (isset($page_tags) && count($page_tags) > 0)
-            <div id="page_tags" aria-label="{{ __('wiki.page.aria.TAGS') }}">
+            <div id="page_tags" aria-label="{{ __('tags') }}">
                 <ul>
                     @foreach($page_tags as $tag)
                         <li class="page-tag">


### PR DESCRIPTION
This PR updates all of the `__()` calls to use the new message IDs in our Fluent system.