### PR TITLE
Update Rust dependencies, including ftml

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -686,7 +686,7 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -970,7 +970,7 @@ dependencies = [
  "async-std",
  "built",
  "chrono",
- "clap 3.1.2",
+ "clap 3.1.6",
  "color-backtrace",
  "crossfire",
  "cuid",
@@ -989,11 +989,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.2",
- "slog",
  "sqlx",
  "str-macro",
- "strum 0.24.0",
- "strum_macros 0.24.0",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tide",
  "unic-langid",
@@ -1075,18 +1074,18 @@ checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "enum-map"
-version = "1.1.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e893a7ba6116821058dec84a6fb14fb2a97cd8ce5fd0f85d5a4e760ecd7329d9"
+checksum = "82605a2a3d13a9661b07ba27f39d00496aa347c9c236b1a3b8201c1b6d761408"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
+checksum = "a63b7a0ddec6f38dcec5e36257750b7a8fcaf4227e12ceb306e341d63634da05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1186,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.12.6"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461900e8dbb28edab3c6f604da0a975f33c8e696fe4809fdf3434a0194b58f3c"
+checksum = "1a1ae1a80460217f73f813485a790efb0267eec898d4dd094a5fba3ed990a816"
 dependencies = [
  "built",
  "cbindgen",
@@ -1199,8 +1198,9 @@ dependencies = [
  "getrandom 0.2.5",
  "latex2mathml",
  "lazy_static",
+ "log",
  "maplit",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pest",
  "pest_derive",
  "rand 0.8.5",
@@ -1210,11 +1210,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "slog",
  "slog-bunyan",
  "str-macro",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "strum",
+ "strum_macros",
  "tinyvec",
  "unicase",
  "void",
@@ -1721,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "df2bf61678a0a521c3f7daf815d2e6717d85a272a7dcd02c9768272b32bd1e2a"
 dependencies = [
  "cc",
  "libc",
@@ -1908,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -2286,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2958,28 +2957,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-
-[[package]]
-name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "strum_macros"
@@ -3033,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -3051,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -23,7 +23,7 @@ crossfire = "0.1"
 cuid = "1"
 dotenv = "0.15"
 fluent = "0.16"
-ftml = { version = "1.12", features = ["mathml"] }
+ftml = { version = "1.13", features = ["mathml"] }
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 governor = "0.4"
 hex = "0.4"
@@ -36,7 +36,6 @@ sea-orm = { version = "0.6", features = ["sqlx-postgres", "runtime-async-std-rus
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-slog = "2.7"
 sqlx = "0.5"
 str-macro = "1"
 strum = "0.24"

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 rust-version = "1.56.0"

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct ServiceContext<'txn> {
     state: ApiServerState,
-    slog: slog::Logger,
     transaction: &'txn DatabaseTransaction,
 }
 
@@ -41,8 +40,6 @@ impl<'txn> ServiceContext<'txn> {
     ) -> Self {
         ServiceContext {
             state: Arc::clone(state),
-            // TODO: hook slog into tide's logger
-            slog: slog::Logger::root(slog::Discard, slog::o!()),
             transaction,
         }
     }
@@ -52,11 +49,6 @@ impl<'txn> ServiceContext<'txn> {
     #[allow(dead_code)] // temp
     pub fn state(&self) -> &ApiServerState {
         &self.state
-    }
-
-    #[inline]
-    pub fn slog(&self) -> &slog::Logger {
-        &self.slog
     }
 
     #[inline]

--- a/deepwell/src/services/render/service.rs
+++ b/deepwell/src/services/render/service.rs
@@ -35,11 +35,11 @@ impl RenderService {
 
         // Run ftml to parse and render
         // TODO include
-        ftml::preprocess(ctx.slog(), &mut wikitext);
-        let tokens = ftml::tokenize(ctx.slog(), &wikitext);
-        let result = ftml::parse(ctx.slog(), &tokens, page_info, settings);
+        ftml::preprocess(&mut wikitext);
+        let tokens = ftml::tokenize(&wikitext);
+        let result = ftml::parse(&tokens, page_info, settings);
         let (tree, warnings) = result.into();
-        let html_output = HtmlRender.render(ctx.slog(), &tree, page_info, settings);
+        let html_output = HtmlRender.render(&tree, page_info, settings);
 
         // Insert compiled HTML into text table
         let compiled_hash = TextService::create(ctx, html_output.body.clone()).await?;

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "df2bf61678a0a521c3f7daf815d2e6717d85a272a7dcd02c9768272b32bd1e2a"
 dependencies = [
  "cc",
  "libc",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"


### PR DESCRIPTION
In addition to general dependency upgrades, this PR also upgrades DEEPWELL to use the latest ftml, which has `slog` removed.