### PR TITLE
Decrease dependabot updating to once a week

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,22 +6,22 @@ updates:
   - package-ecosystem: composer
     directory: "/web"
     schedule:
-      interval: weekly # Eventually change to 'daily'
+      interval: weekly
 
   # Frontend
   - package-ecosystem: npm
     directory: "/web"
     schedule:
-      interval: daily
+      interval: weekly
 
   # DEEPWELL
   - package-ecosystem: cargo
     directory: "/deepwell"
     schedule:
-      interval: daily
+      interval: weekly
 
   # FTML
   - package-ecosystem: cargo
     directory: "/ftml"
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
We've had it at daily for a while, and most updates are not urgent enough to require the PR spam that it creates. I think once a week is more than sufficient to balance frequency with notification generation.