### PR TITLE
Temporary fix: Use npm to invoke compose instead of pnpm

### DIFF
--- a/web/scripts/dev/util.ts
+++ b/web/scripts/dev/util.ts
@@ -16,7 +16,7 @@ export async function pnpm(args: string, pipe = true, cd?: string) {
 export function compose(args: string, spawn?: false, pipe?: boolean): Promise<string>
 export function compose(args: string, spawn: true, pipe?: boolean): Promise<ChildProcess>
 export async function compose(args: string, spawn = false, pipe = true) {
-  const str = `pnpm -s compose${isSudo ? "-sudo" : ""} -- ${args}`
+  const str = `npm run compose${isSudo ? "-sudo" : ""} -- ${args}`
   return spawn ? await shell(str, pipe) : await cmd(str, pipe)
 }
 


### PR DESCRIPTION
Due to an unknown particular issue with pnpm, it passes in arguments incorrectly, preventing docker from being invoked.

Until this is investigated or fixed, the PR changes the script to invoke `npm` instead.

<details>
<summary>More information on the issue</summary>
The `pnpm dev` script fails to start up Docker Compose, reporting an error saying that you're trying to call `docker compose` with the command `compose logs` (it should just be `logs`).

Tracking this down, it's not an issue with the dev script, but in the utility file that invokes `pnpm -s compose -- [command]`. So looking at the `compose`/`compose-sudo` scripts, it runs the commands very faithfully (and if you use a shim script to print the arguments you see the same thing). Similarly, if you invoke this using `npm` and not `pnpm` it works fine.

So somehow `pnpm` is screwing up the command string (since node `child_process` wants a shell-like command string and not a list of arguments). This may be related to a newer pnpm change.
</details>
