### PR TITLE
Add CLI commands utility

### DIFF
--- a/web/scripts/dev/containers.ts
+++ b/web/scripts/dev/containers.ts
@@ -21,7 +21,7 @@ export class Containers {
   async close() {
     if (this.stopped) return
     this.stopped = true
-    await this.stoplogging()
+    await this.stopLogging()
     await compose("stop")
   }
 
@@ -32,7 +32,7 @@ export class Containers {
     this.logger.stderr?.on("data", this.log)
   }
 
-  async stoplogging() {
+  async stopLogging() {
     if (!this.logger) return
     this.logger.stdout?.off("data", this.log)
     this.logger.stderr?.off("data", this.log)
@@ -50,11 +50,19 @@ export class Containers {
 
   static async services() {
     const out = await compose("ps --services", false, false)
-    return out.toString().split("\n")
+    return out.split("\n").filter(Boolean).sort()
   }
 
   static async isRunning() {
     const out = await compose("top", false, false)
     return out.length !== 0
+  }
+
+  async buildService(service: string) {
+    await compose(`build ${service}`)
+  }
+
+  async restartService(service: string) {
+    await compose(`restart ${service}`)
   }
 }

--- a/web/scripts/dev/terminal.ts
+++ b/web/scripts/dev/terminal.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { info, rl } from "../pretty-logs"
+
+const _log = console.log
+
+export type CommandFunction = (...args: (string | undefined)[]) => void | Promise<void>
+
+export class Terminal {
+  commands = new Map<string, CommandFunction>()
+
+  busy = false
+
+  constructor() {
+    this.log = this.log.bind(this)
+    this.handle = this.handle.bind(this)
+    console.log = this.log
+    rl.on("line", this.handle)
+
+    this.addCommand("help", () => {
+      info("Available commands:")
+      for (const name of this.commands.keys()) {
+        console.log(`  ${name}`)
+      }
+    })
+  }
+
+  log(...args: any[]) {
+    rl.pause()
+    process.stdout.clearLine(-1)
+    process.stdout.cursorTo(0)
+    _log(...args)
+    if (!this.busy) rl.prompt(true)
+  }
+
+  addCommand(name: string, fn: CommandFunction) {
+    this.commands.set(name, fn)
+  }
+
+  async handle(line: string) {
+    const args = line.split(/\s+/)
+    const command = args.shift()
+    const fn = this.commands.get(command!)
+    if (fn) {
+      this.busy = true
+      await fn(...args)
+      this.busy = false
+      rl.prompt(true)
+    } else {
+      console.log(`Unknown command: ${command}`)
+    }
+  }
+
+  close() {
+    console.log = _log
+    rl.off("line", this.handle)
+    this.busy = false
+  }
+}

--- a/web/scripts/dev/tsconfig.json
+++ b/web/scripts/dev/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "lib": ["ESNext"]
   },
   "extends": "../../tsconfig.json",

--- a/web/scripts/pretty-logs.js
+++ b/web/scripts/pretty-logs.js
@@ -8,6 +8,11 @@ const pc = require("picocolors")
 /** @type Set<import("child_process").ChildProcessWithoutNullStreams> */
 const processes = new Set()
 
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+})
+
 function linebreak(count = 1) {
   for (let i = 0; i < count; i++) console.log("")
 }
@@ -84,19 +89,7 @@ function shellAsync(command, pipe = true) {
 }
 
 function question(question) {
-  return new Promise((resolve, reject) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
-    })
-
-    rl.question(pc.magenta(question), answer => {
-      // breaks using readline for anything else
-      // so we'll just leave the interface alone (technically a memory leak)
-      // rl.close()
-      resolve(answer)
-    })
-  })
+  return new Promise(resolve => rl.question(pc.magenta(question), resolve))
 }
 
 function answerYesOrNo(answer, def = false) {
@@ -109,6 +102,7 @@ function answerYesOrNo(answer, def = false) {
 module.exports = {
   pc,
   processes,
+  rl,
   linebreak,
   separator,
   section,


### PR DESCRIPTION
This PR adds a feature to the `pnpm dev` script that lets you input certain commands.

![image](https://user-images.githubusercontent.com/34875062/149232411-78e43aeb-91f2-446b-ac3c-9ee838b1f69a.png)

The commands are simple to add and are already very useful, e.g. turning off Vite and then rebuilding `nginx` so that you get a view of the production assets.