### PR TITLE
Add include compatibility mode setting

### DIFF
--- a/ftml/README.md
+++ b/ftml/README.md
@@ -123,6 +123,7 @@ Finally, with the syntax tree you `render` it with whatever `Render` instance yo
 fn include<'t, I, E>(
     input: &'t str,
     includer: I,
+    settings: &WikitextSettings,
 ) -> Result<(String, Vec<PageRef<'t>>), E>
 where
     I: Includer<'t, Error = E>;
@@ -171,19 +172,19 @@ let includer = MyIncluderImpl::new();
 let mut input = "**some** test <<string?>>";
 
 // Substitute page inclusions
-let (mut text, included_pages) = ftml::include(&log, input, includer);
+let (mut text, included_pages) = ftml::include(input, includer, &settings);
 
 // Perform preprocess substitions
 ftml::preprocess(&log, &mut text);
 
 // Generate token from input text
-let tokens = ftml::tokenize(&log, &text);
+let tokens = ftml::tokenize(&text);
 
 // Parse the token list to produce an AST.
 //
 // Note that this produces a `ParseResult<SyntaxTree>`, which records the
 // parsing warnings in addition to the final result.
-let result = ftml::parse(&log, &tokens);
+let result = ftml::parse(&tokens, &page_info, &settings);
 
 // Here we extract the tree separately from the warning list.
 //
@@ -197,7 +198,7 @@ let (tree, warnings) = result.into();
 // You must provide a `PageInfo` struct, which describes the page being rendered.
 // You must also provide a handle to provide various remote sources, such as
 // module content, but this is not stabilized yet.
-let html_output = HtmlRender.render(&log, &page_info, &tree);
+let html_output = HtmlRender.render(&tree, &page_info, &settings);
 ```
 
 ### JSON Serialization

--- a/ftml/src/includes/grammar.pest
+++ b/ftml/src/includes/grammar.pest
@@ -31,9 +31,21 @@
 // That is, all internal parameters need pipes inside, but the last does not,
 // and is optional should the sequence end in a pipe.
 
-include = {
+// Normal version ([[include-messy]] only)
+include_normal = {
     SOI ~ // Because we slice from the start of an include block using regex
     "[[" ~ space? ~ ^"include-messy" ~ space ~
+    page_ref ~ space? ~
+    ("|" ~ space?)? ~
+    (argument ~ space? ~ "|" ~ space?)* ~
+    (argument ~ space? ~ "|"?)? ~
+    space? ~ include_end
+}
+
+// Compatibility version (accepts [[include]] too)
+include_compatibility = {
+    SOI ~ // Because we slice from the start of an include block using regex
+    "[[" ~ space? ~ (^"include" | ^"include-messy") ~ space ~
     page_ref ~ space? ~
     ("|" ~ space?)? ~
     (argument ~ space? ~ "|" ~ space?)* ~

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -86,7 +86,7 @@ where
             mtch.as_str(),
         );
 
-        match parse_include_block(&input[start..], start) {
+        match parse_include_block(&input[start..], start, settings) {
             Ok((include, end)) => {
                 ranges.push(start..end);
                 includes.push(include);

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -20,6 +20,7 @@
 
 use super::IncludeRef;
 use crate::data::{PageRef, PageRefParseError};
+use crate::settings::WikitextSettings;
 use pest::iterators::Pairs;
 use pest::Parser;
 use std::borrow::Cow;
@@ -29,11 +30,18 @@ use std::collections::HashMap;
 #[grammar = "includes/grammar.pest"]
 struct IncludeParser;
 
-pub fn parse_include_block(
-    text: &str,
+pub fn parse_include_block<'t>(
+    text: &'t str,
     start: usize,
-) -> Result<(IncludeRef, usize), IncludeParseError> {
-    match IncludeParser::parse(Rule::include, text) {
+    settings: &WikitextSettings,
+) -> Result<(IncludeRef<'t>, usize), IncludeParseError> {
+    let rule = if settings.use_include_compatibility {
+        Rule::include_compatibility
+    } else {
+        Rule::include_normal
+    };
+
+    match IncludeParser::parse(rule, text) {
         Ok(mut pairs) => {
             // Extract inner pairs
             // These actually make up the include block's tokens

--- a/ftml/src/settings/mod.rs
+++ b/ftml/src/settings/mod.rs
@@ -38,6 +38,14 @@ pub struct WikitextSettings {
     /// * Button
     pub enable_page_syntax: bool,
 
+    /// Whether a literal `[[include]]` is permitted.
+    ///
+    /// If this is true, then `[[include]]` is treated as an alias
+    /// for `[[include-messy]]`, which is necessary for Wikidot compatibility.
+    ///
+    /// It is off by default.
+    pub use_include_compatibility: bool,
+
     /// Whether IDs should have true values, or be excluded or randomly generated.
     ///
     /// In the latter case, IDs can be used for navigation, for instance
@@ -87,6 +95,7 @@ impl WikitextSettings {
             WikitextMode::Page => WikitextSettings {
                 mode,
                 enable_page_syntax: true,
+                use_include_compatibility: false,
                 use_true_ids: true,
                 isolate_user_ids: false,
                 allow_local_paths: true,
@@ -95,6 +104,7 @@ impl WikitextSettings {
             WikitextMode::Draft => WikitextSettings {
                 mode,
                 enable_page_syntax: true,
+                use_include_compatibility: false,
                 use_true_ids: false,
                 isolate_user_ids: false,
                 allow_local_paths: true,
@@ -103,6 +113,7 @@ impl WikitextSettings {
             WikitextMode::ForumPost | WikitextMode::DirectMessage => WikitextSettings {
                 mode,
                 enable_page_syntax: false,
+                use_include_compatibility: false,
                 use_true_ids: false,
                 isolate_user_ids: false,
                 allow_local_paths: false,
@@ -111,6 +122,7 @@ impl WikitextSettings {
             WikitextMode::List => WikitextSettings {
                 mode,
                 enable_page_syntax: true,
+                use_include_compatibility: false,
                 use_true_ids: false,
                 isolate_user_ids: false,
                 allow_local_paths: true,

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -54,6 +54,7 @@ fn isolate_user_ids() {
         mode: WikitextMode::Page,
         enable_page_syntax: true,
         use_true_ids: true,
+        use_include_compatibility: false,
         isolate_user_ids: true,
         allow_local_paths: true,
         interwiki: EMPTY_INTERWIKI.clone(),


### PR DESCRIPTION
This adds the wikitext setting `use_include_compatibility`, which enables `[[include]]` as an alias for `[[include-messy]]`.