### PR TITLE
Remove Croquembouche from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,16 +14,9 @@ deepwell                            @emmiegit
 web/app/Services/Deepwell           @emmiegit
 
 # Frontend monorepo
-.github/workflows/client.yaml       @Monkatraz @rossjrw
-web/modules                         @Monkatraz @rossjrw
-web/resources                       @Monkatraz @rossjrw
-
-# Frontend files related to browser scripting or styling.
-# (Wikidot legacy)
-.github/workflows/test-js.yaml      @rossjrw
-web/web/files--common/dialogs       @rossjrw
-web/web/files--common/javascript    @rossjrw
-web/web/files--common/modules       @rossjrw
+.github/workflows/client.yaml       @Monkatraz
+web/modules                         @Monkatraz
+web/resources                       @Monkatraz
 
 # Localization
 .github/workflows/locales.yaml      @emmiegit


### PR DESCRIPTION
After talking to @rossjrw, we agreed to remove them from the `CODEOWNERS` file since we aren't pursuing the legacy JS rehabilitation route, and they haven't been active on the project for a while.