### PR TITLE
Fix docker package name

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,6 @@ You will need Docker installed and running:
       <p><pre>$ dockerd</pre></p>
     </td>
     <td>
-      <p><pre># apt install docker</pre></p>
       <p>Install <a href="https://docs.docker.com/docker-for-windows/install-windows-home">Docker Desktop</a>, which you'll be using as the Docker daemon, and leave it running in the background.</p>
       <p>If you have set <code>appendWindowsPath=false</code> in your WSL config, then you may hit an error along the lines of <code>"docker-credential-desktop.exe": executable file not found in $PATH</code>. In this case you should either add <code>/mnt/c/Program\ Files/Docker/Docker/resources/bin</code> to your PATH, or <a href="https://github.com/rossjrw/dotfiles/blob/3c5445abb138b735cc3caf61f070c9125fa87d2f/.profile#L28">create a symlink</a> in a directory that is in your PATH already.</p>
     </td>

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ You will need Docker installed and running:
   <thead><tr><th>Ubuntu / Ubuntu VM</th><th>Windows via WSL2</th></tr></thead>
   <tbody valign="top"><tr>
     <td>
-      <p><pre># apt install docker</pre></p>
+      <p><pre># apt install docker.io</pre></p>
       <p>Start the Docker daemon in another terminal, and leave it running in the background:</p>
       <p><pre>$ dockerd</pre></p>
     </td>


### PR DESCRIPTION
The `docker` package on Debian derived distros is an old weird desktop dock bar people don't use.

h/t @MajorRaccoon for noticing the issue in our docs