### PR TITLE
[WJ-996] Finish clean up of ftml-ffi

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.15.2"
+version = "1.15.3"
 dependencies = [
  "built",
  "cfg-if",

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -124,25 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbindgen"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6d248e3ca02f3fbfabcb9284464c596baec223a26d91bbf44a5a62ddb0d900"
-dependencies = [
- "clap",
- "heck",
- "indexmap",
- "log",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
- "tempfile",
- "toml",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,30 +152,6 @@ dependencies = [
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "clap"
-version = "3.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -328,7 +285,6 @@ name = "ftml"
 version = "1.15.2"
 dependencies = [
  "built",
- "cbindgen",
  "cfg-if",
  "chrono",
  "entities",
@@ -397,12 +353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,16 +376,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -608,12 +548,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "percent-encoding"
@@ -1036,12 +970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7514866270741c7b03dd36e2c68f71cf064b230e8217c81bbd4d619d564864"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,12 +1038,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -49,7 +49,6 @@ wikidot-normalize = "0.9"
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }
-cbindgen = "0.23"
 
 [dev-dependencies]
 proptest = "1"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.15.2"
+version = "1.15.3"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 rust-version = "1.60.0"

--- a/ftml/build.rs
+++ b/ftml/build.rs
@@ -1,44 +1,12 @@
 extern crate built;
 
-use cbindgen::Language;
 use std::env;
-use std::path::PathBuf;
-
-const FTML_FFI_HEADER: &str = r#"
-#define FFI_SCOPE   "ftml"
-#define FFI_LIB     "libftml.so"
-"#;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
     // Generate build information
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-cfg=build={:?}", &profile);
     }
 
     built::write_built_file().expect("Failed to compile build information!");
-
-    // Generate C bindings for FFI
-    let target_path = {
-        let target_dir = env::var("OUT_DIR").unwrap();
-
-        // This takes the form '/path/to/repo/target/release/build/ftml-0000000000000000/out'
-        // We want '/path/to/repo/target/release/ftml.h'
-        let mut path = PathBuf::from(target_dir);
-        path.pop();
-        path.pop();
-        path.pop();
-        path.push("ftml.h");
-        path
-    };
-
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_language(Language::C)
-        .with_no_includes()
-        .with_header(FTML_FFI_HEADER)
-        .generate()
-        .expect("Unable to generate C bindings")
-        .write_to_file(&target_path);
 }


### PR DESCRIPTION
The PR #934 reminded me that `cbindgen` (used for generating C bindings for Rust code) is still in the crate, even though we decommissioned ftml-ffi in [WJ-996](https://scuttle.atlassian.net/browse/WJ-996). This is a follow-up PR to clean up the rest.