### PR TITLE
[WJ-984] Add page deletion to DEEPWELL

### DIFF
--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -25,7 +25,7 @@ use crate::services::revision::{
     CreateFirstRevision, CreateFirstRevisionOutput, CreateRevision, CreateRevisionBody,
 };
 use crate::services::{CategoryService, RevisionService};
-use crate::web::trim_default;
+use crate::web::{get_category_name, trim_default};
 use wikidot_normalize::normalize;
 
 #[derive(Debug)]
@@ -64,7 +64,9 @@ impl PageService {
         }
 
         // Create category if not already present
-        let category = CategoryService::get_or_create(ctx, site_id, &slug).await?;
+        let category =
+            CategoryService::get_or_create(ctx, site_id, get_category_name(&slug))
+                .await?;
 
         // Insert page
         let model = page::ActiveModel {

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -117,8 +117,7 @@ impl PageService {
         let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
 
         // Get latest revision
-        let last_revision =
-            RevisionService::get_latest(ctx, site_id, page_id).await?;
+        let last_revision = RevisionService::get_latest(ctx, site_id, page_id).await?;
 
         // Create new revision
         //
@@ -137,14 +136,9 @@ impl PageService {
             },
         };
 
-        let revision_output = RevisionService::create(
-            ctx,
-            site_id,
-            page_id,
-            revision_input,
-            last_revision,
-        )
-        .await?;
+        let revision_output =
+            RevisionService::create(ctx, site_id, page_id, revision_input, last_revision)
+                .await?;
 
         // Set page updated_at column.
         //
@@ -186,6 +180,9 @@ impl PageService {
         let txn = ctx.transaction();
         let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
 
+        // Get latest revision
+        let last_revision = RevisionService::get_latest(ctx, site_id, page_id).await?;
+
         // Create tombstone revision
         // This also updates backlinks, includes, etc
         let output = RevisionService::create_tombstone(
@@ -194,6 +191,7 @@ impl PageService {
             page_id,
             input.user_id,
             input.revision_comments,
+            last_revision,
         )
         .await?;
 

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -114,11 +114,11 @@ impl PageService {
         }: EditPage,
     ) -> Result<Option<EditPageOutput>> {
         let txn = ctx.transaction();
-        let page = Self::get(ctx, site_id, reference).await?;
+        let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
 
         // Get latest revision
         let last_revision =
-            RevisionService::get_latest(ctx, site_id, page.page_id).await?;
+            RevisionService::get_latest(ctx, site_id, page_id).await?;
 
         // Create new revision
         //
@@ -140,7 +140,7 @@ impl PageService {
         let revision_output = RevisionService::create(
             ctx,
             site_id,
-            page.page_id,
+            page_id,
             revision_input,
             last_revision,
         )
@@ -151,7 +151,7 @@ impl PageService {
         // Previously this was conditional on whether a revision was actually created.
         // But since this rerenders regardless, we need to update the page row.
         let model = page::ActiveModel {
-            page_id: Set(page.page_id),
+            page_id: Set(page_id),
             updated_at: Set(Some(now())),
             ..Default::default()
         };

--- a/deepwell/src/services/parent/service.rs
+++ b/deepwell/src/services/parent/service.rs
@@ -18,7 +18,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use super::prelude::*;
+
 #[derive(Debug)]
 pub struct ParentService;
+
+impl ParentService {
+    pub async fn delete_children() -> Result<()> {
+        // TODO
+        Ok(())
+    }
+}
 
 // TODO

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -54,7 +54,6 @@ pub fn get_category(slug: &str) -> Option<&str> {
 
 /// Retrieves the category name for a slug.
 #[inline]
-#[allow(dead_code)] // TEMP
 pub fn get_category_name(slug: &str) -> &str {
     get_category(slug).unwrap_or("_default")
 }

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -71,7 +71,7 @@ class DeepwellPage extends Migration
                 slug TEXT NOT NULL,
                 discussion_thread_id BIGINT REFERENCES forum_thread(thread_id),
 
-                UNIQUE (site_id, slug)
+                UNIQUE (site_id, slug, deleted_at)
             )
         ");
 


### PR DESCRIPTION
This implements the previously-stubbed method that allows for deleting pages via DEEPWELL. This works by adding a "tombstone" revision where the only change is the metadata field marking it as deleted. I consulted Wikidot's [`Deleter.php`](https://github.com/scpwiki/wikijump/blob/legacy/php/utils/Deleter.php) implementation for this, but there wasn't anything to carry over actually since we're not hard-deleting.