### PR TITLE
[WJ-1024] Add separate feature flag for the HTML renderer.

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.15.4"
+version = "1.16.0"
 dependencies = [
  "built",
  "cfg-if",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -18,9 +18,11 @@ name = "ftml"
 crate-type = ["cdylib", "lib"]
 
 [features]
-default  = ["mathml"]
+default  = ["html", "mathml"]
+# Adds HTML rendering.
+html     = []
 # Adds LaTeX -> MathML support for rendering.
-mathml   = ["latex2mathml"]
+mathml   = ["html", "latex2mathml"]
 
 [dependencies]
 cfg-if = "1"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.15.4"
+version = "1.16.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 rust-version = "1.60.0"

--- a/ftml/src/render/mod.rs
+++ b/ftml/src/render/mod.rs
@@ -26,10 +26,12 @@ mod prelude {
 }
 
 pub mod debug;
-pub mod html;
 pub mod json;
 pub mod null;
 pub mod text;
+
+#[cfg(feature = "html")]
+pub mod html;
 
 mod handle;
 

--- a/ftml/src/wasm/mod.rs
+++ b/ftml/src/wasm/mod.rs
@@ -39,6 +39,9 @@ mod prelude {
 pub use self::misc::version;
 pub use self::parsing::{parse, ParseOutcome, SyntaxTree};
 pub use self::preproc::preprocess;
-pub use self::render::{render_html, render_text};
+pub use self::render::render_text;
 pub use self::settings::WikitextSettings;
 pub use self::tokenizer::{tokenize, Tokenization};
+
+#[cfg(feature = "html")]
+pub use self::render::render_html;

--- a/ftml/src/wasm/render.rs
+++ b/ftml/src/wasm/render.rs
@@ -22,13 +22,18 @@ use super::page_info::PageInfo;
 use super::parsing::SyntaxTree;
 use super::prelude::*;
 use super::settings::WikitextSettings;
-use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use crate::render::text::TextRender;
 use crate::render::Render;
+
+#[cfg(feature = "html")]
 use std::sync::Arc;
+
+#[cfg(feature = "html")]
+use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 
 // Typescript declarations
 
+#[cfg(feature = "html")]
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &str = r#"
 
@@ -52,6 +57,7 @@ export interface IBacklinks {
 
 "#;
 
+#[cfg(feature = "html")]
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "string[]")]
@@ -66,12 +72,14 @@ extern "C" {
 
 // Wrapper structures
 
+#[cfg(feature = "html")]
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct HtmlOutput {
     inner: Arc<RustHtmlOutput>,
 }
 
+#[cfg(feature = "html")]
 #[wasm_bindgen]
 impl HtmlOutput {
     #[wasm_bindgen]
@@ -104,6 +112,7 @@ impl HtmlOutput {
 
 // Exported functions
 
+#[cfg(feature = "html")]
 #[wasm_bindgen]
 pub fn render_html(
     syntax_tree: SyntaxTree,

--- a/ftml/src/wasm/render/html.rs
+++ b/ftml/src/wasm/render/html.rs
@@ -1,5 +1,5 @@
 /*
- * wasm/render.rs
+ * wasm/render/html.rs
  *
  * ftml - Library to parse Wikidot text
  * Copyright (C) 2019-2022 Wikijump Team
@@ -18,22 +18,21 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::page_info::PageInfo;
-use super::parsing::SyntaxTree;
-use super::prelude::*;
-use super::settings::WikitextSettings;
-use crate::render::text::TextRender;
-use crate::render::Render;
+//! Isolated module for WASM HTML rendering.
+//!
+//! This submodule is separate to easily gate it within `#[cfg(feature = "html")]`,
+//! and so imports essentially the same fields as its parent.
 
-#[cfg(feature = "html")]
-use std::sync::Arc;
-
-#[cfg(feature = "html")]
+use super::super::page_info::PageInfo;
+use super::super::parsing::SyntaxTree;
+use super::super::prelude::*;
+use super::super::settings::WikitextSettings;
 use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
+use crate::render::Render;
+use std::sync::Arc;
 
 // Typescript declarations
 
-#[cfg(feature = "html")]
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &str = r#"
 
@@ -57,7 +56,6 @@ export interface IBacklinks {
 
 "#;
 
-#[cfg(feature = "html")]
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(typescript_type = "string[]")]
@@ -72,14 +70,12 @@ extern "C" {
 
 // Wrapper structures
 
-#[cfg(feature = "html")]
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct HtmlOutput {
     inner: Arc<RustHtmlOutput>,
 }
 
-#[cfg(feature = "html")]
 #[wasm_bindgen]
 impl HtmlOutput {
     #[wasm_bindgen]
@@ -110,9 +106,8 @@ impl HtmlOutput {
     }
 }
 
-// Exported functions
+// Function exports
 
-#[cfg(feature = "html")]
 #[wasm_bindgen]
 pub fn render_html(
     syntax_tree: SyntaxTree,
@@ -127,18 +122,4 @@ pub fn render_html(
     HtmlOutput {
         inner: Arc::new(html),
     }
-}
-
-#[wasm_bindgen]
-pub fn render_text(
-    syntax_tree: SyntaxTree,
-    page_info: PageInfo,
-    settings: WikitextSettings,
-) -> String {
-    let tree = syntax_tree.get();
-    let page_info = page_info.get();
-    let settings = settings.get();
-    let text = TextRender.render(tree, page_info, settings);
-
-    text
 }

--- a/ftml/src/wasm/render/mod.rs
+++ b/ftml/src/wasm/render/mod.rs
@@ -21,15 +21,15 @@
 #[cfg(feature = "html")]
 mod html;
 
+#[cfg(feature = "html")]
+pub use self::html::*;
+
 use super::page_info::PageInfo;
 use super::parsing::SyntaxTree;
 use super::prelude::*;
 use super::settings::WikitextSettings;
 use crate::render::text::TextRender;
 use crate::render::Render;
-
-#[cfg(feature = "html")]
-pub use self::html::*;
 
 // Function exports
 

--- a/ftml/src/wasm/render/mod.rs
+++ b/ftml/src/wasm/render/mod.rs
@@ -1,0 +1,48 @@
+/*
+ * wasm/render/mod.rs
+ *
+ * ftml - Library to parse Wikidot text
+ * Copyright (C) 2019-2022 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#[cfg(feature = "html")]
+mod html;
+
+use super::page_info::PageInfo;
+use super::parsing::SyntaxTree;
+use super::prelude::*;
+use super::settings::WikitextSettings;
+use crate::render::text::TextRender;
+use crate::render::Render;
+
+#[cfg(feature = "html")]
+pub use self::html::*;
+
+// Function exports
+
+#[wasm_bindgen]
+pub fn render_text(
+    syntax_tree: SyntaxTree,
+    page_info: PageInfo,
+    settings: WikitextSettings,
+) -> String {
+    let tree = syntax_tree.get();
+    let page_info = page_info.get();
+    let settings = settings.get();
+    let text = TextRender.render(tree, page_info, settings);
+
+    text
+}


### PR DESCRIPTION
This adds a new feature to the `ftml` crate called `html`, enabled by default, which covers `HtmlRender` and related code. This way, a potential user who does not want the HTML renderer (either because they only want the syntax tree or have their own custom renderer) do not need to bring in what is a fairly large segment of the code.