### PR TITLE
Fix head type for checkbox

### DIFF
--- a/ftml/conf/blocks.toml
+++ b/ftml/conf/blocks.toml
@@ -30,7 +30,7 @@ html-output = "other"
 
 [checkbox]
 accepts-star = true
-head = "value+map"
+head = "map"
 body = "none"
 html-attributes = true
 html-output = "html,input"


### PR DESCRIPTION
Another oversight from when I added checkboxes: I copied the same config for both even though radio buttons require a name and checkboxes don't have one at all.