### PR TITLE
[WJ-1049] Support non-breaking spaces in the lexer

### DIFF
--- a/ftml/src/parsing/lexer.pest
+++ b/ftml/src/parsing/lexer.pest
@@ -222,7 +222,7 @@ string = @{ "\"" ~ char* ~ "\"" }
 
 line_break = @{ NEWLINE }
 paragraph_break = @{ NEWLINE{2,} }
-space = @{ (" " | "\t")+ }
+space = @{ (" " | "\t" | "\u{00a0}" | "\u{2007}" | "\u{202f}")+ }
 
 // To be consolidated in code
 //

--- a/ftml/test/spaces.json
+++ b/ftml/test/spaces.json
@@ -1,5 +1,5 @@
 {
-    "input": "  ",
+    "input": "    ",
     "tree": {
         "elements": [
             {


### PR DESCRIPTION
Presently non-breaking spaces and other weird unicode spaces are treated as `text` (the fallback token) in the lexer. This is incorrect and causes issues when non-breaking spaces are used for list indentation and the like.