### PR TITLE
[WJ-999] Add build check for PHP integer width

### DIFF
--- a/install/aws/dev/docker/php-fpm/Dockerfile
+++ b/install/aws/dev/docker/php-fpm/Dockerfile
@@ -15,7 +15,10 @@ ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 
 # Copy setup scripts
 RUN mkdir /src
-COPY ./install/files/php-fpm/setup*.sh /src/
+COPY ./install/files/php-fpm/*.sh /src/
+
+# Ensure PHP integer width is correct
+RUN /src/check-php-int.sh
 
 # Install system dependencies
 RUN /src/setup-system.sh

--- a/install/aws/prod/docker/php-fpm/Dockerfile
+++ b/install/aws/prod/docker/php-fpm/Dockerfile
@@ -15,7 +15,10 @@ ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 
 # Copy setup scripts
 RUN mkdir /src
-COPY ./install/files/php-fpm/setup*.sh /src/
+COPY ./install/files/php-fpm/*.sh /src/
+
+# Ensure PHP integer width is correct
+RUN /src/check-php-int.sh
 
 # Install system dependencies
 RUN /src/setup-system.sh

--- a/install/files/php-fpm/check-php-int.sh
+++ b/install/files/php-fpm/check-php-int.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+[[ $(php -r 'echo PHP_INT_SIZE;') == 8 ]]

--- a/install/local/dev/php-fpm/Dockerfile
+++ b/install/local/dev/php-fpm/Dockerfile
@@ -16,7 +16,10 @@ ARG WWW_DOMAIN="www.${MAIN_DOMAIN}"
 
 # Copy setup scripts
 RUN mkdir /src
-COPY ./install/files/php-fpm/setup*.sh /src/
+COPY ./install/files/php-fpm/*.sh /src/
+
+# Ensure PHP integer width is correct
+RUN /src/check-php-int.sh
 
 # Install system dependencies
 RUN /src/setup-system.sh


### PR DESCRIPTION
This adds a step in our `php-fpm` Dockerfiles to ensure that `PHP_INT_SIZE` (which gives integer width in bytes) is 8, meaning 64-bit. Because we depend on 64-bit IDs it is important that builds do not succeed in a 32-bit environment.