### PR TITLE
Use replacement script instead of artisan key generation

### DIFF
--- a/install/files/php-fpm/setup-key.sh
+++ b/install/files/php-fpm/setup-key.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -eux
 
-sed -i "s/APP_KEY=/APP_KEY=base64:$(head -c 32 /dev/random | base64)/" .env
+key="$(head -c 32 /dev/random | base64 | sed -e 's/[\/&]/\\&/g')"
+sed -i "s/APP_KEY=/APP_KEY=base64:/" .env

--- a/install/files/php-fpm/setup-key.sh
+++ b/install/files/php-fpm/setup-key.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eux
+
+sed -i "s/APP_KEY=/APP_KEY=base64:$(head -c 32 /dev/random | base64)/" .env

--- a/install/files/php-fpm/setup-php-create.sh
+++ b/install/files/php-fpm/setup-php-create.sh
@@ -5,7 +5,7 @@ mkdir -p /var/www/wikijump/web
 cd /var/www/wikijump/web
 
 mkdir -p \
-	bootstrap \
+	bootstrap/cache \
 	conf \
 	logs \
 	public/files--built \

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -96,8 +96,8 @@ COPY --from=rust /src/ftml/target/release/libftml.so /usr/local/lib/libftml.so
 COPY --from=rust /usr/local/cargo/bin/mrml /usr/local/bin/mrml
 
 # PHP configuration preparation
-RUN php artisan key:generate
-RUN php artisan config:cache
+# Don't cache config for local
+RUN /src/setup-key.sh
 RUN /src/setup-misc.sh
 
 # Install runner


### PR DESCRIPTION
This replaces the `php artisan key:generate` command from the local container build only, to avoid issues with the PHP environment being incorrect and preventing a run of the key generation command. Since all this does is generate some random base64, we don't actually need to load the entire PHP package ecosystem to do this. This avoids an issue where the build will fail if an unrelated issue in the PHP environment prevents it from loading, which is already a difficult class of issue to debug. (The `php artisan config:cache` command is also removed because it is not required and would also have the same PHP issues).