### PR TITLE
Fix container link cycle

### DIFF
--- a/install/aws/dev/terraform/deploy/task-definitions.tf
+++ b/install/aws/dev/terraform/deploy/task-definitions.tf
@@ -186,7 +186,7 @@ module "php-fpm" {
     }
   ]
 
-  links = ["api:api", "cache:cache", "database:database", "nginx:nginx"]
+  links = ["api:api", "cache:cache", "database:database"]
 
   secrets = [
     {


### PR DESCRIPTION
Currently the following error is reported when attempting to apply our Terraform plan for dev:

```
aws_launch_template.node: Modifying... [id=lt-03a1dbb434e5b57b1]
aws_ecs_task_definition.wikijump_task: Creating...
aws_launch_template.node: Modifications complete after 1s [id=lt-03a1dbb434e5b57b1]
╷
│ Error: failed creating ECS Task Definition (wikijump-dev-ec2): ClientException: Container links should not have a cycle
│ 
│   on ecs.tf line 59, in resource "aws_ecs_task_definition" "wikijump_task":
│   59: resource "aws_ecs_task_definition" "wikijump_task" {
│ 
╵
```

We will need to figure out an alternate solution to allow php-fpm to store its Vite information in nginx. For now we'll revert the change as part of fixing Terraform builds.