### PR TITLE
Update wikidot-normalize crate

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
  "tide",
  "unic-langid",
  "void",
- "wikidot-normalize",
+ "wikidot-normalize 0.10.0",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ dependencies = [
  "void",
  "wasm-bindgen",
  "web-sys",
- "wikidot-normalize",
+ "wikidot-normalize 0.9.2",
 ]
 
 [[package]]
@@ -3394,6 +3394,19 @@ name = "wikidot-normalize"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d588fdb14aa51e8a5dc3e3b90cdc54dfedf93828d8fb638180cd5b3a92f15d76"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "regex",
+ "trim-in-place",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "wikidot-normalize"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8a6e16ee5d9b390282f1544e7634b4162694e72203ec8a84d63c0695ea97a"
 dependencies = [
  "lazy_static",
  "maplit",

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.15"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
@@ -899,16 +899,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
-]
-
-[[package]]
-name = "dashmap"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
@@ -1080,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "femme"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2997b612abb06bc299486c807e68c5fd12e7618e69cf34c5958ca6b575674403"
+checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1150,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577ad028ee5aff9512c1e3f533e15109585ec9102ecf1f7a290a6ac16b4ff003"
+checksum = "34e9d845a5e2a128ebf81802632e1e40eb9581b5b651dde6f47149fb0d5c0f2b"
 dependencies = [
  "built",
  "cfg-if 1.0.0",
@@ -1395,7 +1385,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19775995ee20209163239355bc3ad2f33f83da35d9ef72dea26e5af753552c87"
 dependencies = [
- "dashmap 5.3.3",
+ "dashmap",
  "futures",
  "futures-timer",
  "no-std-compat",
@@ -1524,13 +1514,12 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "6.5.1"
+version = "6.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
+checksum = "e023af341b797ce2c039f7c6e1d347b68d0f7fd0bc7ac234fe69cfadcca1f89a"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
- "dashmap 4.0.2",
  "http-types",
  "log",
 ]
@@ -1860,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
@@ -2130,9 +2119,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
@@ -2918,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1"
 tide = "0.16"
 unic-langid = "0.9"
 void = "1"
-wikidot-normalize = "0.9"
+wikidot-normalize = "0.10"
 
 # NOTE: "indexmap" was formerly pinned to "=1.6.2" to avoid a cyclic dependency issue.
 #       This seems to no longer be necessary, but the comment is kept here in case it becomes a problem again.

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -612,9 +612,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid",
 ]
@@ -990,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -1307,9 +1307,9 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "wikidot-normalize"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d588fdb14aa51e8a5dc3e3b90cdc54dfedf93828d8fb638180cd5b3a92f15d76"
+checksum = "6fb8a6e16ee5d9b390282f1544e7634b4162694e72203ec8a84d63c0695ea97a"
 dependencies = [
  "lazy_static",
  "maplit",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -47,7 +47,7 @@ strum_macros = "0.24"
 tinyvec = "1"
 unicase = "2"
 void = "1"
-wikidot-normalize = "0.9"
+wikidot-normalize = "0.10"
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }


### PR DESCRIPTION
I recently merged https://github.com/scpwiki/wikidot-normalize/pull/2, and so bumped the crate version. This PR updates the versions used to this latest change.