### PR TITLE
Add Docker Compose version to helper

### DIFF
--- a/install/local/dev/docker-compose.dev.yaml
+++ b/install/local/dev/docker-compose.dev.yaml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   php-fpm:
     volumes:


### PR DESCRIPTION
The lack of an explicit Docker Compose version causes issues if the default compose file version is different, as there will be a version mismatch.