### PR TITLE
[WJ-1051] Filter out URL contexts

### DIFF
--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -169,6 +169,22 @@ lazy_static! {
         ]
     };
 
+    /// List of HTML attributes which need to be checked for XSS.
+    ///
+    /// For instance, you could have `href="javascript:doSomething()"`,
+    /// which would escape normal sandboxing and run trusted javascript
+    /// from untrusted user data.
+    ///
+    /// ## See also
+    /// * `detect_dangerous_schemes()`
+    /// * `normalize_href()`
+    pub static ref URL_ATTRIBUTES: HashSet<UniCase<&'static str>> = {
+        hashset_unicase![
+            "href",
+            "src",
+        ]
+    };
+
     static ref ATTRIBUTE_SUFFIX_SAFE: Regex = Regex::new(r"[a-zA-z0-9\-]+").unwrap();
 }
 

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -101,3 +101,28 @@ pub fn normalize_href(url: &str) -> Cow<str> {
 pub trait BuildSiteUrl {
     fn build_url(&self, site: &str, path: &str) -> String;
 }
+
+#[test]
+fn detect_dangerous_schemes() {
+    macro_rules! check {
+        ($input:expr, $result:expr $(,)?) => {
+            assert_eq!(
+                dangerous_scheme($input),
+                $result,
+                "For input {:?}, dangerous scheme detection failed",
+                $input,
+            )
+        };
+    }
+
+    check!("http://example.com/", false);
+    check!("https://example.com/", false);
+    check!("irc://irc.scpwiki.com", false);
+    check!("javascript:alert(1)", true);
+    check!("JAVASCRIPT:alert(1)", true);
+    check!("JaVaScRiPt:alert(document.cookie)", true);
+    check!("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==", true);
+    check!("data:text/javascript,alert(1)", true);
+    check!("data:text/html,<script>alert('XSS');</script>", true);
+    check!("DATA:text/html,<script>alert('XSS');</script>", true);
+}

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -22,12 +22,11 @@ use crate::tree::LinkLocation;
 use std::borrow::Cow;
 use wikidot_normalize::normalize;
 
-pub const URL_SCHEMES: [&str; 20] = [
+pub const URL_SCHEMES: [&str; 19] = [
     "blob:",
     "chrome-extension://",
     "chrome://",
     "content://",
-    "data:",
     "dns:",
     "feed:",
     "file://",

--- a/ftml/test/anchor-xss-2.html
+++ b/ftml/test/anchor-xss-2.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p><a class="wj-anchor" href="#invalid-url">My not-suspicious link</a></p></wj-body>

--- a/ftml/test/anchor-xss-2.json
+++ b/ftml/test/anchor-xss-2.json
@@ -1,0 +1,68 @@
+{
+    "input": "[[a href=\"JAVASCRIPT:alert('XSS!')\"]]My not-suspicious link[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "#invalid-url"
+                                },
+                                "target": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "not"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "-"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "suspicious"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "errors": [
+    ]
+}

--- a/ftml/test/anchor-xss-2.txt
+++ b/ftml/test/anchor-xss-2.txt
@@ -1,0 +1,1 @@
+My not-suspicious link [#invalid-url]

--- a/ftml/test/anchor-xss.html
+++ b/ftml/test/anchor-xss.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p><a class="wj-anchor" href="#invalid-url">My not-suspicious link</a></p></wj-body>

--- a/ftml/test/anchor-xss.json
+++ b/ftml/test/anchor-xss.json
@@ -1,0 +1,68 @@
+{
+    "input": "[[a href=\"javascript:alert('XSS!')\"]]My not-suspicious link[[/a]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "anchor",
+                            "data": {
+                                "attributes": {
+                                    "href": "#invalid-url"
+                                },
+                                "target": null,
+                                "elements": [
+                                    {
+                                        "element": "text",
+                                        "data": "My"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "not"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "-"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "suspicious"
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": " "
+                                    },
+                                    {
+                                        "element": "text",
+                                        "data": "link"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ]
+    },
+    "errors": [
+    ]
+}

--- a/ftml/test/anchor-xss.txt
+++ b/ftml/test/anchor-xss.txt
@@ -1,0 +1,1 @@
+My not-suspicious link [#invalid-url]


### PR DESCRIPTION
This ensures that the `href` and `src` attributes cannot output `javascript:` or `data:` values, which could lead to security issues.