### PR TITLE
[WJ-971] Add orange links 

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -727,9 +727,9 @@ checksum = "d22b73985e369f260445a5e08ad470117b30e522c91b4820585baa2e0cbf7075"
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1154,9 +1154,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicase"

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.16.2"
+version = "1.16.3"
 dependencies = [
  "built",
  "cfg-if",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.16.2"
+version = "1.16.3"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -78,6 +78,11 @@ impl<'t> PageRef<'t> {
         (self.site(), self.page())
     }
 
+    /// Like `fields()`, but uses the passed in value as the current site for local references.
+    pub fn fields_or<'a>(&'a self, current_site: &'a str) -> (&'a str, &'a str) {
+        (self.site().unwrap_or(current_site), self.page())
+    }
+
     pub fn parse(s: &'t str) -> Result<PageRef<'t>, PageRefParseError> {
         let s = s.trim();
         if s.is_empty() {

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -122,8 +122,8 @@ impl Handle {
                 LinkLocation::Page(page_ref) => page_ref.page(),
             },
             LinkLabel::Page => match link {
-                LinkLocation::Url(url) => {
-                    panic!("Requested link label of page for a URL")
+                LinkLocation::Url(_) => {
+                    panic!("Requested link label of page for a URL");
                 }
                 LinkLocation::Page(page_ref) => {
                     let (site, page) = page_ref.fields_or(site);

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -63,6 +63,12 @@ impl Handle {
     pub fn get_page_exists(&self, _site: &str, _page: &str) -> bool {
         info!("Checking page existence");
 
+        // For testing
+        #[cfg(test)]
+        if _page == "missing" {
+            return false;
+        }
+
         // TODO
         true
     }

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -53,11 +53,18 @@ impl Handle {
         }
     }
 
-    pub fn get_page_title(&self, link: &LinkLocation) -> String {
+    pub fn get_page_title(&self, _site: &str, _page: &str) -> Option<String> {
         info!("Fetching page title");
 
         // TODO
-        format!("TODO: actual title ({:?})", link)
+        Some(format!("TODO: actual title ({_site} {_page})"))
+    }
+
+    pub fn get_page_exists(&self, _site: &str, _page: &str) -> bool {
+        info!("Checking page existence");
+
+        // TODO
+        true
     }
 
     pub fn get_user_info<'a>(&self, name: &'a str) -> Option<UserInfo<'a>> {
@@ -97,8 +104,13 @@ impl Handle {
         )))
     }
 
-    pub fn get_link_label<F>(&self, link: &LinkLocation, label: &LinkLabel, f: F)
-    where
+    pub fn get_link_label<F>(
+        &self,
+        page_info: &PageInfo,
+        link: &LinkLocation,
+        label: &LinkLabel,
+        f: F,
+    ) where
         F: FnOnce(&str),
     {
         let page_title;
@@ -109,10 +121,20 @@ impl Handle {
                 LinkLocation::Url(url) => url,
                 LinkLocation::Page(page_ref) => page_ref.page(),
             },
-            LinkLabel::Page => {
-                page_title = self.get_page_title(link);
-                &page_title
-            }
+            LinkLabel::Page => match link {
+                LinkLocation::Url(url) => {
+                    panic!("Requested link label of page for a URL")
+                }
+                LinkLocation::Page(page_ref) => {
+                    let (site, page) = page_ref.fields_or(&page_info.site);
+                    page_title = match self.get_page_title(site, page) {
+                        Some(title) => title,
+                        None => page_ref.to_string(),
+                    };
+
+                    &page_title
+                }
+            },
         };
 
         f(label_text);

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -106,7 +106,7 @@ impl Handle {
 
     pub fn get_link_label<F>(
         &self,
-        page_info: &PageInfo,
+        site: &str,
         link: &LinkLocation,
         label: &LinkLabel,
         f: F,
@@ -126,7 +126,7 @@ impl Handle {
                     panic!("Requested link label of page for a URL")
                 }
                 LinkLocation::Page(page_ref) => {
-                    let (site, page) = page_ref.fields_or(&page_info.site);
+                    let (site, page) = page_ref.fields_or(site);
                     page_title = match self.get_page_title(site, page) {
                         Some(title) => title,
                         None => page_ref.to_string(),

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -64,7 +64,7 @@ where
     //
     // Cached data
     //
-    pages_exists: HashMap<(&'t str, &'t str), bool>,
+    pages_exists: HashMap<PageRef<'static>, bool>,
 
     //
     // Other fields to track
@@ -250,15 +250,15 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         }
     }
 
-    pub fn page_exists(&mut self, page_ref: &PageRef<'t>) -> bool {
-        let (site, page) = page_ref.fields_or(&self.page_info);
+    pub fn page_exists(&mut self, page_ref: &PageRef) -> bool {
+        let (site, page) = page_ref.fields_or(&self.info.site);
 
         // Get from cache, or fetch and add
-        match self.pages_exists.get(&(site, page)) {
+        match self.pages_exists.get(page_ref) {
             Some(exists) => *exists,
             None => {
                 let exists = self.handle.get_page_exists(site, page);
-                self.pages_exists.insert((site, page), exists);
+                self.pages_exists.insert(page_ref.to_owned(), exists);
                 exists
             }
         }

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -32,6 +32,7 @@ use crate::settings::WikitextSettings;
 use crate::tree::{Element, LinkLocation, VariableScopes};
 use crate::url::is_url;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::num::NonZeroUsize;
 
@@ -59,6 +60,11 @@ where
     //
     table_of_contents: &'e [Element<'t>],
     footnotes: &'e [Vec<Element<'t>>],
+
+    //
+    // Cached data
+    //
+    pages_exists: HashMap<(&'t str, &'t str), bool>,
 
     //
     // Other fields to track
@@ -90,6 +96,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
             variables: VariableScopes::new(),
             table_of_contents,
             footnotes,
+            pages_exists: HashMap::new(),
             code_snippet_index: NonZeroUsize::new(1).unwrap(),
             table_of_contents_index: 0,
             equation_index: NonZeroUsize::new(1).unwrap(),
@@ -239,6 +246,20 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
                     let page_ref = PageRef::page_only(cow!(link));
                     self.backlinks.internal_links.push(page_ref.to_owned());
                 }
+            }
+        }
+    }
+
+    pub fn page_exists(&mut self, page_ref: &PageRef<'t>) -> bool {
+        let (site, page) = page_ref.fields_or(&self.page_info);
+
+        // Get from cache, or fetch and add
+        match self.pages_exists.get(&(site, page)) {
+            Some(exists) => *exists,
+            None => {
+                let exists = self.handle.get_page_exists(site, page);
+                self.pages_exists.insert((site, page), exists);
+                exists
             }
         }
     }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -72,7 +72,13 @@ pub fn render_link(
         LinkLocation::Url(url) if url.starts_with('#') => "wj-link-anchor",
         LinkLocation::Url(url) if url.starts_with('/') => "wj-link-internal",
         LinkLocation::Url(_) => "wj-link-external",
-        LinkLocation::Page(_) => "wj-link-internal",
+        LinkLocation::Page(page) => {
+            if ctx.page_exists(&page) {
+                "wj-link-internal"
+            } else {
+                "wj-link-internal wj-link-missing"
+            }
+        }
     };
 
     let interwiki_class = if ltype == LinkType::Interwiki {

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -87,6 +87,7 @@ pub fn render_link(
         ""
     };
 
+    let site = ctx.info().site.as_ref().to_string();
     let mut tag = ctx.html().a();
     tag.attr(attr!(
         "href" => &url,
@@ -96,7 +97,7 @@ pub fn render_link(
     ));
 
     // Add <a> internals, i.e. the link name
-    handle.get_link_label(link, label, |label| {
+    handle.get_link_label(&site, link, label, |label| {
         tag.inner(label);
     });
 }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -73,7 +73,7 @@ pub fn render_link(
         LinkLocation::Url(url) if url.starts_with('/') => "wj-link-internal",
         LinkLocation::Url(_) => "wj-link-external",
         LinkLocation::Page(page) => {
-            if ctx.page_exists(&page) {
+            if ctx.page_exists(page) {
                 "wj-link-internal"
             } else {
                 "wj-link-internal wj-link-missing"

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -177,8 +177,9 @@ pub fn render_element(ctx: &mut TextContext, element: &Element) {
         }
         Element::Link { link, label, .. } => {
             let url = get_url_from_link(ctx, link);
+            let site = ctx.info().site.as_ref().to_string();
 
-            ctx.handle().get_link_label(link, label, |label| {
+            ctx.handle().get_link_label(&site, link, label, |label| {
                 ctx.push_str(label);
 
                 // Don't show URL if it's a name link, or an anchor

--- a/ftml/test/link-triple-missing.html
+++ b/ftml/test/link-triple-missing.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p><a href="/missing" class="wj-link wj-link-internal wj-link-missing" data-link-type="page">Wanted page</a></p></wj-body>

--- a/ftml/test/link-triple-missing.json
+++ b/ftml/test/link-triple-missing.json
@@ -1,0 +1,45 @@
+{
+    "input": "[[[missing | Wanted page]]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "link",
+                            "data": {
+                                "type": "page",
+                                "link": {
+                                    "site": null,
+                                    "page": "missing"
+                                },
+                                "label": {
+                                    "text": "Wanted page"
+                                },
+                                "target": null
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/link-triple-missing.txt
+++ b/ftml/test/link-triple-missing.txt
@@ -1,0 +1,1 @@
+Wanted page [/missing]

--- a/ftml/test/link-triple-site-title.html
+++ b/ftml/test/link-triple-site-title.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><a href="https://scp-wiki.wikijump.com/scp-series" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (Page(PageRef { site: Some(&quot;scp-wiki&quot;), page: &quot;scp-series&quot; }))</a></p></wj-body>
+<wj-body class="wj-body"><p><a href="https://scp-wiki.wikijump.com/scp-series" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (scp-wiki scp-series)</a></p></wj-body>

--- a/ftml/test/link-triple-site-title.txt
+++ b/ftml/test/link-triple-site-title.txt
@@ -1,1 +1,1 @@
-TODO: actual title (Page(PageRef { site: Some("scp-wiki"), page: "scp-series" })) [https://scp-wiki.wikijump.com/scp-series]
+TODO: actual title (scp-wiki scp-series) [https://scp-wiki.wikijump.com/scp-series]

--- a/ftml/test/link-triple-title-new-tab.html
+++ b/ftml/test/link-triple-title-new-tab.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><a href="/some-page" target="_blank" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (Page(PageRef { site: None, page: &quot;some-page&quot; }))</a></p></wj-body>
+<wj-body class="wj-body"><p><a href="/some-page" target="_blank" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (test some-page)</a></p></wj-body>

--- a/ftml/test/link-triple-title-new-tab.txt
+++ b/ftml/test/link-triple-title-new-tab.txt
@@ -1,1 +1,1 @@
-TODO: actual title (Page(PageRef { site: None, page: "some-page" })) [/some-page]
+TODO: actual title (test some-page) [/some-page]

--- a/ftml/test/link-triple-title.html
+++ b/ftml/test/link-triple-title.html
@@ -1,1 +1,1 @@
-<wj-body class="wj-body"><p><a href="/some-page" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (Page(PageRef { site: None, page: &quot;some-page&quot; }))</a></p></wj-body>
+<wj-body class="wj-body"><p><a href="/some-page" class="wj-link wj-link-internal" data-link-type="page">TODO: actual title (test some-page)</a></p></wj-body>

--- a/ftml/test/link-triple-title.txt
+++ b/ftml/test/link-triple-title.txt
@@ -1,1 +1,1 @@
-TODO: actual title (Page(PageRef { site: None, page: "some-page" })) [/some-page]
+TODO: actual title (test some-page) [/some-page]


### PR DESCRIPTION
This adds the class `wj-link-missing` to any triple-bracket links which have missing pages. This would correspond to the `newpage` class in Wikidot which is used to make links "orange" (corresponding page doesn't exist yet).