### PR TITLE
[terraform] Connect php-fpm container to nginx

### DIFF
--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -183,7 +183,7 @@ module "php-fpm" {
     }
   ]
 
-  links = ["api:api", "cache:cache", "database:database"]
+  links = ["api:api", "cache:cache", "database:database", "nginx:nginx"]
 
   secrets = [
     {


### PR DESCRIPTION
The PHP-FPM container needs the ability to connect to nginx container so it can load the JS build manifest file. Locally this works but in our deployment it does not. Hopefully this change is sufficient to permit this.