### PR TITLE
Revert "Use replacement script instead of artisan key generation"

### DIFF
--- a/install/files/php-fpm/setup-key.sh
+++ b/install/files/php-fpm/setup-key.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -eux
-
-key="$(head -c 32 /dev/random | base64 | sed -e 's/[\/&]/\\&/g')"
-sed -i "s/APP_KEY=/APP_KEY=base64:/" .env

--- a/install/files/php-fpm/setup-php-create.sh
+++ b/install/files/php-fpm/setup-php-create.sh
@@ -5,7 +5,7 @@ mkdir -p /var/www/wikijump/web
 cd /var/www/wikijump/web
 
 mkdir -p \
-	bootstrap \
+	bootstrap/cache \
 	conf \
 	logs \
 	public/files--built \

--- a/install/files/php-fpm/setup-php-create.sh
+++ b/install/files/php-fpm/setup-php-create.sh
@@ -5,7 +5,7 @@ mkdir -p /var/www/wikijump/web
 cd /var/www/wikijump/web
 
 mkdir -p \
-	bootstrap/cache \
+	bootstrap \
 	conf \
 	logs \
 	public/files--built \

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -96,8 +96,8 @@ COPY --from=rust /src/ftml/target/release/libftml.so /usr/local/lib/libftml.so
 COPY --from=rust /usr/local/cargo/bin/mrml /usr/local/bin/mrml
 
 # PHP configuration preparation
-# Don't cache config for local
-RUN /src/setup-key.sh
+RUN php artisan key:generate
+RUN php artisan config:cache
 RUN /src/setup-misc.sh
 
 # Install runner


### PR DESCRIPTION
Reverts scpwiki/wikijump#759

The `APP_KEY` is more than just random bytes, it's formatted in some way to also represent the algorithm. Because it's more than trivial, we should restore the original PHP scripts and figure out dependency issues directly instead.