### PR TITLE
[WJ-832] Add ID isolation

### DIFF
--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -1,0 +1,39 @@
+/*
+ * id_prefix.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2022 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Utility to prefix HTML IDs for isolation.
+//!
+//! This adds `u-` to all IDs in the string (if non-empty)
+//! to ensure non-collision with generated elements.
+
+pub fn isolate_ids(id_string: &str) -> String {
+    let mut isolated_ids = String::new();
+
+    for class in id_string.split_whitespace() {
+        str_write!(isolated_ids, "u-{}", class);
+    }
+
+    isolated_ids
+}
+
+#[test]
+fn test_isolate_ids() {
+    panic!("TODO");
+}

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -27,6 +27,10 @@ pub fn isolate_ids(id_string: &str) -> String {
     let mut isolated_ids = String::new();
 
     for class in id_string.split_whitespace() {
+        if !isolated_ids.is_empty() {
+            isolated_ids.push(' ');
+        }
+
         str_write!(isolated_ids, "u-{}", class);
     }
 
@@ -35,5 +39,24 @@ pub fn isolate_ids(id_string: &str) -> String {
 
 #[test]
 fn test_isolate_ids() {
-    panic!("TODO");
+    macro_rules! check {
+        ($input:expr, $expected:expr) => {
+            assert_eq!(
+                isolate_ids($input),
+                $expected,
+                "Actual isolated ID string doesn't match expected",
+            );
+        };
+    }
+
+    check!("", "");
+    check!("  ", "");
+    check!("apple", "u-apple");
+    check!("apple banana", "u-apple u-banana");
+    check!("apple  banana", "u-apple u-banana");
+    check!(" apple  banana", "u-apple u-banana");
+    check!(" apple   banana ", "u-apple u-banana");
+    check!("apple banana cherry", "u-apple u-banana u-cherry");
+    check!("apple  banana cherry", "u-apple u-banana u-cherry");
+    check!("  apple  banana\tcherry", "u-apple u-banana u-cherry");
 }

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -27,6 +27,7 @@
 //! it's already prefixed with that.
 
 pub fn isolate_ids(id_string: &str) -> String {
+    const PREFIX: &str = "u-";
     let mut isolated_ids = String::new();
 
     for class in id_string.split_whitespace() {
@@ -34,10 +35,10 @@ pub fn isolate_ids(id_string: &str) -> String {
             isolated_ids.push(' ');
         }
 
-        if class.starts_with("u-") {
+        if class.starts_with(PREFIX) {
             isolated_ids.push_str(class);
         } else {
-            str_write!(isolated_ids, "u-{}", class);
+            str_write!(isolated_ids, "{}{}", PREFIX, class);
         }
     }
 

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -69,4 +69,8 @@ fn test_isolate_ids() {
     check!("apple banana cherry", "u-apple u-banana u-cherry");
     check!("apple  banana cherry", "u-apple u-banana u-cherry");
     check!("  apple  banana\tcherry", "u-apple u-banana u-cherry");
+    check!("u-apple banana cherry", "u-apple u-banana u-cherry");
+    check!("u-apple u-banana cherry", "u-apple u-banana u-cherry");
+    check!("u-apple u-banana u-cherry", "u-apple u-banana u-cherry");
+    check!("apple u-banana cherry", "u-apple u-banana u-cherry");
 }

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -73,4 +73,5 @@ fn test_isolate_ids() {
     check!("u-apple u-banana cherry", "u-apple u-banana u-cherry");
     check!("u-apple u-banana u-cherry", "u-apple u-banana u-cherry");
     check!("apple u-banana cherry", "u-apple u-banana u-cherry");
+    check!("u-u-apple", "u-u-apple");
 }

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -31,15 +31,17 @@ pub fn isolate_ids(id_string: &str) -> String {
     let mut isolated_ids = String::new();
 
     for class in id_string.split_whitespace() {
+        // Add space separator between each class
         if !isolated_ids.is_empty() {
             isolated_ids.push(' ');
         }
 
-        if class.starts_with(PREFIX) {
-            isolated_ids.push_str(class);
-        } else {
-            str_write!(isolated_ids, "{}{}", PREFIX, class);
+        // Prefix if not already present
+        if !class.starts_with(PREFIX) {
+            isolated_ids.push_str(PREFIX);
         }
+
+        isolated_ids.push_str(class);
     }
 
     isolated_ids

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -22,6 +22,9 @@
 //!
 //! This adds `u-` to all IDs in the string (if non-empty)
 //! to ensure non-collision with generated elements.
+//!
+//! However it is intelligent, and doesn't add the `u-` if
+//! it's already prefixed with that.
 
 pub fn isolate_ids(id_string: &str) -> String {
     let mut isolated_ids = String::new();
@@ -31,7 +34,11 @@ pub fn isolate_ids(id_string: &str) -> String {
             isolated_ids.push(' ');
         }
 
-        str_write!(isolated_ids, "u-{}", class);
+        if class.starts_with("u-") {
+            isolated_ids.push_str(class);
+        } else {
+            str_write!(isolated_ids, "u-{}", class);
+        }
     }
 
     isolated_ids

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -113,6 +113,7 @@ mod test;
 #[macro_use]
 mod macros;
 
+mod id_prefix;
 mod next_index;
 mod non_empty_vec;
 mod preproc;

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -147,6 +147,7 @@ pub mod prelude {
     pub use super::render::Render;
     pub use super::settings::{
         InterwikiSettings, WikitextMode, WikitextSettings, DEFAULT_INTERWIKI,
+        EMPTY_INTERWIKI,
     };
     pub use super::tokenizer::{tokenize, Tokenization};
     pub use super::tree::{Element, SyntaxTree};

--- a/ftml/src/parsing/rule/impls/anchor.rs
+++ b/ftml/src/parsing/rule/impls/anchor.rs
@@ -25,6 +25,8 @@
 //! `<a id="name-of-anchor">` anchor that can be jumped to.
 
 use super::prelude::*;
+use crate::id_prefix::isolate_ids;
+use std::borrow::Cow;
 
 pub const RULE_ANCHOR: Rule = Rule {
     name: "anchor",
@@ -54,6 +56,12 @@ fn try_consume_fn<'p, 'r, 't>(
         None,
     )?;
 
+    let name = if parser.settings().isolate_user_ids {
+        Cow::Owned(isolate_ids(name))
+    } else {
+        cow!(name)
+    };
+
     // Build and return link element
-    ok!(Element::AnchorName(cow!(name)))
+    ok!(Element::AnchorName(name))
 }

--- a/ftml/src/parsing/rule/impls/block/arguments.rs
+++ b/ftml/src/parsing/rule/impls/block/arguments.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::parsing::{parse_boolean, ParseWarning, ParseWarningKind, Parser};
+use crate::settings::WikitextSettings;
 use crate::tree::AttributeMap;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -106,8 +107,13 @@ impl<'t> Arguments<'t> {
     }
 
     /// Similar to `to_hash_map()`, but creates an `AttributeMap` instead.
+    ///
+    /// Because all fields are passed from the user, this does ID isolation
+    /// if that is enabled, and so needs `WikitextSettings` to be passed in.
     #[inline]
-    pub fn to_attribute_map(&self) -> AttributeMap<'t> {
-        AttributeMap::from_arguments(&self.inner)
+    pub fn to_attribute_map(&self, settings: &WikitextSettings) -> AttributeMap<'t> {
+        let mut map = AttributeMap::from_arguments(&self.inner);
+        map.isolate_id(settings);
+        map
     }
 }

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -42,7 +42,7 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_ANCHOR, name);
 
     let arguments = parser.get_head_map(&BLOCK_ANCHOR, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
 
     // "a" means we wrap interpret as-is
     // "a_" means we strip out any newlines or paragraph breaks

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -51,7 +51,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Blockquote,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Bold,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -45,7 +45,7 @@ fn parse_fn<'r, 't>(
 
     let element = Element::CheckBox {
         checked: flag_star,
-        attributes: arguments.to_attribute_map(),
+        attributes: arguments.to_attribute_map(parser.settings()),
     };
 
     ok!(element)

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -65,7 +65,7 @@ fn parse_fn<'r, 't>(
     // Build element and return
     let element = Element::Collapsible {
         elements,
-        attributes: arguments.to_attribute_map(),
+        attributes: arguments.to_attribute_map(parser.settings()),
         start_open,
         show_text,
         hide_text,

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -51,7 +51,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Deletion,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -56,7 +56,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Div,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Hidden,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     let (url, arguments) = parser.get_head_name_map(&BLOCK_IFRAME, in_head)?;
     let element = Element::Iframe {
         url: cow!(url),
-        attributes: arguments.to_attribute_map(),
+        attributes: arguments.to_attribute_map(parser.settings()),
     };
 
     ok!(element)

--- a/ftml/src/parsing/rule/impls/block/blocks/image.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/image.rs
@@ -57,7 +57,7 @@ fn parse_fn<'r, 't>(
         source,
         link,
         alignment,
-        attributes: arguments.to_attribute_map(),
+        attributes: arguments.to_attribute_map(parser.settings()),
     };
 
     ok!(element)

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -51,7 +51,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Insertion,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Invisible,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Italics,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/list.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/list.rs
@@ -115,7 +115,7 @@ fn parse_list_block<'r, 't>(
 
     // Get attributes
     let arguments = parser.get_head_map(block_rule, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
 
     // Get body and convert into list form.
     let (mut elements, exceptions, _) =
@@ -199,7 +199,7 @@ fn parse_list_item<'r, 't>(
 
     // Get attributes
     let arguments = parser.get_head_map(&BLOCK_LI, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
 
     // Get body elements
     let (mut elements, exceptions, _) =

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -51,7 +51,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Mark,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -27,7 +27,7 @@ pub const MODULE_JOIN: ModuleRule = ModuleRule {
 };
 
 fn parse_fn<'r, 't>(
-    _parser: &mut Parser<'r, 't>,
+    parser: &mut Parser<'r, 't>,
     name: &'t str,
     mut arguments: Arguments<'t>,
 ) -> ParseResult<'r, 't, Option<Module<'t>>> {
@@ -35,7 +35,7 @@ fn parse_fn<'r, 't>(
     assert_module_name(&MODULE_JOIN, name);
 
     let button_text = arguments.get("button");
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
 
     ok!(false; Some(Module::Join {
         button_text,

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Monospace,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
 
     // Gather paragraphs
     let arguments = parser.get_head_map(&BLOCK_PARAGRAPH, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
     let (mut elements, exceptions, _) =
         parser.get_body_elements(&BLOCK_PARAGRAPH, true)?.into();
 

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -48,7 +48,7 @@ fn parse_fn<'r, 't>(
     let element = Element::RadioButton {
         name: cow!(name),
         checked: flag_star,
-        attributes: arguments.to_attribute_map(),
+        attributes: arguments.to_attribute_map(parser.settings()),
     };
 
     ok!(element)

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -58,7 +58,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Span,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -51,7 +51,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Strikethrough,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Subscript,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Superscript,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/parsing/rule/impls/block/blocks/table.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/table.rs
@@ -95,7 +95,7 @@ where
 
     // Get attributes
     let arguments = parser.get_head_map(block_rule, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
 
     // Get body elements
     let (elements, exceptions, _) = parser.get_body_elements(block_rule, false)?.into();

--- a/ftml/src/parsing/rule/impls/block/blocks/toc.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/toc.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_TABLE_OF_CONTENTS, name);
 
     let arguments = parser.get_head_map(&BLOCK_TABLE_OF_CONTENTS, in_head)?;
-    let attributes = arguments.to_attribute_map();
+    let attributes = arguments.to_attribute_map(parser.settings());
     let align = FloatAlignment::parse(name).map(|float| float.align);
     let element = Element::TableOfContents { align, attributes };
     ok!(false; element)

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -50,7 +50,7 @@ fn parse_fn<'r, 't>(
     let element = Element::Container(Container::new(
         ContainerType::Underline,
         elements,
-        arguments.to_attribute_map(),
+        arguments.to_attribute_map(parser.settings()),
     ));
 
     ok!(paragraph_safe; element, exceptions)

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -172,11 +172,26 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         }
     }
 
-    fn attr_value(&mut self, value_parts: &[&str]) {
+    fn attr_value(&mut self, key: &str, value_parts: &[&str]) {
         self.ctx.push_raw('"');
 
-        for part in value_parts {
-            self.ctx.push_escaped(part);
+        // Isolate IDs, special handling of value
+        if key == "id" && self.ctx.settings().isolate_user_ids {
+            let mut value = String::new();
+
+            // Render to string
+            for part in value_parts {
+                value.push_str(part);
+            }
+
+            // Isolate ID
+            let value = isolate_ids(&value);
+            self.ctx.push_escaped(&value);
+        } else {
+            // Normal rendering
+            for part in value_parts {
+                self.ctx.push_escaped(part);
+            }
         }
 
         self.ctx.push_raw('"');
@@ -199,7 +214,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         self.attr_key(key, has_value);
 
         if has_value {
-            self.attr_value(value_parts);
+            self.attr_value(key, value_parts);
         }
 
         self

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -172,6 +172,16 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         }
     }
 
+    fn attr_value(&mut self, value_parts: &[&str]) {
+        self.ctx.push_raw('"');
+
+        for part in value_parts {
+            self.ctx.push_escaped(part);
+        }
+
+        self.ctx.push_raw('"');
+    }
+
     pub fn attr_single(&mut self, key: &str, value_parts: &[&str]) -> &mut Self {
         // If value_parts is empty, then we just give the key.
         //
@@ -189,11 +199,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         self.attr_key(key, has_value);
 
         if has_value {
-            self.ctx.push_raw('"');
-            for part in value_parts {
-                self.ctx.push_escaped(part);
-            }
-            self.ctx.push_raw('"');
+            self.attr_value(value_parts);
         }
 
         self

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -21,7 +21,6 @@
 use super::attributes::AddedAttributes;
 use super::context::HtmlContext;
 use super::render::ItemRender;
-use crate::id_prefix::isolate_ids;
 use std::collections::HashSet;
 
 macro_rules! tag_method {
@@ -172,26 +171,11 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         }
     }
 
-    fn attr_value(&mut self, key: &str, value_parts: &[&str]) {
+    fn attr_value(&mut self, value_parts: &[&str]) {
         self.ctx.push_raw('"');
 
-        // Isolate IDs, special handling of value
-        if key == "id" && self.ctx.settings().isolate_user_ids {
-            let mut value = String::new();
-
-            // Render to string
-            for part in value_parts {
-                value.push_str(part);
-            }
-
-            // Isolate ID
-            let value = isolate_ids(&value);
-            self.ctx.push_escaped(&value);
-        } else {
-            // Normal rendering
-            for part in value_parts {
-                self.ctx.push_escaped(part);
-            }
+        for part in value_parts {
+            self.ctx.push_escaped(part);
         }
 
         self.ctx.push_raw('"');
@@ -214,7 +198,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         self.attr_key(key, has_value);
 
         if has_value {
-            self.attr_value(key, value_parts);
+            self.attr_value(value_parts);
         }
 
         self

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -67,6 +67,7 @@ use self::toc::render_table_of_contents;
 use self::user::render_user;
 use super::attributes::AddedAttributes;
 use super::HtmlContext;
+use crate::id_prefix::isolate_ids;
 use crate::render::ModuleRenderMode;
 use crate::tree::Element;
 use ref_map::*;
@@ -106,7 +107,16 @@ pub fn render_element(ctx: &mut HtmlContext, element: &Element) {
             target,
         } => render_anchor(ctx, elements, attributes, *target),
         Element::AnchorName(name) => {
-            ctx.html().a().attr(attr!("id" => name));
+            // Prefix with "u-" if settings call for it.
+            let value;
+            let id: &str = if ctx.settings().isolate_user_ids {
+                value = isolate_ids(name);
+                &value
+            } else {
+                &name
+            };
+
+            ctx.html().a().attr(attr!("id" => id));
         }
         Element::Link {
             ltype,

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -113,7 +113,7 @@ pub fn render_element(ctx: &mut HtmlContext, element: &Element) {
                 value = isolate_ids(name);
                 &value
             } else {
-                &name
+                name
             };
 
             ctx.html().a().attr(attr!("id" => id));

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -67,7 +67,6 @@ use self::toc::render_table_of_contents;
 use self::user::render_user;
 use super::attributes::AddedAttributes;
 use super::HtmlContext;
-use crate::id_prefix::isolate_ids;
 use crate::render::ModuleRenderMode;
 use crate::tree::Element;
 use ref_map::*;
@@ -106,16 +105,7 @@ pub fn render_element(ctx: &mut HtmlContext, element: &Element) {
             attributes,
             target,
         } => render_anchor(ctx, elements, attributes, *target),
-        Element::AnchorName(name) => {
-            // Prefix with "u-" if settings call for it.
-            let value;
-            let id: &str = if ctx.settings().isolate_user_ids {
-                value = isolate_ids(name);
-                &value
-            } else {
-                name
-            };
-
+        Element::AnchorName(id) => {
             ctx.html().a().attr(attr!("id" => id));
         }
         Element::Link {

--- a/ftml/src/settings/interwiki.rs
+++ b/ftml/src/settings/interwiki.rs
@@ -22,6 +22,11 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 lazy_static! {
+    pub static ref EMPTY_INTERWIKI: InterwikiSettings = {
+        InterwikiSettings {
+            prefixes: hashmap! {},
+        }
+    };
     pub static ref DEFAULT_INTERWIKI: InterwikiSettings = {
         InterwikiSettings {
             prefixes: hashmap! {

--- a/ftml/src/settings/mod.rs
+++ b/ftml/src/settings/mod.rs
@@ -45,6 +45,13 @@ pub struct WikitextSettings {
     /// context where more than one instance of rendered wikitext could be emitted.
     pub use_true_ids: bool,
 
+    /// Whether to prefix user IDs with `u-`.
+    ///
+    /// This is a behavior found in Wikidot (although implemented incompletely)
+    /// which prefixes IDs in HTML elements provided by the user with `u-` to ensure
+    /// isolation.
+    pub isolate_user_ids: bool,
+
     /// Whether local paths are permitted.
     ///
     /// This applies to:
@@ -76,6 +83,7 @@ impl WikitextSettings {
                 mode,
                 enable_page_syntax: true,
                 use_true_ids: true,
+                isolate_user_ids: false,
                 allow_local_paths: true,
                 interwiki,
             },
@@ -83,6 +91,7 @@ impl WikitextSettings {
                 mode,
                 enable_page_syntax: true,
                 use_true_ids: false,
+                isolate_user_ids: false,
                 allow_local_paths: true,
                 interwiki,
             },
@@ -90,6 +99,7 @@ impl WikitextSettings {
                 mode,
                 enable_page_syntax: false,
                 use_true_ids: false,
+                isolate_user_ids: false,
                 allow_local_paths: false,
                 interwiki,
             },
@@ -97,6 +107,7 @@ impl WikitextSettings {
                 mode,
                 enable_page_syntax: true,
                 use_true_ids: false,
+                isolate_user_ids: false,
                 allow_local_paths: true,
                 interwiki,
             },

--- a/ftml/src/settings/mod.rs
+++ b/ftml/src/settings/mod.rs
@@ -54,6 +54,11 @@ pub struct WikitextSettings {
 
     /// Whether local paths are permitted.
     ///
+    /// This should be disabled in contexts where there is no "local context"
+    /// to which these paths could be interpreted. For instance, on pages
+    /// you can reference an attached file, but on an arbitrary forum thread
+    /// no such file can exist.
+    ///
     /// This applies to:
     /// * Files
     /// * Images

--- a/ftml/src/settings/mod.rs
+++ b/ftml/src/settings/mod.rs
@@ -20,7 +20,7 @@
 
 mod interwiki;
 
-pub use self::interwiki::{InterwikiSettings, DEFAULT_INTERWIKI};
+pub use self::interwiki::{InterwikiSettings, DEFAULT_INTERWIKI, EMPTY_INTERWIKI};
 
 /// Settings to tweak behavior in the ftml parser and renderer.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -82,7 +82,7 @@ fn only_test_should_skip(name: &str) -> bool {
             return false;
         }
 
-        // Test prefix
+        // Test name prefix
         if pattern.ends_with('-') {
             if name.starts_with(pattern) {
                 return false;

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -80,10 +80,7 @@ fn isolate_user_ids() {
             let expected = append_footnote_block($elements);
 
             assert!(warnings.is_empty(), "Warnings produced during parsing!");
-            assert_eq!(
-                actual, expected,
-                "Actual elements didn't match expected",
-            );
+            assert_eq!(actual, expected, "Actual elements didn't match expected");
         }};
     }
 
@@ -330,6 +327,26 @@ fn isolate_user_ids() {
             hide_text: None,
             show_top: true,
             show_bottom: false,
+        }],
+    );
+
+    // Table of contents [[toc]]
+    check!(
+        r#"[[toc id="apple"]]"#,
+        vec![Element::TableOfContents {
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            align: None,
+        }],
+    );
+    check!(
+        r#"[[toc id="u-apple"]]"#,
+        vec![Element::TableOfContents {
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            align: None,
         }],
     );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -297,4 +297,44 @@ fn isolate_user_ids() {
             AttributeMap::new(),
         ))],
     );
+
+    // Collapsibles [[collapsible]]
+    check!(
+        r#"[[collapsible class="apple" id="banana"]]X[[/collapsible]]"#,
+        vec![Element::Collapsible {
+            elements: vec![Element::Container(Container::new(
+                ContainerType::Paragraph,
+                vec![text!("X")],
+                AttributeMap::new(),
+            ))],
+            attributes: AttributeMap::from(btreemap! {
+                cow!("class") => cow!("apple"),
+                cow!("id") => cow!("u-banana"),
+            }),
+            start_open: false,
+            show_text: None,
+            hide_text: None,
+            show_top: true,
+            show_bottom: false,
+        }],
+    );
+    check!(
+        r#"[[collapsible class="u-apple" id="u-banana"]]X[[/collapsible]]"#,
+        vec![Element::Collapsible {
+            elements: vec![Element::Container(Container::new(
+                ContainerType::Paragraph,
+                vec![text!("X")],
+                AttributeMap::new(),
+            ))],
+            attributes: AttributeMap::from(btreemap! {
+                cow!("class") => cow!("u-apple"),
+                cow!("id") => cow!("u-banana"),
+            }),
+            start_open: false,
+            show_text: None,
+            hide_text: None,
+            show_top: true,
+            show_bottom: false,
+        }],
+    );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -124,6 +124,20 @@ fn isolate_user_ids() {
             AttributeMap::new(),
         ))],
     );
+    check!(
+        r#"[[a id="u-u-apple"]]X[[/a]]"#,
+        vec![Element::Container(Container::new(
+            ContainerType::Paragraph,
+            vec![Element::Anchor {
+                target: None,
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-u-apple"),
+                }),
+                elements: vec![text!("X")],
+            }],
+            AttributeMap::new(),
+        ))],
+    );
 
     // Images [[image]]
     check!(

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -22,7 +22,6 @@ use crate::data::PageInfo;
 use crate::settings::{WikitextMode, WikitextSettings, EMPTY_INTERWIKI};
 use crate::tree::{
     AttributeMap, Container, ContainerType, Element, ImageSource, ListItem, ListType,
-    SyntaxTree,
 };
 use std::borrow::Cow;
 
@@ -75,19 +74,15 @@ fn isolate_user_ids() {
             crate::preprocess(&mut text);
             let tokens = crate::tokenize(&text);
             let result = crate::parse(&tokens, &page_info, &settings);
-            let (actual_tree, warnings) = result.into();
+            let (tree, warnings) = result.into();
 
-            let expected_tree = SyntaxTree {
-                elements: append_footnote_block($elements),
-                styles: vec![],
-                table_of_contents: vec![],
-                footnotes: vec![],
-            };
+            let actual = tree.elements;
+            let expected = append_footnote_block($elements);
 
             assert!(warnings.is_empty(), "Warnings produced during parsing!");
             assert_eq!(
-                actual_tree, expected_tree,
-                "Actual syntax tree didn't match expected",
+                actual, expected,
+                "Actual elements didn't match expected",
             );
         }};
     }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -21,7 +21,8 @@
 use crate::data::PageInfo;
 use crate::settings::{WikitextMode, WikitextSettings, EMPTY_INTERWIKI};
 use crate::tree::{
-    AttributeMap, Container, ContainerType, Element, ListItem, ListType, ImageSource, SyntaxTree,
+    AttributeMap, Container, ContainerType, Element, ImageSource, ListItem, ListType,
+    SyntaxTree,
 };
 use std::borrow::Cow;
 
@@ -170,14 +171,12 @@ fn isolate_user_ids() {
             attributes: AttributeMap::from(btreemap! {
                 cow!("id") => cow!("u-apple"),
             }),
-            items: vec![
-                ListItem::Elements {
-                    attributes: AttributeMap::from(btreemap! {
-                        cow!("id") => cow!("u-banana"),
-                    }),
-                    elements: vec![text!("X")],
-                },
-            ],
+            items: vec![ListItem::Elements {
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-banana"),
+                }),
+                elements: vec![text!("X")],
+            }],
         }],
     );
     check!(
@@ -187,14 +186,12 @@ fn isolate_user_ids() {
             attributes: AttributeMap::from(btreemap! {
                 cow!("id") => cow!("u-apple"),
             }),
-            items: vec![
-                ListItem::Elements {
-                    attributes: AttributeMap::from(btreemap! {
-                        cow!("id") => cow!("u-banana"),
-                    }),
-                    elements: vec![text!("X")],
-                },
-            ],
+            items: vec![ListItem::Elements {
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-banana"),
+                }),
+                elements: vec![text!("X")],
+            }],
         }],
     );
 
@@ -205,31 +202,85 @@ fn isolate_user_ids() {
             attributes: AttributeMap::from(btreemap! {
                 cow!("id") => cow!("u-apple"),
             }),
-            items: vec![
-                ListItem::Elements {
-                    attributes: AttributeMap::from(btreemap! {
-                        cow!("id") => cow!("u-banana"),
-                    }),
-                    elements: vec![text!("X")],
-                },
-            ],
+            items: vec![ListItem::Elements {
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-banana"),
+                }),
+                elements: vec![text!("X")],
+            }],
         }],
     );
     check!(
         r#"[[ol id="u-apple"]] [[li id="banana"]]X[[/li]] [[/ol]]"#,
         vec![Element::List {
-            ltype: ListType::Bullet,
+            ltype: ListType::Numbered,
             attributes: AttributeMap::from(btreemap! {
                 cow!("id") => cow!("u-apple"),
             }),
-            items: vec![
-                ListItem::Elements {
+            items: vec![ListItem::Elements {
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-banana"),
+                }),
+                elements: vec![text!("X")],
+            }],
+        }],
+    );
+
+    // Radio buttons and checkboxes
+    check!(
+        r#"[[radio vegetables class="apple" id="banana"]] Celery
+[[radio vegetables class="u-cherry" id="u-durian"]] Lettuce"#,
+        vec![Element::Container(Container::new(
+            ContainerType::Paragraph,
+            vec![
+                Element::RadioButton {
+                    name: cow!("vegetables"),
+                    checked: false,
                     attributes: AttributeMap::from(btreemap! {
+                        cow!("class") => cow!("apple"),
                         cow!("id") => cow!("u-banana"),
                     }),
-                    elements: vec![text!("X")],
                 },
+                text!("Celery"),
+                Element::LineBreak,
+                Element::RadioButton {
+                    name: cow!("vegetables"),
+                    checked: false,
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("class") => cow!("u-cherry"),
+                        cow!("id") => cow!("u-durian"),
+                    }),
+                },
+                text!("Lettuce"),
             ],
-        }],
+            AttributeMap::new(),
+        ))],
+    );
+    check!(
+        r#"[[checkbox class="apple" id="banana"]] Celery
+[[checkbox class="u-cherry" id="u-durian"]] Lettuce"#,
+        vec![Element::Container(Container::new(
+            ContainerType::Paragraph,
+            vec![
+                Element::CheckBox {
+                    checked: false,
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("class") => cow!("apple"),
+                        cow!("id") => cow!("u-banana"),
+                    }),
+                },
+                text!("Celery"),
+                Element::LineBreak,
+                Element::CheckBox {
+                    checked: false,
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("class") => cow!("u-cherry"),
+                        cow!("id") => cow!("u-durian"),
+                    }),
+                },
+                text!("Lettuce"),
+            ],
+            AttributeMap::new(),
+        ))],
     );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -105,7 +105,7 @@ fn isolate_user_ids() {
                 elements: vec![text!("X")],
             }],
             AttributeMap::new(),
-        )),],
+        ))],
     );
     check!(
         r#"[[a id="u-apple"]]X[[/a]]"#,
@@ -119,6 +119,6 @@ fn isolate_user_ids() {
                 elements: vec![text!("X")],
             }],
             AttributeMap::new(),
-        )),],
+        ))],
     );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -89,7 +89,10 @@ fn isolate_user_ids() {
         }};
     }
 
+    // Trivial
     check!("", vec![]);
+
+    // Anchor block ([[a]])
     check!(
         r#"[[a id="apple"]]X[[/a]]"#,
         vec![Element::Container(Container::new(

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -349,4 +349,24 @@ fn isolate_user_ids() {
             align: None,
         }],
     );
+
+    // Iframes [[iframe]]
+    check!(
+        r#"[[iframe https://example.com/ id="apple"]]"#,
+        vec![Element::Iframe {
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            url: cow!("https://example.com/"),
+        }],
+    );
+    check!(
+        r#"[[iframe https://example.com/ id="u-apple"]]"#,
+        vec![Element::Iframe {
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            url: cow!("https://example.com/"),
+        }],
+    );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -21,7 +21,7 @@
 use crate::data::PageInfo;
 use crate::settings::{WikitextMode, WikitextSettings, EMPTY_INTERWIKI};
 use crate::tree::{
-    AttributeMap, Container, ContainerType, Element, ImageSource, SyntaxTree,
+    AttributeMap, Container, ContainerType, Element, ListItem, ListType, ImageSource, SyntaxTree,
 };
 use std::borrow::Cow;
 
@@ -160,5 +160,76 @@ fn isolate_user_ids() {
             }],
             AttributeMap::new(),
         ))],
+    );
+
+    // Lists [[ul]] / [[ol]]
+    check!(
+        r#"[[ul id="apple"]] [[li id="u-banana"]]X[[/li]] [[/ul]]"#,
+        vec![Element::List {
+            ltype: ListType::Bullet,
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            items: vec![
+                ListItem::Elements {
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("id") => cow!("u-banana"),
+                    }),
+                    elements: vec![text!("X")],
+                },
+            ],
+        }],
+    );
+    check!(
+        r#"[[ul id="u-apple"]] [[li id="banana"]]X[[/li]] [[/ul]]"#,
+        vec![Element::List {
+            ltype: ListType::Bullet,
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            items: vec![
+                ListItem::Elements {
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("id") => cow!("u-banana"),
+                    }),
+                    elements: vec![text!("X")],
+                },
+            ],
+        }],
+    );
+
+    check!(
+        r#"[[ol id="apple"]] [[li id="u-banana"]]X[[/li]] [[/ol]]"#,
+        vec![Element::List {
+            ltype: ListType::Numbered,
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            items: vec![
+                ListItem::Elements {
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("id") => cow!("u-banana"),
+                    }),
+                    elements: vec![text!("X")],
+                },
+            ],
+        }],
+    );
+    check!(
+        r#"[[ol id="u-apple"]] [[li id="banana"]]X[[/li]] [[/ol]]"#,
+        vec![Element::List {
+            ltype: ListType::Bullet,
+            attributes: AttributeMap::from(btreemap! {
+                cow!("id") => cow!("u-apple"),
+            }),
+            items: vec![
+                ListItem::Elements {
+                    attributes: AttributeMap::from(btreemap! {
+                        cow!("id") => cow!("u-banana"),
+                    }),
+                    elements: vec![text!("X")],
+                },
+            ],
+        }],
     );
 }

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -104,4 +104,18 @@ fn isolate_user_ids() {
             AttributeMap::new(),
         )),],
     );
+    check!(
+        r#"[[a id="u-apple"]]X[[/a]]"#,
+        vec![Element::Container(Container::new(
+            ContainerType::Paragraph,
+            vec![Element::Anchor {
+                target: None,
+                attributes: AttributeMap::from(btreemap! {
+                    cow!("id") => cow!("u-apple"),
+                }),
+                elements: vec![text!("X")],
+            }],
+            AttributeMap::new(),
+        )),],
+    );
 }

--- a/ftml/src/test/mod.rs
+++ b/ftml/src/test/mod.rs
@@ -19,6 +19,7 @@
  */
 
 mod ast;
+mod id_prefix;
 mod includer;
 mod large;
 mod prop;

--- a/ftml/src/tree/attribute/mod.rs
+++ b/ftml/src/tree/attribute/mod.rs
@@ -21,6 +21,7 @@
 mod safe;
 
 use super::clone::string_to_owned;
+use crate::id_prefix::isolate_ids;
 use crate::parsing::parse_boolean;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
@@ -89,6 +90,13 @@ impl<'t> AttributeMap<'t> {
     #[inline]
     pub fn get(&self) -> &BTreeMap<Cow<'t, str>, Cow<'t, str>> {
         &self.inner
+    }
+
+    pub fn isolate_id(&mut self) {
+        if let Some(value) = self.inner.get_mut("id") {
+            debug!("Found 'id' attribute, isolating value");
+            *value = Cow::Owned(isolate_ids(&value));
+        }
     }
 
     pub fn to_owned(&self) -> AttributeMap<'static> {

--- a/ftml/src/tree/attribute/mod.rs
+++ b/ftml/src/tree/attribute/mod.rs
@@ -23,6 +23,7 @@ mod safe;
 use super::clone::string_to_owned;
 use crate::id_prefix::isolate_ids;
 use crate::parsing::parse_boolean;
+use crate::settings::WikitextSettings;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Debug};
@@ -92,10 +93,12 @@ impl<'t> AttributeMap<'t> {
         &self.inner
     }
 
-    pub fn isolate_id(&mut self) {
-        if let Some(value) = self.inner.get_mut("id") {
-            debug!("Found 'id' attribute, isolating value");
-            *value = Cow::Owned(isolate_ids(&value));
+    pub fn isolate_id(&mut self, settings: &WikitextSettings) {
+        if settings.isolate_user_ids {
+            if let Some(value) = self.inner.get_mut("id") {
+                debug!("Found 'id' attribute, isolating value");
+                *value = Cow::Owned(isolate_ids(&value));
+            }
         }
     }
 

--- a/ftml/src/tree/attribute/mod.rs
+++ b/ftml/src/tree/attribute/mod.rs
@@ -97,7 +97,7 @@ impl<'t> AttributeMap<'t> {
         if settings.isolate_user_ids {
             if let Some(value) = self.inner.get_mut("id") {
                 debug!("Found 'id' attribute, isolating value");
-                *value = Cow::Owned(isolate_ids(&value));
+                *value = Cow::Owned(isolate_ids(value));
             }
         }
     }

--- a/ftml/src/tree/list.rs
+++ b/ftml/src/tree/list.rs
@@ -80,7 +80,7 @@ pub enum ListType {
     /// Corresponds to the tag `<ol>`.
     Numbered,
 
-    /// Generic list, which does not have a preferred
+    /// Generic list, which does not have a preferred list type.
     ///
     /// This can be implemented in HTML with either
     /// `<ul>` or `<ol>`, as these should not have any


### PR DESCRIPTION
Wikidot adds `u-` prefixes to IDs specified by users to ensure uniqueness. However, because this has a few problems, this behavior was not previously copied to ftml as-is:

* The application is inconsistent. Elements in some blocks would have it added while others would not.
* The prefixing itself was incomplete, simply prepending `u-` to the string. So an `id="abc def"` would become `id="u-abc def"`, causing `def` to not be isolated in the same way.
* There are several syntax elements that allow interfacing with IDs directly. If I create a link to `[#apple Anchor]`, because of a `[[#apple]]`, the link won't work because it's not `u-apple`. Or, the `[[module CSS]]`, where all IDs in rules are specified directly, bypassing the `u-` prefixing requirement. (Neither of these are changed in this PR, it would be up to the user to add `u-`s where appropriate if the option is enabled.

This implements `u-` ID prefix isolation in ftml. It is set via a wikitext setting and not enabled by default.