### PR TITLE
[WJ-988] Add page moves

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 

--- a/deepwell/src/api/internal.rs
+++ b/deepwell/src/api/internal.rs
@@ -77,6 +77,9 @@ pub fn build(mut app: ApiServer) -> ApiServer {
         .post(page_edit)
         .delete(page_delete);
 
+    app.at("/page/:site_id/:type/:id_or_slug/move/:new_slug")
+        .post(page_move);
+
     app.at("/page/:site_id/:page_id/rerender")
         .post(page_rerender);
 

--- a/deepwell/src/methods/page.rs
+++ b/deepwell/src/methods/page.rs
@@ -163,6 +163,7 @@ pub async fn page_move(mut req: ApiRequest) -> ApiResponse {
     let reference = Reference::try_from(&req)?;
     let site_id = req.param("site_id")?.parse()?;
     let new_slug = req.param("new_slug")?;
+
     tide::log::info!(
         "Moving page {:?} in site ID {} to {}",
         reference,

--- a/deepwell/src/models/sea_orm_active_enums.rs
+++ b/deepwell/src/models/sea_orm_active_enums.rs
@@ -16,4 +16,6 @@ pub enum RevisionType {
     Regular,
     #[sea_orm(string_value = "undelete")]
     Undelete,
+    #[sea_orm(string_value = "move")]
+    Move,
 }

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -199,10 +199,13 @@ impl PageService {
             RevisionService::create(ctx, site_id, page_id, revision_input, last_revision)
                 .await?;
 
-        // Update page category ID.
-        // We also of course bump the updated_at column.
+        // Update page after move. This changes:
+        // * slug             -- New slug for the page
+        // * page_category_id -- In case the category also changed
+        // * updated_at       -- This is updated every time a page is changed
         let model = page::ActiveModel {
             page_id: Set(page_id),
+            slug: Set(new_slug.clone()),
             page_category_id: Set(category_id),
             updated_at: Set(Some(now())),
             ..Default::default()
@@ -226,7 +229,6 @@ impl PageService {
             }),
             None => {
                 tide::log::error!("Page move did not create new revision");
-
                 Err(Error::BadRequest)
             }
         }

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -156,9 +156,9 @@ impl PageService {
         reference: Reference<'_>,
         MovePage {
             revision_comments: comments,
-            mut new_slug,
             user_id,
         }: MovePage,
+        mut new_slug: String,
     ) -> Result<MovePageOutput> {
         let txn = ctx.transaction();
 

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -172,6 +172,7 @@ impl PageService {
         // and that a page with that slug doesn't already exist.
         normalize(&mut new_slug);
         if old_slug == new_slug {
+            tide::log::error!("Source and destination slugs are the same: {}", old_slug);
             return Err(Error::BadRequest);
         }
 

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -96,6 +96,14 @@ pub struct EditPageOutput {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct MovePage {
+    pub revision_comments: String,
+    pub new_slug: String,
+    pub user_id: i64,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct DeletePage {
     pub revision_comments: String,
     pub user_id: i64,

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -98,8 +98,8 @@ pub struct EditPageOutput {
 #[serde(rename_all = "camelCase")]
 pub struct MovePage {
     pub revision_comments: String,
-    pub new_slug: String,
     pub user_id: i64,
+    // NOTE: slug field is a parameter, not in the body
 }
 
 #[derive(Serialize, Debug)]

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -102,6 +102,16 @@ pub struct MovePage {
     pub user_id: i64,
 }
 
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MovePageOutput {
+    pub old_slug: String,
+    pub new_slug: String,
+    pub revision_id: i64,
+    pub revision_number: i32,
+    pub parser_warnings: Option<Vec<ParseWarning>>,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DeletePage {

--- a/deepwell/src/services/revision/service.rs
+++ b/deepwell/src/services/revision/service.rs
@@ -196,6 +196,9 @@ impl RevisionService {
             return Ok(None);
         }
 
+        // Calculate rating
+        let rating = ScoreService::score(ctx, page_id).await?;
+
         // Run tasks based on changes:
         // See RevisionTasks struct for more information.
         let tasks = RevisionTasks::determine(&changes);
@@ -208,7 +211,7 @@ impl RevisionService {
                 slug: &slug,
                 title: &title,
                 alt_title: alt_title.ref_map(|s| s.as_str()),
-                rating: 0.0, // TODO
+                rating,
                 tags: &temp_tags,
             };
 

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -81,7 +81,8 @@ class DeepwellPage extends Migration
                 'regular',
                 'create',
                 'delete',
-                'undelete'
+                'undelete',
+                'move'
             )
         ");
 

--- a/web/database/migrations/2022_01_11_031640_deepwell_page.php
+++ b/web/database/migrations/2022_01_11_031640_deepwell_page.php
@@ -81,8 +81,7 @@ class DeepwellPage extends Migration
                 'regular',
                 'create',
                 'delete',
-                'undelete',
-                'move'
+                'undelete'
             )
         ");
 

--- a/web/database/migrations/2022_05_19_223203_revision_type_move.php
+++ b/web/database/migrations/2022_05_19_223203_revision_type_move.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RevisionTypeMove extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TYPE revision_type ADD VALUE IF NOT EXISTS 'move'");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Cannot undo
+    }
+}


### PR DESCRIPTION
Depends on #984 	

This adds a DEEPWELL method to move / rename a page. The `RevisionService::create()` method already handled slug moves, but this was never invoked in any code.

The new `PageService::rename()` method (since `move` is a Rust reserved word) makes a revision which only alters the `slug`, and ensures the `page` row in the database is updated appropriately.

I have also added a new `revision_type` of `move` to correspond with these revisions which only encompass slug changes (otherwise they are indistinguishable from `regular` revisions). This revision type is automatically applied to any revision which changes the slug, but because only the `PageService::rename()` method does so, and does not alter any other fields, it is effectively solely reserved for page moves.