### PR TITLE
Add tests for category slug parsing, fix up category handling

### DIFF
--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -77,9 +77,31 @@ fn test_split_category() {
     }
 
     // Proper
+    check!("foo-bar", None, "foo-bar");
     check!("apple", None, "apple");
     check!("banana:apple", Some("banana"), "apple");
     check!("cherry:banana:apple", Some("cherry:banana"), "apple");
     check!("_default:start", Some("_default"), "start");
     check!("_default:_template", Some("_default"), "_template");
+}
+
+#[test]
+fn test_split_category_name() {
+    macro_rules! check {
+        ($input:expr, $category:expr, $page:expr $(,)?) => {
+            assert_eq!(
+                split_category_name($input),
+                ($category, $page),
+                "Actual split category doesn't match expected",
+            )
+        };
+    }
+
+    // Proper
+    check!("foo-bar", "_default", "foo-bar");
+    check!("apple", "_default", "apple");
+    check!("banana:apple", "banana", "apple");
+    check!("cherry:banana:apple", "cherry:banana", "apple");
+    check!("_default:start", "_default", "start");
+    check!("_default:_template", "_default", "_template");
 }

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -69,7 +69,7 @@ pub fn get_category_name(slug: &str) -> &str {
 pub fn slug_is_valid(slug: &str) -> bool {
     let (category, page) = split_category_name(slug);
     !slug.starts_with(':')
-        && slug.find("::").is_none()
+        && slug.contains("::")
         && !category.is_empty()
         && !page.is_empty()
 }

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -69,7 +69,17 @@ pub fn slug_is_valid(slug: &str) -> bool {
 
 /// Trims off the `_default:` category if present.
 pub fn trim_default(slug: &str) -> &str {
-    slug.strip_prefix("_default:").unwrap_or(slug)
+    // We cannot simply use str::strip_prefix() here,
+    // since if the category *starts* with "_default"
+    // but is not solely "_default" (for instance,
+    // the category string "_default:blah", as in
+    // "_default:blah:page-name") then this will
+    // mangle the category name.
+
+    match split_category_name(slug) {
+        ("_default", page_slug) => page_slug,
+        (_, _) => slug,
+    }
 }
 
 #[test]

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -20,13 +20,13 @@
 
 /// Splits a normalized slug into the category and page portions.
 ///
-/// This finds the first `:` in the full slug and returns everything
+/// This finds the last `:` in the full slug and returns everything
 /// up to that as the category slug.
 ///
 /// Normalized slugs do not have an explicit `_default`, so they
 /// should lack a `:` entirely.
 pub fn split_category(slug: &str) -> (Option<&str>, &str) {
-    match slug.find(':') {
+    match slug.rfind(':') {
         None => (None, slug),
         Some(idx) => {
             let (category, page) = slug.split_at(idx);

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -103,3 +103,23 @@ fn test_split_category_name() {
     check!("_default:start", "_default", "start");
     check!("_default:_template", "_default", "_template");
 }
+
+#[test]
+fn test_get_category() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {
+            assert_eq!(
+                get_category($input),
+                $expected,
+                "Actual parsed category doesn't match expected",
+            )
+        };
+    }
+
+    check!("apple", None);
+    check!("foo-bar", None);
+    check!("component:wide-modal", Some("component"));
+    check!("archived:component:wide-modal", Some("archived:component"));
+    check!("_default:start", Some("_default"));
+    check!("_default:_template", Some("_default"));
+}

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -61,7 +61,10 @@ pub fn get_category_name(slug: &str) -> &str {
 
 pub fn slug_is_valid(slug: &str) -> bool {
     let (category, page) = split_category_name(slug);
-    !slug.starts_with(':') && slug.find("::").is_none() && !category.is_empty() && !page.is_empty()
+    !slug.starts_with(':')
+        && slug.find("::").is_none()
+        && !category.is_empty()
+        && !page.is_empty()
 }
 
 /// Trims off the `_default:` category if present.
@@ -84,7 +87,11 @@ fn test_split_category() {
     check!("apple", None, "apple");
     check!("foo-bar", None, "foo-bar");
     check!("component:wide-modal", Some("component"), "wide-modal");
-    check!("archived:component:wide-modal", Some("archived:component"), "wide-modal");
+    check!(
+        "archived:component:wide-modal",
+        Some("archived:component"),
+        "wide-modal",
+    );
     check!("_default:start", Some("_default"), "start");
     check!("_default:_template", Some("_default"), "_template");
 }
@@ -104,7 +111,11 @@ fn test_split_category_name() {
     check!("apple", "_default", "apple");
     check!("foo-bar", "_default", "foo-bar");
     check!("component:wide-modal", "component", "wide-modal");
-    check!("archived:component:wide-modal", "archived:component", "wide-modal");
+    check!(
+        "archived:component:wide-modal",
+        "archived:component",
+        "wide-modal",
+    );
     check!("_default:start", "_default", "start");
     check!("_default:_template", "_default", "_template");
 }
@@ -164,7 +175,10 @@ fn test_trim_default() {
     check!("apple", "apple");
     check!("foo-bar", "foo-bar");
     check!("component:wide-modal", "component:wide-modal");
-    check!("archived:component:wide-modal", "archived:component:wide-modal");
+    check!(
+        "archived:component:wide-modal",
+        "archived:component:wide-modal",
+    );
     check!("_default:start", "start");
     check!("_default:foo-bar", "foo-bar");
     check!("_default:_template", "_template");

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -59,6 +59,12 @@ pub fn get_category_name(slug: &str) -> &str {
     split_category_name(slug).0
 }
 
+/// Determines if a slug is valid or not.
+///
+/// This does *not* check if the slug is normalized,
+/// but it does check if the slug contains incorrect
+/// constructions, such as empty category or page sub-slugs.
+// TODO do we need this? we should be normalizing anyways?
 #[allow(dead_code)] // TEMP
 pub fn slug_is_valid(slug: &str) -> bool {
     let (category, page) = split_category_name(slug);

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -30,7 +30,7 @@ pub fn split_category(slug: &str) -> (Option<&str>, &str) {
         None => (None, slug),
         Some(idx) => {
             let (category, page) = slug.split_at(idx);
-            (Some(category), page)
+            (Some(category), &page[1..])
         }
     }
 }

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -69,7 +69,7 @@ pub fn get_category_name(slug: &str) -> &str {
 pub fn slug_is_valid(slug: &str) -> bool {
     let (category, page) = split_category_name(slug);
     !slug.starts_with(':')
-        && slug.contains("::")
+        && !slug.contains("::")
         && !category.is_empty()
         && !page.is_empty()
 }

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -63,3 +63,23 @@ pub fn get_category_name(slug: &str) -> &str {
 pub fn trim_default(slug: &str) -> &str {
     slug.strip_prefix("_default:").unwrap_or(slug)
 }
+
+#[test]
+fn test_split_category() {
+    macro_rules! check {
+        ($input:expr, $category:expr, $page:expr $(,)?) => {
+            assert_eq!(
+                split_category($input),
+                ($category, $page),
+                "Actual split category doesn't match expected",
+            )
+        };
+    }
+
+    // Proper
+    check!("apple", None, "apple");
+    check!("banana:apple", Some("banana"), "apple");
+    check!("cherry:banana:apple", Some("cherry:banana"), "apple");
+    check!("_default:start", Some("_default"), "start");
+    check!("_default:_template", Some("_default"), "_template");
+}

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -76,11 +76,10 @@ fn test_split_category() {
         };
     }
 
-    // Proper
-    check!("foo-bar", None, "foo-bar");
     check!("apple", None, "apple");
-    check!("banana:apple", Some("banana"), "apple");
-    check!("cherry:banana:apple", Some("cherry:banana"), "apple");
+    check!("foo-bar", None, "foo-bar");
+    check!("component:wide-modal", Some("component"), "wide-modal");
+    check!("archived:component:wide-modal", Some("archived:component"), "wide-modal");
     check!("_default:start", Some("_default"), "start");
     check!("_default:_template", Some("_default"), "_template");
 }
@@ -92,16 +91,15 @@ fn test_split_category_name() {
             assert_eq!(
                 split_category_name($input),
                 ($category, $page),
-                "Actual split category doesn't match expected",
+                "Actual split category with name doesn't match expected",
             )
         };
     }
 
-    // Proper
-    check!("foo-bar", "_default", "foo-bar");
     check!("apple", "_default", "apple");
-    check!("banana:apple", "banana", "apple");
-    check!("cherry:banana:apple", "cherry:banana", "apple");
+    check!("foo-bar", "_default", "foo-bar");
+    check!("component:wide-modal", "component", "wide-modal");
+    check!("archived:component:wide-modal", "archived:component", "wide-modal");
     check!("_default:start", "_default", "start");
     check!("_default:_template", "_default", "_template");
 }

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -123,3 +123,23 @@ fn test_get_category() {
     check!("_default:start", Some("_default"));
     check!("_default:_template", Some("_default"));
 }
+
+#[test]
+fn test_get_category_name() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {
+            assert_eq!(
+                get_category_name($input),
+                $expected,
+                "Actual parsed category doesn't match expected",
+            )
+        };
+    }
+
+    check!("apple", "_default");
+    check!("foo-bar", "_default");
+    check!("component:wide-modal", "component");
+    check!("archived:component:wide-modal", "archived:component");
+    check!("_default:start", "_default");
+    check!("_default:_template", "_default");
+}

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -161,6 +161,36 @@ fn test_get_category_name() {
 }
 
 #[test]
+fn test_slug_is_valid() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {
+            assert_eq!(
+                slug_is_valid($input),
+                $expected,
+                "Actual slug validity doesn't match expected",
+            )
+        };
+    }
+
+    check!("", false);
+    check!("apple", true);
+    check!("", true);
+    check!("_template", true);
+    check!("component:wide-modal", true);
+    check!("archived:component:wide-modal", true);
+    check!(":banana", false);
+    check!("banana:", false);
+    check!(":banana:", false);
+    check!("::banana", false);
+    check!("banana::", false);
+    check!("::banana::", false);
+    check!("apple:banana:page", false);
+    check!("apple::banana:page", false);
+    check!("_default:", false);
+    check!("_default:apple", true);
+}
+
+#[test]
 fn test_trim_default() {
     macro_rules! check {
         ($input:expr, $expected:expr $(,)?) => {

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -56,7 +56,7 @@ pub fn get_category(slug: &str) -> Option<&str> {
 #[inline]
 #[allow(dead_code)] // TEMP
 pub fn get_category_name(slug: &str) -> &str {
-    get_category(slug).unwrap_or("_default")
+    split_category_name(slug).0
 }
 
 /// Trims off the `_default:` category if present.

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -59,6 +59,7 @@ pub fn get_category_name(slug: &str) -> &str {
     split_category_name(slug).0
 }
 
+#[allow(dead_code)] // TEMP
 pub fn slug_is_valid(slug: &str) -> bool {
     let (category, page) = split_category_name(slug);
     !slug.starts_with(':')

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -59,6 +59,11 @@ pub fn get_category_name(slug: &str) -> &str {
     split_category_name(slug).0
 }
 
+pub fn slug_is_valid(slug: &str) -> bool {
+    let (category, page) = split_category_name(slug);
+    !slug.starts_with(':') && slug.find("::").is_none() && !category.is_empty() && !page.is_empty()
+}
+
 /// Trims off the `_default:` category if present.
 pub fn trim_default(slug: &str) -> &str {
     slug.strip_prefix("_default:").unwrap_or(slug)

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -184,7 +184,7 @@ fn test_slug_is_valid() {
 
     check!("", false);
     check!("apple", true);
-    check!("", true);
+    check!("some-page", true);
     check!("_template", true);
     check!("component:wide-modal", true);
     check!("archived:component:wide-modal", true);
@@ -194,7 +194,7 @@ fn test_slug_is_valid() {
     check!("::banana", false);
     check!("banana::", false);
     check!("::banana::", false);
-    check!("apple:banana:page", false);
+    check!("apple:banana:page", true);
     check!("apple::banana:page", false);
     check!("_default:", false);
     check!("_default:apple", true);

--- a/deepwell/src/web/category.rs
+++ b/deepwell/src/web/category.rs
@@ -143,3 +143,26 @@ fn test_get_category_name() {
     check!("_default:start", "_default");
     check!("_default:_template", "_default");
 }
+
+#[test]
+fn test_trim_default() {
+    macro_rules! check {
+        ($input:expr, $expected:expr $(,)?) => {
+            assert_eq!(
+                trim_default($input),
+                $expected,
+                "Actual trimmed slug doesn't match expected",
+            )
+        };
+    }
+
+    check!("apple", "apple");
+    check!("foo-bar", "foo-bar");
+    check!("component:wide-modal", "component:wide-modal");
+    check!("archived:component:wide-modal", "archived:component:wide-modal");
+    check!("_default:start", "start");
+    check!("_default:foo-bar", "foo-bar");
+    check!("_default:_template", "_template");
+    check!("archived:_default:start", "archived:_default:start");
+    check!("_default:archived:start", "_default:archived:start");
+}


### PR DESCRIPTION
Also adds (the possibly unneeded?) function `slug_is_valid()`, fixes `trim_default()`'s behavior with non-single-colon categories, and adds some tests.

This also enables non-single-colon categories, such as the category `abc:def` in `abc:def:ghi`. Previous the _first_ colon was used to separate the category/page, which I think is less useful because if you see `archived:component:page`, while [multicategories are _not_ supported](https://scuttle.atlassian.net/browse/WJ-355) (that said, WJ-355 says we should redirect `abc:def:ghi` -> `abc-def:ghi`? which makes sense but is out of scope for this?) it allows categories to nominally exist with that name, though they do not exhibit any kind of "parent"-like relationship.