### PR TITLE
[terraform] Make API ratelimit secret available in container

### DIFF
--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -26,7 +26,10 @@ module "api" {
   links = ["database:database"]
 
   secrets = [
-    # TODO: Add API ratelimit bypass secret here and in php-fpm
+    {
+      name      = "RATE_LIMIT_SECRET"
+      valueFrom = var.api_ratelimit_secret
+    },
     {
       name      = "WIKIJUMP_DB_HOST"
       valueFrom = aws_ssm_parameter.DB_HOST.name
@@ -186,6 +189,10 @@ module "php-fpm" {
   links = ["api:api", "cache:cache", "database:database"]
 
   secrets = [
+    {
+      name      = "WIKIJUMP_API_RATE_LIMIT_SECRET"
+      valueFrom = var.api_ratelimit_secret
+    },
     {
       name      = "WIKIJUMP_URL_DOMAIN"
       valueFrom = aws_ssm_parameter.URL_DOMAIN.name

--- a/install/aws/dev/terraform/deploy/variables.tf
+++ b/install/aws/dev/terraform/deploy/variables.tf
@@ -143,6 +143,11 @@ variable "route53_secret_key" {
   sensitive = true
 }
 
+variable "api_ratelimit_secret" {
+  type      = string
+  sensitive = true
+}
+
 variable "datadog_api_key" {
   type      = string
   sensitive = true

--- a/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
+++ b/install/aws/dev/terraform/deploy/wikijump.auto.tfvars
@@ -53,7 +53,8 @@ redeploy_ecs_on_tf_apply = true
 # unique credentials, we store some vars in terraform cloud as terraform vars
 # there. Generally speaking some sort of secret store is better than putting
 # sensitive keys in a .tfvars file. You need these vars to plan or deploy.
-# cf_auth_token      = "12345678-abcd-1234-5678-1234567890ab"
-# route53_access_key = "AEXAMPLEAPIKEY1234"
-# route53_secret_key = "example123/abcdefghijklmnopqrstuvwxyzABC"
-# datadog_api_key    = "1234567890abcdef1234567890abcdef"
+# cf_auth_token        = "12345678-abcd-1234-5678-1234567890ab"
+# route53_access_key   = "AEXAMPLEAPIKEY1234"
+# route53_secret_key   = "example123/abcdefghijklmnopqrstuvwxyzABC"
+# datadog_api_key      = "1234567890abcdef1234567890abcdef"
+# api_ratelimit_secret = "1234567890abdefghijklmnopqrstuvwxyz1234567890abdefghijklmnopqrst"


### PR DESCRIPTION
The `api_ratelimit_secret` secret has been added to Terraform Cloud, so now we can make this value available in-container as an environment variable.