### PR TITLE
Fixes bug in vite-pack

### DIFF
--- a/web/scripts/vite-pack.js
+++ b/web/scripts/vite-pack.js
@@ -193,7 +193,7 @@ async function copy(from, to, isDir) {
         let fromPath = path.join(from, entry.name)
         let toPath = path.join(to, entry.name)
 
-        return entry.isDirectory() ?
+        entry.isDirectory() ?
           await copy(fromPath, toPath, true) :
           await fs.copyFile(fromPath, toPath)
       }


### PR DESCRIPTION
This fixes the packing script only copying the first entry in each level and folder, which I overlooked in #979.