### PR TITLE
[WJ-964] Implement compatibility IDs

### DIFF
--- a/docs/compatibility-ids.md
+++ b/docs/compatibility-ids.md
@@ -1,0 +1,25 @@
+## Compatibility IDs
+
+Backwards compatibility with Wikidot is an important goal of the Wikijump project. In order to allow imported data from Wikidot to be usable in Wikijump, the project utilizes "compatibility IDs" in order to ensure that any ID valid on Wikidot is also valid on Wikijump (if the relevant data is imported).
+
+This is important because Wikidot exposes IDs in several places, such as forum URLs, which we need to preserve in some way in order for all those legacy links to remain valid.
+
+The approach used here is to set the starting ID value to be higher than Wikidot in production will ever conceivably reach (at least before Wikijump is deployed). We did this by finding a recent ID value for that kind of object, and increasing that increases its most significant digit by at least one value. For the most populous objects (pages and revisions), the produced value is higher than Wikidot could ever achieve, since they use only 32-bit integers for IDs.
+
+```
+- Page           -- 3000000000 (sample       1331370625)
+- Revision       -- 3000000000 (sample       1388179085)
+- Forum Post     --    7000000 (sample          5174477)
+- Forum Thread   --   30000000 (sample         14447612)
+- Forum Category --    9000000 (sample          7412040)
+- User           --   10000000 (sample          7840760)
+```
+
+And as a point of comparison, these are the maximum values for 32-bit and 64-bit signed integers:
+
+```
+- i32 max        --            (max          2147483647)
+- i64 max        --            (max 9223372036854775807)
+```
+
+This change was implemented in [WJ-964](https://scuttle.atlassian.net/browse/WJ-964).

--- a/web/database/migrations/2021_04_22_013230_create_users_table.php
+++ b/web/database/migrations/2021_04_22_013230_create_users_table.php
@@ -48,7 +48,7 @@ class CreateUsersTable extends Migration
 
         // Set compatibility IDs
         // The initial users should have early IDs due to their special status.
-        DB::statement('ALTER SEQUENCE users_id_seq START WITH 10000000');
+        DB::statement('ALTER SEQUENCE users_id_seq RESTART WITH 10000000');
     }
 
     /**

--- a/web/database/migrations/2021_04_22_013230_create_users_table.php
+++ b/web/database/migrations/2021_04_22_013230_create_users_table.php
@@ -43,13 +43,12 @@ class CreateUsersTable extends Migration
             $table->softDeletes();
         });
 
-        // Set compatibility IDs
-        DB::statement('ALTER SEQUENCE users_id_seq START WITH 10000000');
-
         // Seed initial users
-        Artisan::call('db:seed', [
-            '--class' => UserSeeder::class,
-        ]);
+        Artisan::call('db:seed', ['--class' => UserSeeder::class]);
+
+        // Set compatibility IDs
+        // The initial users should have early IDs due to their special status.
+        DB::statement('ALTER SEQUENCE users_id_seq START WITH 10000000');
     }
 
     /**

--- a/web/database/migrations/2021_04_22_013230_create_users_table.php
+++ b/web/database/migrations/2021_04_22_013230_create_users_table.php
@@ -43,6 +43,10 @@ class CreateUsersTable extends Migration
             $table->softDeletes();
         });
 
+        // Set compatibility IDs
+        DB::statement('ALTER SEQUENCE users_id_seq START WITH 10000000');
+
+        // Seed initial users
         Artisan::call('db:seed', [
             '--class' => UserSeeder::class,
         ]);

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -189,6 +189,10 @@ class DeepwellPage extends Migration
         DB::statement('ALTER TABLE page_rate_vote ADD CONSTRAINT page_rate_vote_page_id_fkey FOREIGN KEY (page_id) REFERENCES page(page_id)');
         DB::statement('ALTER TABLE watched_page ADD CONSTRAINT watched_page_page_id_fkey FOREIGN KEY (page_id) REFERENCES page(page_id)');
 
+        // Set compatibility IDs
+        DB::statement('ALTER SEQUENCE page_page_id_seq              START WITH 3000000000');
+        DB::statement('ALTER SEQUENCE page_revision_revision_id_seq START WITH 3000000000');
+
         // Seed initial pages
         Artisan::call('db:seed', [
             '--class' => PageSeeder::class,

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -190,8 +190,8 @@ class DeepwellPage extends Migration
         DB::statement('ALTER TABLE watched_page ADD CONSTRAINT watched_page_page_id_fkey FOREIGN KEY (page_id) REFERENCES page(page_id)');
 
         // Set compatibility IDs
-        DB::statement('ALTER SEQUENCE page_page_id_seq              START WITH 3000000000');
-        DB::statement('ALTER SEQUENCE page_revision_revision_id_seq START WITH 3000000000');
+        DB::statement('ALTER SEQUENCE page_page_id_seq              RESTART WITH 3000000000');
+        DB::statement('ALTER SEQUENCE page_revision_revision_id_seq RESTART WITH 3000000000');
 
         // Seed initial pages
         Artisan::call('db:seed', ['--class' => PageSeeder::class]);

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -194,9 +194,7 @@ class DeepwellPage extends Migration
         DB::statement('ALTER SEQUENCE page_revision_revision_id_seq START WITH 3000000000');
 
         // Seed initial pages
-        Artisan::call('db:seed', [
-            '--class' => PageSeeder::class,
-        ]);
+        Artisan::call('db:seed', ['--class' => PageSeeder::class]);
     }
 
     /**

--- a/web/database/migrations/2022_03_08_121219_legacy_compatibility_ids.php
+++ b/web/database/migrations/2022_03_08_121219_legacy_compatibility_ids.php
@@ -15,9 +15,9 @@ class LegacyCompatibilityIds extends Migration
     public function up()
     {
         // Temporary compatibility IDs while these tables are still in Ozone
-        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         START WITH  7000000');
-        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     START WITH 30000000');
-        DB::statement('ALTER SEQUENCE forum_category_category_id_seq START WITH  9000000');
+        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         RESTART WITH  7000000');
+        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     RESTART WITH 30000000');
+        DB::statement('ALTER SEQUENCE forum_category_category_id_seq RESTART WITH  9000000');
     }
 
     /**
@@ -27,8 +27,8 @@ class LegacyCompatibilityIds extends Migration
      */
     public function down()
     {
-        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         START WITH 1');
-        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     START WITH 1');
-        DB::statement('ALTER SEQUENCE forum_category_category_id_seq START WITH 1');
+        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         RESTART WITH 1');
+        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     RESTART WITH 1');
+        DB::statement('ALTER SEQUENCE forum_category_category_id_seq RESTART WITH 1');
     }
 }

--- a/web/database/migrations/2022_03_08_121219_legacy_compatibility_ids.php
+++ b/web/database/migrations/2022_03_08_121219_legacy_compatibility_ids.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class LegacyCompatibilityIds extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Temporary compatibility IDs while these tables are still in Ozone
+        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         START WITH  7000000');
+        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     START WITH 30000000');
+        DB::statement('ALTER SEQUENCE forum_category_category_id_seq START WITH  9000000');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER SEQUENCE forum_post_post_id_seq         START WITH 1');
+        DB::statement('ALTER SEQUENCE forum_thread_thread_id_seq     START WITH 1');
+        DB::statement('ALTER SEQUENCE forum_category_category_id_seq START WITH 1');
+    }
+}

--- a/web/database/seeders/PageSeeder.php
+++ b/web/database/seeders/PageSeeder.php
@@ -700,43 +700,31 @@ EOF
         );
 
         // Add links and connections
-        $this->addExternalLinks(
-            $www_start_page_id,
-            [
-                'https://github.com/scpwiki/wikijump/pulls' => 1,
-                'https://github.com/scpwiki/wikijump' => 1,
-                'https://github.com/scpwiki/wikijump/tree/legacy' => 1,
-                'https://scuttle.atlassian.net/browse/WJ' => 2,
-                'https://scuttle.atlassian.net/wiki/spaces/WD/overview' => 1,
-                'https://creativecommons.org/licenses/by-sa/4.0/' => 1,
-                'https://www.wikidot.com/' => 1,
-                'https://wikijump.org' => 1,
-                'https://scpwiki.com/forum/c-3335628/general-information' => 1,
-                'https://scpwiki.com/forum/c-3335630/feature-requests' => 1,
-            ],
-        );
-        $this->addExternalLinks(
-            $template_start_page_id,
-            [
-                'https://creativecommons.org/licenses/by-sa/4.0/' => 1,
-                'https://www.wikidot.com/' => 1,
-                'https://wikijump.org' => 1,
-                'https://scpwiki.com/forum/c-3335628/general-information' => 1,
-                'https://scpwiki.com/forum/c-3335630/feature-requests' => 1,
-            ],
-        );
-        $this->addExternalLinks(
-            $www_nav_top_page_id,
-            [
-                'https://wikijump.org' => 1,
-            ],
-        );
-        $this->addExternalLinks(
-            $template_nav_top_page_id,
-            [
-                'https://wikijump.org' => 1,
-            ],
-        );
+        $this->addExternalLinks($www_start_page_id, [
+            'https://github.com/scpwiki/wikijump/pulls' => 1,
+            'https://github.com/scpwiki/wikijump' => 1,
+            'https://github.com/scpwiki/wikijump/tree/legacy' => 1,
+            'https://scuttle.atlassian.net/browse/WJ' => 2,
+            'https://scuttle.atlassian.net/wiki/spaces/WD/overview' => 1,
+            'https://creativecommons.org/licenses/by-sa/4.0/' => 1,
+            'https://www.wikidot.com/' => 1,
+            'https://wikijump.org' => 1,
+            'https://scpwiki.com/forum/c-3335628/general-information' => 1,
+            'https://scpwiki.com/forum/c-3335630/feature-requests' => 1,
+        ]);
+        $this->addExternalLinks($template_start_page_id, [
+            'https://creativecommons.org/licenses/by-sa/4.0/' => 1,
+            'https://www.wikidot.com/' => 1,
+            'https://wikijump.org' => 1,
+            'https://scpwiki.com/forum/c-3335628/general-information' => 1,
+            'https://scpwiki.com/forum/c-3335630/feature-requests' => 1,
+        ]);
+        $this->addExternalLinks($www_nav_top_page_id, [
+            'https://wikijump.org' => 1,
+        ]);
+        $this->addExternalLinks($template_nav_top_page_id, [
+            'https://wikijump.org' => 1,
+        ]);
 
         // NOTE: format is [from_page_id, to_page_id, count]
         $this->addInternalLinks([
@@ -796,7 +784,8 @@ EOF
         return $hash;
     }
 
-    private function addCategory(int $site_id, string $slug): int {
+    private function addCategory(int $site_id, string $slug): int
+    {
         // Add page category
         $category = DB::selectOne(
             "INSERT INTO page_category (
@@ -813,7 +802,9 @@ EOF
 
         $category_id = $category->category_id;
         if (!is_integer($category_id)) {
-            throw new Exception("Returned category ID from insert not an integer: $category_id");
+            throw new Exception(
+                "Returned category ID from insert not an integer: $category_id",
+            );
         }
 
         return $category_id;
@@ -908,7 +899,9 @@ EOF
             // If this happens, the structure of the array is incorrect
             // For instance, they may have forgotten the count value.
             if (!is_string($url) || !is_integer($count)) {
-                throw new Exception("Invalid external link data: url $url, count: $count");
+                throw new Exception(
+                    "Invalid external link data: url $url, count: $count",
+                );
             }
 
             $rows[] = [
@@ -933,7 +926,9 @@ EOF
                 $to_display = var_export($to_page_id, true);
                 $count_display = var_export($count, true);
 
-                throw new Exception("Invalid internal link data, from_page_id $from_display, to_page_id $to_display, count $count_display");
+                throw new Exception(
+                    "Invalid internal link data, from_page_id $from_display, to_page_id $to_display, count $count_display",
+                );
             }
 
             $rows[] = [

--- a/web/database/seeders/PageSeeder.php
+++ b/web/database/seeders/PageSeeder.php
@@ -526,163 +526,106 @@ EOF
 EOF
         );
 
-        DB::table('page_category')->insert([
-            // Main site (www)
-
-            // ID: 1
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 1,
-                'slug' => '_default',
-            ],
-            // ID: 2
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 1,
-                'slug' => 'admin',
-            ],
-            // ID: 3
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 1,
-                'slug' => 'nav',
-            ],
-            // ID: 4
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 1,
-                'slug' => 'platform',
-            ],
-            // ID: 5
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 1,
-                'slug' => 'system',
-            ],
-            // ID: 6
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 2,
-                'slug' => '_default',
-            ],
-
-            // Template site (template-en)
-
-            // ID: 7
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 2,
-                'slug' => 'admin',
-            ],
-            // ID: 8
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 2,
-                'slug' => 'nav',
-            ],
-            // ID: 9
-            [
-                'created_at' => self::TIMESTAMP,
-                'site_id' => 2,
-                'slug' => 'system',
-            ],
-        ]);
+        $www_site_id = 1;
+        $template_site_id = 2;
 
         // Main site (www)
-        $this->addPage(
-            1,
-            1,
-            1,
+        $www_default_category_id = $this->addCategory($www_site_id, '_default');
+        $www_admin_category_id = $this->addCategory($www_site_id, 'admin');
+        $www_nav_category_id = $this->addCategory($www_site_id, 'nav');
+        $www_platform_category_id = $this->addCategory($www_site_id, 'platform');
+        $www_system_category_id = $this->addCategory($www_site_id, 'system');
+
+        // Template site (template-en)
+        $template_default_category_id = $this->addCategory($template_site_id, '_default');
+        $template_admin_category_id = $this->addCategory($template_site_id, 'admin');
+        $template_nav_category_id = $this->addCategory($template_site_id, 'nav');
+        $template_system_category_id = $this->addCategory($template_site_id, 'system');
+
+        // Main site (www)
+        $www_start_page_id = $this->addPage(
+            $www_default_category_id,
+            $www_site_id,
             'start',
             'Welcome to your new Wikijump instance!',
             $www_start_wikitext_hash,
             $www_start_compiled_hash,
         );
-        $this->addPage(
-            2,
-            3,
-            1,
+        $www_nav_side_page_id = $this->addPage(
+            $www_nav_category_id,
+            $www_site_id,
             'nav:side',
             'Sidebar',
             $nav_side_wikitext_hash,
             $nav_side_compiled_hash,
         );
-        $this->addPage(
-            3,
-            3,
-            1,
+        $www_nav_top_page_id = $this->addPage(
+            $www_nav_category_id,
+            $www_site_id,
             'nav:top',
             'Topbar',
             $nav_top_wikitext_hash,
             $nav_top_compiled_hash,
         );
-        $this->addPage(
-            4,
-            4,
-            1,
+        $www_platform_activity_page_id = $this->addPage(
+            $www_platform_category_id,,
+            $www_site_id,
             'platform:activity',
             'Wikijump: Activity across all sites',
             $platform_activity_wikitext_hash,
             $platform_activity_compiled_hash,
         );
-        $this->addPage(
-            5,
-            4,
-            1,
+        $www_platform_sites_page_id = $this->addPage(
+            $www_platform_category_id,
+            $www_site_id,
             'platform:sites',
             'Wikijump: List of all sites',
             $platform_sites_wikitext_hash,
             $platform_sites_compiled_hash,
         );
-        $this->addPage(
-            6,
-            4,
-            1,
+        $www_platform_search_page_id = $this->addPage(
+            $www_platform_category_id,
+            $www_site_id,
             'platform:search',
             'Wikijump: Search all sites',
             $platform_search_wikitext_hash,
             $platform_search_compiled_hash,
         );
-        $this->addPage(
-            7,
-            5,
-            1,
+        $www_system_join_page_id = $this->addPage(
+            $www_system_category_id,
+            $www_site_id,
             'system:join',
             'Join this site',
             $system_join_wikitext_hash,
             $system_join_compiled_hash,
         );
-        $this->addPage(
-            8,
-            5,
-            1,
+        $www_system_members_page_id = $this->addPage(
+            $www_system_category_id,
+            $www_site_id,
             'system:members',
             'Site Members',
             $system_members_wikitext_hash,
             $system_members_compiled_hash,
         );
-        $this->addPage(
-            9,
-            5,
-            1,
+        $www_system_recent_changes_page_id = $this->addPage(
+            $www_system_category_id,
+            $www_site_id,
             'system:recent-changes',
             'Recent Changes',
             $system_recent_changes_wikitext_hash,
             $system_recent_changes_compiled_hash,
         );
-        $this->addPage(
-            10,
-            5,
-            1,
+        $www_system_page_tags_page_id = $this->addPage(
+            $www_system_category_id,
+            $www_site_id,
             'system:page-tags',
             'Page Tags',
             $system_page_tags_wikitext_hash,
             $system_page_tags_compiled_hash,
         );
-        $this->addPage(
-            11,
-            2,
-            1,
+        $www_admin_manage_page_id = $this->addPage(
+            $www_admin_category_id,
+            $www_site_id,
             'admin:manage',
             'Site Manager',
             $admin_manage_wikitext_hash,
@@ -690,73 +633,65 @@ EOF
         );
 
         // Template site (template-en)
-        $this->addPage(
-            12,
-            6,
-            2,
+        $template_start_page_id = $this->addPage(
+            $template_default_category_id,
+            $template_site_id,
             'start',
             "You've just created a new Wikijump wiki!",
             $system_join_wikitext_hash,
             $system_join_compiled_hash,
         );
-        $this->addPage(
-            13,
-            8,
-            2,
+        $template_nav_side_page_id = $this->addPage(
+            $template_nav_category_id,
+            $template_site_id,
             'nav:side',
             'Sidebar',
             $nav_side_wikitext_hash,
             $nav_side_compiled_hash,
         );
-        $this->addPage(
-            14,
-            8,
-            2,
+        $template_nav_top_page_id = $this->addPage(
+            $template_nav_category_id,
+            $template_site_id,
             'nav:top',
             'Topbar',
             $nav_top_wikitext_hash,
             $nav_top_compiled_hash,
         );
-        $this->addPage(
-            15,
-            9,
-            2,
+        $template_system_join_page_id = $this->addPage(
+            $template_system_category_id,
+            $template_site_id,
             'system:join',
             'Join this site',
             $system_join_wikitext_hash,
             $system_join_compiled_hash,
         );
-        $this->addPage(
-            16,
-            9,
-            2,
+        $template_system_members_page_id = $this->addPage(
+            $template_system_category_id,
+            $template_site_id,
             'system:members',
             'Site Members',
             $system_members_wikitext_hash,
             $system_members_compiled_hash,
         );
-        $this->addPage(
-            17,
-            9,
-            2,
+        $template_system_recent_changes_page_id = $this->addPage(
+            $template_system_category_id,
+            $template_site_id,
             'system:recent-changes',
             'Recent Changes',
             $system_recent_changes_wikitext_hash,
             $system_recent_changes_compiled_hash,
         );
-        $this->addPage(
-            18,
-            9,
-            2,
+        $template_system_page_tags_page_id = $this->addPage(
+            $template_system_category_id,
+            $template_site_id,
             'system:page-tags',
             'Page Tags',
             $system_page_tags_wikitext_hash,
             $system_page_tags_compiled_hash,
         );
-        $this->addPage(
-            19,
-            7,
-            2,
+        $template_admin_manage_page_id = $this->addPage(
+            $template_admin_category_id,
+            $template_site_id,
             'admin:manage',
             'Site Manager',
             $admin_manage_wikitext_hash,
@@ -765,7 +700,7 @@ EOF
 
         // Add links and connections
         $this->addExternalLinks(
-            1, // www start
+            $www_start_page_id,
             [
                 'https://github.com/scpwiki/wikijump/pulls' => 1,
                 'https://github.com/scpwiki/wikijump' => 1,
@@ -780,7 +715,7 @@ EOF
             ],
         );
         $this->addExternalLinks(
-            12, // template-en start
+            $template_start_page_id,
             [
                 'https://creativecommons.org/licenses/by-sa/4.0/' => 1,
                 'https://www.wikidot.com/' => 1,
@@ -790,57 +725,52 @@ EOF
             ],
         );
         $this->addExternalLinks(
-            3, // www nav:top
+            $www_nav_top_page_id,
             [
                 'https://wikijump.org' => 1,
             ],
         );
         $this->addExternalLinks(
-            14, // www nav:top
+            $template_nav_top_page_id,
             [
                 'https://wikijump.org' => 1,
             ],
         );
 
         // NOTE: format is [from_page_id, to_page_id, count]
-
         $this->addInternalLinks([
-            // www start
-            [1, 11, 2], // admin:manage
-            [1, 2, 1], // nav:side
-            [1, 3, 1], // nav:top
+            [$www_start_page_id, $www_admin_manage_page_id, 2],
+            [$www_start_page_id, $www_nav_side_page_id, 1],
+            [$www_start_page_id, $www_nav_top_page_id, 1],
 
-            // template start
-            [12, 19, 2], // admin:manage
-            [12, 13, 1], // nav:side
-            [12, 14, 1], // nav:top
+            [$template_start_page_id, $template_admin_manage_page_id, 2],
+            [$template_start_page_id, $template_nav_side_page_id, 1],
+            [$template_start_page_id, $template_nav_top_page_id, 1],
 
-            // both system:join
-            [7, 11, 1], // admin:manage
-            [15, 11, 1],
+            [$www_system_join_page_id, $www_admin_manage_page_id, 1],
+            [$template_system_join_page_id, $template_admin_manage_page_id, 1],
 
-            // both nav:side
-            [2, 1, 1], // start
-            [2, 4, 1], // platform:activity
-            [2, 5, 1], // platform:sites
-            [2, 6, 1], // platform:search
-            [2, 7, 1], // system:join
-            [2, 8, 1], // system:members
-            [2, 9, 1], // system:recent-changes
-            [2, 10, 1], // system:page-tags
-            [2, 11, 1], // admin:manage
-            [2, 2, 1], // self
+            [$www_nav_side_page_id, $www_start_page_id, 1],
+            [$www_nav_side_page_id, $www_platform_activity_page_id, 1],
+            [$www_nav_side_page_id, $www_platform_sites_page_id, 1],
+            [$www_nav_side_page_id, $www_platform_search_page_id, 1],
+            [$www_nav_side_page_id, $www_system_join_page_id, 1],
+            [$www_nav_side_page_id, $www_system_members_page_id, 1],
+            [$www_nav_side_page_id, $www_system_recent_changes_page_id, 1],
+            [$www_nav_side_page_id, $www_system_page_tags_page_id, 1],
+            [$www_nav_side_page_id, $www_admin_manage_page_id, 1],
+            [$www_nav_side_page_id, $www_nav_side_page_id, 1],
 
-            [13, 12, 1], // start
-            [13, 4, 1], // platform:activity
-            [13, 5, 1], // platform:sites
-            [13, 6, 1], // platform:search
-            [13, 15, 1], // system:join
-            [13, 16, 1], // system:members
-            [13, 17, 1], // system:recent-changes
-            [13, 18, 1], // system:page-tags
-            [13, 19, 1], // admin:manage
-            [13, 13, 1], // self
+            [$template_nav_side_page_id, $template_start_page_id, 1],
+            [$template_nav_side_page_id, $template_platform_activity_page_id, 1],
+            [$template_nav_side_page_id, $template_platform_sites_page_id, 1],
+            [$template_nav_side_page_id, $template_platform_search_page_id, 1],
+            [$template_nav_side_page_id, $template_system_join_page_id, 1],
+            [$template_nav_side_page_id, $template_system_members_page_id, 1],
+            [$template_nav_side_page_id, $template_system_recent_changes_page_id, 1],
+            [$template_nav_side_page_id, $template_system_page_tags_page_id, 1],
+            [$template_nav_side_page_id, $template_admin_manage_page_id, 1],
+            [$template_nav_side_page_id, $template_nav_side_page_id, 1],
         ]);
     }
 
@@ -868,8 +798,24 @@ EOF
         return $hash;
     }
 
+    private function addCategory(int $site_id, string $slug): int {
+        // Add page category
+        $category = DB::selectOne(
+            "INSERT INTO page_category (
+                created_at,
+                site_id,
+                slug
+            ) VALUES (
+                ?,
+                ?,
+                ?
+            ) RETURNING category_id",
+            [self::TIMESTAMP, $site_id, $slug],
+
+        return $category->category_id;
+    }
+
     private function addPage(
-        int $page_id,
         int $category_id,
         int $site_id,
         string $slug,
@@ -877,12 +823,9 @@ EOF
         string $wikitext_hash,
         string $compiled_hash,
         int $revision_number = 0
-    ): void {
-        // NOTE: Assumes the $page_id passed in is the
-        //       next one generated when inserting into page.
-
+    ): int {
         // Add page
-        DB::insert(
+        $page = DB::selectOne(
             "INSERT INTO page (
                 created_at,
                 site_id,
@@ -893,7 +836,7 @@ EOF
                 ?,
                 ?,
                 ?
-            )",
+            ) RETURNING page_id",
             [self::TIMESTAMP, $site_id, $category_id, $slug],
         );
 
@@ -944,6 +887,8 @@ EOF
                 $slug,
             ],
         );
+
+        return $page->page_id;
     }
 
     private function addExternalLinks(int $page_id, array $urls): void

--- a/web/database/seeders/UserSeeder.php
+++ b/web/database/seeders/UserSeeder.php
@@ -26,7 +26,7 @@ class UserSeeder extends Seeder
     {
         DB::table('users')->insert([
             [
-                // ID 1
+                'id' => 1,
                 'username' => 'Administrator',
                 'unix_name' => WDStringUtils::toUnixName('admin'),
                 'password' => Hash::make(env('ADMIN_INITIAL_PASSWORD', 'admin1')),
@@ -37,7 +37,7 @@ class UserSeeder extends Seeder
                 'karma_level' => 2,
             ],
             [
-                // ID 2
+                'id' => 2,
                 'username' => 'Automatic',
                 'unix_name' => WDStringUtils::toUnixName('Automatic'),
                 'password' => Hash::make(bin2hex(random_bytes(32))),
@@ -48,7 +48,7 @@ class UserSeeder extends Seeder
                 'karma_level' => 0,
             ],
             [
-                // ID 3
+                'id' => 3,
                 'username' => 'Anonymous',
                 'unix_name' => WDStringUtils::toUnixName('Anonymous'),
                 'password' => Hash::make(bin2hex(random_bytes(32))),
@@ -59,9 +59,10 @@ class UserSeeder extends Seeder
                 'karma_level' => 0,
             ],
         ]);
-        if (env('APP_ENV') != 'production') {
+        if (env('APP_ENV') !== 'production') {
+            // Sample user if not in prod
             DB::table('users')->insert([
-                // ID 4 if not in prod
+                'id' => 4,
                 'username' => 'User',
                 'unix_name' => WDStringUtils::toUnixName('user'),
                 'password' => Hash::make('user1'),

--- a/web/scripts/create-new-migration.sh
+++ b/web/scripts/create-new-migration.sh
@@ -47,10 +47,10 @@ function to_pascal_case() {
 }
 
 function make_migration() {
-	echo "+ $1"
-
 	class_name="$(to_pascal_case "$1")"
 	filename="$(get_filename "$1")"
+
+	echo "+ $filename"
 
 	cat > "$filename" << EOF
 <?php


### PR DESCRIPTION
This PR alters prior migrations. You will need to recreate your local database.

As part of ensuring Wikidot compatibility, we want to ensure that Wikidot IDs can be accepted by Wikijump (if the corresponding data is imported that is). This is important because some legacy URLs include Wikidot IDs in them, and we do not want an ambiguous situation where some ID value could refer to one item in Wikidot and a different item in Wikijump.

Here, we set the starting value to a chosen high value that is beyond what Wikidot in production will likely ever reach. This way we can assign our own IDs without ever worrying about collisions with existing Wikidot items.

The default user IDs have low values since they are special constant users.