### PR TITLE
[WJ-814] Run through all ftml tests

### DIFF
--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -245,8 +245,7 @@ impl Test<'_> {
         if tree != self.tree {
             result = TestResult::Fail;
             eprintln!(
-                "Test '{}' AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nWarnings: {:#?}",
-                self.name,
+                "AST did not match:\nExpected: {:#?}\nActual: {:#?}\n{}\nWarnings: {:#?}",
                 self.tree,
                 tree,
                 json(&tree),
@@ -257,8 +256,7 @@ impl Test<'_> {
         if warnings != self.warnings {
             result = TestResult::Fail;
             eprintln!(
-                "Test '{}' warnings did not match:\nExpected: {:#?}\nActual:   {:#?}\n{}\nTree (correct): {:#?}",
-                self.name,
+                "Warnings did not match:\nExpected: {:#?}\nActual:   {:#?}\n{}\nTree (correct): {:#?}",
                 self.warnings,
                 warnings,
                 json(&warnings),
@@ -269,8 +267,7 @@ impl Test<'_> {
         if html_output.body != self.html {
             result = TestResult::Fail;
             eprintln!(
-                "Test '{}' HTML does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
-                self.name,
+                "HTML does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
                 self.html,
                 html_output.body,
                 html_output.body,
@@ -281,8 +278,7 @@ impl Test<'_> {
         if text_output != self.text {
             result = TestResult::Fail;
             eprintln!(
-                "Test '{}' text output does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
-                self.name,
+                "Text output does not match:\nExpected: {:?}\nActual:   {:?}\n\n{}\n\nTree (correct): {:#?}",
                 self.text,
                 text_output,
                 text_output,

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -366,16 +366,30 @@ fn ast_and_html() {
     tests.sort_by(|a, b| (a.name).cmp(&b.name));
 
     // Run tests
+    let mut failed = 0;
+    let mut skipped = 0;
+
     println!("Running {} syntax tree tests:", tests.len());
-    for test in tests {
-        test.run();
+    for test in &tests {
+        match test.run() {
+            TestResult::Pass => (),
+            TestResult::Fail => failed += 1,
+            TestResult::Skip => skipped += 1,
+        }
     }
 
-    // Ensure we don't accidentally commit excluded tests
-    if !SKIP_TESTS.is_empty() || !ONLY_TESTS.is_empty() {
-        println!("Files are being skipped, returning failure.");
+    println!();
+    println!("Ran a total of {} tests", tests.len());
+
+    if failed > 0 {
+        println!("Of these, {} failed", failed);
+    }
+
+    if skipped > 0 {
+        // Don't allow accidentally committing skipped tests
+        println!("Additionally, {} tests are being skipped", skipped);
         println!("Remember to re-enable all tests before committing!");
-
-        process::exit(2);
     }
+
+    process::exit(failed + skipped);
 }


### PR DESCRIPTION
Previously the AST test runner would quit as soon as it hit its first failure. This change now always runs through all the tests, so multiple runs are not required to debug test failures.