### PR TITLE
[WJ-1048] Prefix with # for hex colors, if missing

### DIFF
--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -23,7 +23,8 @@ use regex::Regex;
 use std::borrow::Cow;
 
 lazy_static! {
-    static ref HEX_COLOR: Regex = Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap();
+    static ref HEX_COLOR: Regex =
+        Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap();
 }
 
 pub const RULE_COLOR: Rule = Rule {

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -23,7 +23,7 @@ use regex::Regex;
 use std::borrow::Cow;
 
 lazy_static! {
-    static ref HEX_COLOR: Regex = Regex::new(r"^[a-fA-F0-9]{3,6}$").unwrap();
+    static ref HEX_COLOR: Regex = Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap();
 }
 
 pub const RULE_COLOR: Rule = Rule {

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -19,6 +19,12 @@
  */
 
 use super::prelude::*;
+use regex::Regex;
+use std::borrow::Cow;
+
+lazy_static! {
+    static ref HEX_COLOR: Regex = Regex::new(r"^[a-fA-F0-9]{3,6}$").unwrap();
+}
 
 pub const RULE_COLOR: Rule = Rule {
     name: "color",
@@ -61,9 +67,22 @@ fn try_consume_fn<'p, 'r, 't>(
 
     // Return result
     let element = Element::Color {
-        color: cow!(color),
+        color: hexify_color(color),
         elements,
     };
 
     ok!(paragraph_safe; element, exceptions)
+}
+
+/// Prefix with `#`, if needed.
+///
+/// Normally we pass the color as-is, such as `blue` or `rgb(10, 12, 14)`,
+/// but if a hex specification is passed, and it doesn't already begin with
+/// `#`, then one should be prepended.
+fn hexify_color(color: &str) -> Cow<str> {
+    if HEX_COLOR.is_match(color) {
+        Cow::Owned(format!("#{color}"))
+    } else {
+        Cow::Borrowed(color)
+    }
 }

--- a/ftml/test/color-hex-2.html
+++ b/ftml/test/color-hex-2.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p><span style="color: #ccc;">CSS color!</span></p></wj-body>

--- a/ftml/test/color-hex-2.json
+++ b/ftml/test/color-hex-2.json
@@ -1,0 +1,55 @@
+{
+    "input": "##ccc|CSS color!##",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "color",
+                            "data": {
+                                "color": "#ccc",
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "CSS"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "color"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "!"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "styles": [
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "warnings": [
+    ]
+}

--- a/ftml/test/color-hex-2.txt
+++ b/ftml/test/color-hex-2.txt
@@ -1,0 +1,1 @@
+CSS color!


### PR DESCRIPTION
@jewalky reported an issue with ftml, showing that hex colors without the `#` are not prefixed. That is, the following works:
```
###ccc|text here##
```
But without the explicit `#` it doesn't work:
```
##ccc|text here##
```
Since it produces `color: ccc`, which is not valid. This code changes it so that if a hex color is used, a `#` is prefixed it it does not already exist.