### PR TITLE
Modify workflow activations to work properly on external PRs

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -7,7 +7,6 @@ on:
       - "ftml/test/*"
       - ".github/workflows/client.yaml"
       - ".github/codecov.yml"
-
   push:
     branches:
       - develop

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -1,12 +1,17 @@
 name: "[web] PHP and TypeScript"
 
 on:
-  push:
+  pull_request:
     paths:
       - "web/**"
       - "ftml/test/*"
       - ".github/workflows/client.yaml"
       - ".github/codecov.yml"
+
+  push:
+    branches:
+      - develop
+      - prod
 
 jobs:
   validate:

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -8,7 +8,6 @@ on:
       - 'deepwell/src/**'
       - '.github/workflows/deepwell.yaml'
       - '.gihub/codecov.yml'
-
   push:
     branches:
       - develop

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -1,13 +1,18 @@
 name: '[deepwell] Rust'
 
 on:
-  push:
+  pull_request:
     paths:
       - 'deepwell/Cargo.toml'
       - 'deepwell/Cargo.lock'
       - 'deepwell/src/**'
       - '.github/workflows/deepwell.yaml'
       - '.gihub/codecov.yml'
+
+  push:
+    branches:
+      - develop
+      - prod
 
 jobs:
   binary_build_and_test:

--- a/.github/workflows/docker-build-api.dev.yaml
+++ b/.github/workflows/docker-build-api.dev.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build API (dev)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'deepwell/**'
       - 'install/aws/dev/docker/api/Dockerfile'

--- a/.github/workflows/docker-build-api.local.yaml
+++ b/.github/workflows/docker-build-api.local.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build API (local)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'deepwell/**'
       - 'install/local/dev/api/Dockerfile'

--- a/.github/workflows/docker-build-api.prod.yaml
+++ b/.github/workflows/docker-build-api.prod.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build API (prod)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'deepwell/*'
       - 'install/aws/prod/docker/api/Dockerfile'

--- a/.github/workflows/docker-build-nginx.dev.yaml
+++ b/.github/workflows/docker-build-nginx.dev.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build Nginx (dev)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/web/**'
       - 'web/package.json'

--- a/.github/workflows/docker-build-nginx.local.yaml
+++ b/.github/workflows/docker-build-nginx.local.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build Nginx (local)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/web/**'
       - 'web/package.json'

--- a/.github/workflows/docker-build-nginx.prod.yaml
+++ b/.github/workflows/docker-build-nginx.prod.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build Nginx (prod)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/web/**'
       - 'web/package.json'

--- a/.github/workflows/docker-build-php.dev.yaml
+++ b/.github/workflows/docker-build-php.dev.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PHP-FPM (dev)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/**/*.php'
       - 'web/composer.*'

--- a/.github/workflows/docker-build-php.local.yaml
+++ b/.github/workflows/docker-build-php.local.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PHP-FPM (local)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/**/*.php'
       - 'web/composer.*'

--- a/.github/workflows/docker-build-php.prod.yaml
+++ b/.github/workflows/docker-build-php.prod.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PHP-FPM (prod)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/**/*.php'
       - 'web/composer.*'

--- a/.github/workflows/docker-build-postgres.dev.yaml
+++ b/.github/workflows/docker-build-postgres.dev.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PostgreSQL (dev)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/database/**'
       - 'install/files/postgres/**'

--- a/.github/workflows/docker-build-postgres.local.yaml
+++ b/.github/workflows/docker-build-postgres.local.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PostgreSQL (local)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/database/**'
       - 'install/files/postgres/**'

--- a/.github/workflows/docker-build-postgres.prod.yaml
+++ b/.github/workflows/docker-build-postgres.prod.yaml
@@ -1,10 +1,7 @@
 name: '[backend] Docker build PostgreSQL (prod)'
 
 on:
-  push:
-    branches-ignore:
-      - develop
-      - prod
+  pull_request:
     paths:
       - 'web/database/**'
       - 'install/files/postgres/**'

--- a/.github/workflows/ftml-config.yaml
+++ b/.github/workflows/ftml-config.yaml
@@ -1,7 +1,7 @@
 name: '[ftml] Rust'
 
 on:
-  push:
+  pull_request:
     paths:
       - 'ftml/Cargo.toml'
       - 'ftml/Cargo.lock'
@@ -10,6 +10,11 @@ on:
       - 'ftml/src/**/*'
       - 'ftml/scripts/*'
       - '.github/workflows/ftml-config.yaml'
+
+  push:
+    branches:
+      - develop
+      - prod
 
 jobs:
   conf_check:

--- a/.github/workflows/ftml-config.yaml
+++ b/.github/workflows/ftml-config.yaml
@@ -10,7 +10,6 @@ on:
       - 'ftml/src/**/*'
       - 'ftml/scripts/*'
       - '.github/workflows/ftml-config.yaml'
-
   push:
     branches:
       - develop

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -10,7 +10,6 @@ on:
       - 'ftml/test/*'
       - '.github/workflows/ftml.yaml'
       - '.github/codecov.yml'
-
   push:
     branches:
       - develop

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -1,7 +1,7 @@
 name: '[ftml] Rust'
 
 on:
-  push:
+  pull_request:
     paths:
       - 'ftml/Cargo.toml'
       - 'ftml/Cargo.lock'
@@ -10,6 +10,11 @@ on:
       - 'ftml/test/*'
       - '.github/workflows/ftml.yaml'
       - '.github/codecov.yml'
+
+  push:
+    branches:
+      - develop
+      - prod
 
 jobs:
   library_build_and_test:

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -1,10 +1,15 @@
 name: '[l10n] Localization'
 
 on:
-  push:
+  pull_request:
     paths:
       - 'locales/**'
       - '.github/workflows/locales.yaml'
+
+  push:
+    branches:
+      - develop
+      - prod
 
 jobs:
   check:

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -5,7 +5,6 @@ on:
     paths:
       - 'locales/**'
       - '.github/workflows/locales.yaml'
-
   push:
     branches:
       - develop


### PR DESCRIPTION
Apparently we've been doing this wrong. The [GitHub workflow documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) has a separate activation for PRs. The `push` workflow type applies only when a commit is added to this repository, so it will not activate for external PRs, explaining our issue.

The `branches-ignore` for `pull_request` is different than `push`. We remove it here because otherwise it doesn't run on PRs _targeting_ that branch, which is the main point of most PRs.

This change also makes it so pushes to `develop` and `prod` run all the standard checks (e.g. `ftml.yaml`) on every merge. May as well do this, it both avoids duplicating the path globs, and ensures nothing incidentally breaks through some unexpected side channel.