### PR TITLE
[WJ-997] Removing english in text renderer

### DIFF
--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -174,35 +174,27 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
         Element::Image {
             source,
             link,
-            alignment,
             attributes,
+            ..
         } => {
             let source_url =
                 ctx.handle()
                     .get_image_link(source, ctx.info(), ctx.settings());
 
-            match source_url {
-                Some(url) => {
-                    str_write!(ctx, "Image: {url}");
+            if let Some(url) = source_url {
+                ctx.push_str(&url);
 
-                    if let Some(image) = alignment {
-                        let float = if image.float { " float" } else { "" };
-                        str_write!(ctx, " [Align: {}{}]", image.align.name(), float);
-                    }
-
-                    if let Some(link) = link {
-                        str_write!(ctx, " [Link: {}]", get_url_from_link(ctx, link));
-                    }
-
-                    if let Some(alt_text) = attributes.get().get("alt") {
-                        str_write!(ctx, " [Alt: {alt_text}]");
-                    }
-
-                    if let Some(title) = attributes.get().get("title") {
-                        str_write!(ctx, " [Title: {title}]");
-                    }
+                if let Some(link) = link {
+                    ctx.push_str(&get_url_from_link(ctx, link));
                 }
-                None => str_write!(ctx, "Missing Image"),
+
+                if let Some(alt_text) = attributes.get().get("alt") {
+                    ctx.push_str(alt_text);
+                }
+
+                if let Some(title) = attributes.get().get("title") {
+                    ctx.push_str(title);
+                }
             }
         }
         Element::List { ltype, items, .. } => {
@@ -389,7 +381,7 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
             str_write!(ctx, "[[$ {latex_source} $]]");
         }
         Element::EquationReference(name) => {
-            str_write!(ctx, "[Equation: {name}]");
+            str_write!(ctx, "[{name}]");
         }
         Element::Embed(embed) => {
             ctx.push_str(&embed.direct_url());
@@ -397,7 +389,7 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
         Element::Html { contents } => {
             str_write!(ctx, "```html\n{contents}\n```");
         }
-        Element::Iframe { url, .. } => str_write!(ctx, "[iframe: {url}]"),
+        Element::Iframe { url, .. } => str_write!(ctx, "[{url}]"),
         Element::Include {
             variables,
             elements,

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -185,14 +185,17 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
                 ctx.push_str(&url);
 
                 if let Some(link) = link {
+                    ctx.push(' ');
                     ctx.push_str(&get_url_from_link(ctx, link));
                 }
 
                 if let Some(alt_text) = attributes.get().get("alt") {
+                    ctx.push(' ');
                     ctx.push_str(alt_text);
                 }
 
                 if let Some(title) = attributes.get().get("title") {
+                    ctx.push(' ');
                     ctx.push_str(title);
                 }
             }

--- a/ftml/test/equation-reference-alias.txt
+++ b/ftml/test/equation-reference-alias.txt
@@ -1,1 +1,1 @@
-Apple[Equation: Fruit]
+Apple[Fruit]

--- a/ftml/test/equation-reference-multiple.txt
+++ b/ftml/test/equation-reference-multiple.txt
@@ -1,4 +1,4 @@
-A[Equation: alpha], B[Equation: beta]
+A[alpha], B[beta]
 
-C[Equation: omega]
+C[omega]
 D

--- a/ftml/test/equation-reference.txt
+++ b/ftml/test/equation-reference.txt
@@ -1,1 +1,1 @@
-Apple[Equation: Fruit]
+Apple[Fruit]

--- a/ftml/test/iframe-http.txt
+++ b/ftml/test/iframe-http.txt
@@ -1,1 +1,1 @@
-[iframe: http://scp-wiki.wikidot.com/scp-1000]
+[http://scp-wiki.wikidot.com/scp-1000]

--- a/ftml/test/iframe-style.txt
+++ b/ftml/test/iframe-style.txt
@@ -1,1 +1,1 @@
-[iframe: https://example.com]
+[https://example.com]

--- a/ftml/test/iframe-uppercase.txt
+++ b/ftml/test/iframe-uppercase.txt
@@ -1,1 +1,1 @@
-[iframe: https://example.com]
+[https://example.com]

--- a/ftml/test/iframe.txt
+++ b/ftml/test/iframe.txt
@@ -1,1 +1,1 @@
-[iframe: https://example.com]
+[https://example.com]

--- a/ftml/test/image-attributes.txt
+++ b/ftml/test/image-attributes.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-attributes/green_apple.png [Alt: A green apple] [Title: Take a big bite!] B
+A https://test.wjfiles.com/local--files/page-image-attributes/green_apple.pngA green appleTake a big bite! B

--- a/ftml/test/image-attributes.txt
+++ b/ftml/test/image-attributes.txt
@@ -1,1 +1,1 @@
-A https://test.wjfiles.com/local--files/page-image-attributes/green_apple.pngA green appleTake a big bite! B
+A https://test.wjfiles.com/local--files/page-image-attributes/green_apple.png A green apple Take a big bite! B

--- a/ftml/test/image-center.txt
+++ b/ftml/test/image-center.txt
@@ -1,1 +1,1 @@
-Image: https://test.wjfiles.com/local--files/page-image-center/landscape.png [Align: center]
+https://test.wjfiles.com/local--files/page-image-center/landscape.png

--- a/ftml/test/image-external.txt
+++ b/ftml/test/image-external.txt
@@ -1,1 +1,1 @@
-A Image: https://example.com/my-image.png B
+A https://example.com/my-image.png B

--- a/ftml/test/image-file1.txt
+++ b/ftml/test/image-file1.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-file1/my-picture.jpeg B
+A https://test.wjfiles.com/local--files/page-image-file1/my-picture.jpeg B

--- a/ftml/test/image-file2-slash.txt
+++ b/ftml/test/image-file2-slash.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg B
+A https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg B

--- a/ftml/test/image-file2.txt
+++ b/ftml/test/image-file2.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg B
+A https://test.wjfiles.com/local--files/some-other-page/my-picture.jpeg B

--- a/ftml/test/image-file3-slash.txt
+++ b/ftml/test/image-file3-slash.txt
@@ -1,1 +1,1 @@
-A Image: https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg B
+A https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg B

--- a/ftml/test/image-file3.txt
+++ b/ftml/test/image-file3.txt
@@ -1,1 +1,1 @@
-A Image: https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg B
+A https://scp-wiki.wjfiles.com/local--files/some-other-page/my-picture.jpeg B

--- a/ftml/test/image-float-left.txt
+++ b/ftml/test/image-float-left.txt
@@ -1,1 +1,1 @@
-Image: https://test.wjfiles.com/local--files/page-image-float-left/landscape.png [Align: left float]
+https://test.wjfiles.com/local--files/page-image-float-left/landscape.png

--- a/ftml/test/image-float-right.txt
+++ b/ftml/test/image-float-right.txt
@@ -1,1 +1,1 @@
-Image: https://test.wjfiles.com/local--files/page-image-float-right/landscape.png [Align: right float]
+https://test.wjfiles.com/local--files/page-image-float-right/landscape.png

--- a/ftml/test/image-left.txt
+++ b/ftml/test/image-left.txt
@@ -1,1 +1,1 @@
-Image: https://test.wjfiles.com/local--files/page-image-left/landscape.png [Align: left]
+https://test.wjfiles.com/local--files/page-image-left/landscape.png

--- a/ftml/test/image-link-anchor.txt
+++ b/ftml/test/image-link-anchor.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png [Link: #section] B
+A https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png#section B

--- a/ftml/test/image-link-anchor.txt
+++ b/ftml/test/image-link-anchor.txt
@@ -1,1 +1,1 @@
-A https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png#section B
+A https://test.wjfiles.com/local--files/page-image-link-anchor/filename.png #section B

--- a/ftml/test/image-link-page.txt
+++ b/ftml/test/image-link-page.txt
@@ -1,1 +1,1 @@
-A https://test.wjfiles.com/local--files/page-image-link-page/filename.png/scp-001 B
+A https://test.wjfiles.com/local--files/page-image-link-page/filename.png /scp-001 B

--- a/ftml/test/image-link-page.txt
+++ b/ftml/test/image-link-page.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-link-page/filename.png [Link: /scp-001] B
+A https://test.wjfiles.com/local--files/page-image-link-page/filename.png/scp-001 B

--- a/ftml/test/image-link.txt
+++ b/ftml/test/image-link.txt
@@ -1,1 +1,1 @@
-A https://test.wjfiles.com/local--files/page-image-link/filename.pnghttps://example.com/ B
+A https://test.wjfiles.com/local--files/page-image-link/filename.png https://example.com/ B

--- a/ftml/test/image-link.txt
+++ b/ftml/test/image-link.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image-link/filename.png [Link: https://example.com/] B
+A https://test.wjfiles.com/local--files/page-image-link/filename.pnghttps://example.com/ B

--- a/ftml/test/image-right.txt
+++ b/ftml/test/image-right.txt
@@ -1,1 +1,1 @@
-Image: https://test.wjfiles.com/local--files/page-image-right/landscape.png [Align: right]
+https://test.wjfiles.com/local--files/page-image-right/landscape.png

--- a/ftml/test/image.txt
+++ b/ftml/test/image.txt
@@ -1,1 +1,1 @@
-A Image: https://test.wjfiles.com/local--files/page-image/filename.png B
+A https://test.wjfiles.com/local--files/page-image/filename.png B


### PR DESCRIPTION
The text renderer became rather descriptive for complex elements (e.g. images), which helped readability by adding English words. However this is counter to our internationalization policy, and instead of adding a million small words to our localization system for each, I'm just removing them and making this more internal content-based as it should be.