### PR TITLE
Disallow usernames that look like IP addresses

### DIFF
--- a/web/php/Config/ForbiddenNames.php
+++ b/web/php/Config/ForbiddenNames.php
@@ -100,6 +100,8 @@ class ForbiddenNames {
         '/^undefined$/',
         '/^bot$/',
         '/^robot$/',
+        '/^[0-9]+(\.[0-9]+){1,}$/', // Looks like IPv4
+        '/^:*[0-9a-fA-F]+(:[0-9a-fA-F]*)*$/', // Looks like IPv6
         '/^O5\-\w+$/',  // These are both SCP Wiki-related, but given how many users are registered on Wikidot
         '/^SCP\-\w+$/', // with these, I think it's a good idea to nip this in the bud at the account creation stage.
     ];


### PR DESCRIPTION
We aren't supporting IP-based ("anonymous") edits, but it is still avoidable confusion if a user chooses a username which is (or appears as) an IP address. These regular expressions deny such usernames.