### PR TITLE
Replace match statements with equivalent ok_or() methods.

### DIFF
--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -104,10 +104,7 @@ impl BlobService {
 
     #[inline]
     pub async fn get(ctx: &ServiceContext<'_>, hash: &[u8]) -> Result<Vec<u8>> {
-        match Self::get_optional(ctx, hash).await? {
-            Some(string) => Ok(string),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, hash).await?.ok_or(Error::NotFound)
     }
 
     pub async fn get_metadata_optional(

--- a/deepwell/src/services/category/service.rs
+++ b/deepwell/src/services/category/service.rs
@@ -76,10 +76,7 @@ impl CategoryService {
         site_id: i64,
         reference: Reference<'_>,
     ) -> Result<PageCategoryModel> {
-        match Self::get_optional(ctx, site_id, reference).await? {
-            Some(category) => Ok(category),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, site_id, reference).await?.ok_or(Error::NotFound)
     }
 
     #[inline]

--- a/deepwell/src/services/category/service.rs
+++ b/deepwell/src/services/category/service.rs
@@ -76,7 +76,9 @@ impl CategoryService {
         site_id: i64,
         reference: Reference<'_>,
     ) -> Result<PageCategoryModel> {
-        Self::get_optional(ctx, site_id, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, site_id, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     #[inline]

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -414,7 +414,9 @@ impl FileService {
         page_id: i64,
         reference: CuidReference<'_>,
     ) -> Result<FileModel> {
-        Self::get_optional(ctx, page_id, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, page_id, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     pub async fn exists(

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -414,10 +414,7 @@ impl FileService {
         page_id: i64,
         reference: CuidReference<'_>,
     ) -> Result<FileModel> {
-        match Self::get_optional(ctx, page_id, reference).await? {
-            Some(file) => Ok(file),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, page_id, reference).await?.ok_or(Error::NotFound)
     }
 
     pub async fn exists(

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -469,7 +469,9 @@ impl FileRevisionService {
         file_id: &str,
         revision_number: i32,
     ) -> Result<FileRevisionModel> {
-        Self::get_optional(ctx, page_id, file_id, revision_number).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, page_id, file_id, revision_number)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     /// Counts the number of revisions for a file.

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -469,10 +469,7 @@ impl FileRevisionService {
         file_id: &str,
         revision_number: i32,
     ) -> Result<FileRevisionModel> {
-        match Self::get_optional(ctx, page_id, file_id, revision_number).await? {
-            Some(revision) => Ok(revision),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, page_id, file_id, revision_number).await?.ok_or(Error::NotFound)
     }
 
     /// Counts the number of revisions for a file.

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -443,10 +443,7 @@ impl PageService {
         site_id: i64,
         reference: Reference<'_>,
     ) -> Result<PageModel> {
-        match Self::get_optional(ctx, site_id, reference).await? {
-            Some(page) => Ok(page),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, site_id, reference).await?.ok_or(Error::NotFound)
     }
 
     pub async fn get_optional(

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -443,7 +443,9 @@ impl PageService {
         site_id: i64,
         reference: Reference<'_>,
     ) -> Result<PageModel> {
-        Self::get_optional(ctx, site_id, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, site_id, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     pub async fn get_optional(

--- a/deepwell/src/services/parent/service.rs
+++ b/deepwell/src/services/parent/service.rs
@@ -141,10 +141,7 @@ impl ParentService {
         parent_page_ref: Reference<'_>,
         child_page_ref: Reference<'_>,
     ) -> Result<PageParentModel> {
-        match Self::get_optional(ctx, site_id, parent_page_ref, child_page_ref).await? {
-            Some(model) => Ok(model),
-            None => Err(Error::NotFound),
-        }
+       Self::get_optional(ctx, site_id, parent_page_ref, child_page_ref).await?.ok_or(Error::NotFound)
     }
 
     /// Gets all relationships of the given type.

--- a/deepwell/src/services/parent/service.rs
+++ b/deepwell/src/services/parent/service.rs
@@ -141,7 +141,9 @@ impl ParentService {
         parent_page_ref: Reference<'_>,
         child_page_ref: Reference<'_>,
     ) -> Result<PageParentModel> {
-       Self::get_optional(ctx, site_id, parent_page_ref, child_page_ref).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, site_id, parent_page_ref, child_page_ref)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     /// Gets all relationships of the given type.

--- a/deepwell/src/services/revision/service.rs
+++ b/deepwell/src/services/revision/service.rs
@@ -764,7 +764,9 @@ impl RevisionService {
         page_id: i64,
         revision_number: i32,
     ) -> Result<PageRevisionModel> {
-        Self::get_optional(ctx, site_id, page_id, revision_number).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, site_id, page_id, revision_number)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     pub async fn count(

--- a/deepwell/src/services/revision/service.rs
+++ b/deepwell/src/services/revision/service.rs
@@ -764,10 +764,7 @@ impl RevisionService {
         page_id: i64,
         revision_number: i32,
     ) -> Result<PageRevisionModel> {
-        match Self::get_optional(ctx, site_id, page_id, revision_number).await? {
-            Some(revision) => Ok(revision),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, site_id, page_id, revision_number).await?.ok_or(Error::NotFound)
     }
 
     pub async fn count(

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -61,6 +61,8 @@ impl SiteService {
         ctx: &ServiceContext<'_>,
         reference: Reference<'_>,
     ) -> Result<SiteModel> {
-        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 }

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -61,9 +61,6 @@ impl SiteService {
         ctx: &ServiceContext<'_>,
         reference: Reference<'_>,
     ) -> Result<SiteModel> {
-        match Self::get_optional(ctx, reference).await? {
-            Some(site) => Ok(site),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
     }
 }

--- a/deepwell/src/services/text.rs
+++ b/deepwell/src/services/text.rs
@@ -49,10 +49,7 @@ impl TextService {
     }
 
     pub async fn get(ctx: &ServiceContext<'_>, hash: &[u8]) -> Result<String> {
-        match Self::get_optional(ctx, hash).await? {
-            Some(string) => Ok(string),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, hash).await?.ok_or(Error::NotFound)
     }
 
     #[inline]

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -119,7 +119,9 @@ impl UserService {
         ctx: &ServiceContext<'_>,
         reference: Reference<'_>,
     ) -> Result<UserModel> {
-        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     pub async fn update(

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -119,10 +119,7 @@ impl UserService {
         ctx: &ServiceContext<'_>,
         reference: Reference<'_>,
     ) -> Result<UserModel> {
-        match Self::get_optional(ctx, reference).await? {
-            Some(user) => Ok(user),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
     }
 
     pub async fn update(

--- a/deepwell/src/services/vote/service.rs
+++ b/deepwell/src/services/vote/service.rs
@@ -87,10 +87,7 @@ impl VoteService {
         ctx: &ServiceContext<'_>,
         reference: VoteReference,
     ) -> Result<PageVoteModel> {
-        match Self::get_optional(ctx, reference).await? {
-            Some(vote) => Ok(vote),
-            None => Err(Error::NotFound),
-        }
+        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
     }
 
     /// Gets any current vote for the current page and user.

--- a/deepwell/src/services/vote/service.rs
+++ b/deepwell/src/services/vote/service.rs
@@ -87,7 +87,9 @@ impl VoteService {
         ctx: &ServiceContext<'_>,
         reference: VoteReference,
     ) -> Result<PageVoteModel> {
-        Self::get_optional(ctx, reference).await?.ok_or(Error::NotFound)
+        Self::get_optional(ctx, reference)
+            .await?
+            .ok_or(Error::NotFound)
     }
 
     /// Gets any current vote for the current page and user.

--- a/deepwell/src/services/vote/service.rs
+++ b/deepwell/src/services/vote/service.rs
@@ -191,7 +191,7 @@ impl VoteService {
         Ok(votes)
     }
 
-    /// Counts the number of historical bvotes for either a page or a user.
+    /// Counts the number of historical votes for either a page or a user.
     ///
     /// See `get_history()` for more information.
     pub async fn count_history(

--- a/deepwell/src/services/vote/service.rs
+++ b/deepwell/src/services/vote/service.rs
@@ -111,7 +111,6 @@ impl VoteService {
         };
 
         let vote = PageVote::find().filter(condition).one(txn).await?;
-
         Ok(vote)
     }
 


### PR DESCRIPTION
This is a small PR that simply replaces some match statements with equivalent ok_or() methods, and fixes a single typo in a comment.