### PR TITLE
[WJ-1063] Swap inner() and contents()

### DIFF
--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -274,7 +274,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
     }
 
     #[inline]
-    pub fn contents2<R: ItemRender>(&mut self, item: R) -> &mut Self {
+    pub fn contents<R: ItemRender>(&mut self, item: R) -> &mut Self {
         self.content_start();
         item.render(self.ctx);
 

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -97,7 +97,7 @@ where
                 "class" => &class,
                 "viewBox" => viewbox,
             ))
-            .contents(|ctx| {
+            .inner(|ctx| {
                 ctx.html().tag("use").attr(attr!("href" => &href));
             });
     }
@@ -281,7 +281,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
         self
     }
 
-    pub fn contents<F>(&mut self, mut f: F) -> &mut Self
+    pub fn inner<F>(&mut self, mut f: F) -> &mut Self
     where
         F: FnMut(&mut HtmlContext),
     {

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -274,7 +274,7 @@ impl<'c, 'i, 'h, 'e, 't> HtmlBuilderTag<'c, 'i, 'h, 'e, 't> {
     }
 
     #[inline]
-    pub fn inner<R: ItemRender>(&mut self, item: R) -> &mut Self {
+    pub fn contents2<R: ItemRender>(&mut self, item: R) -> &mut Self {
         self.content_start();
         item.render(self.ctx);
 

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -91,14 +91,14 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
             "data-show-bottom"; if show_bottom;;
             attributes,
         ))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Open/close button
             ctx.html()
                 .summary()
                 .attr(attr!(
                     "class" => "wj-collapsible-button wj-collapsible-button-top",
                 ))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     // Block is folded text
                     ctx.html()
                         .span()
@@ -125,7 +125,7 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
                     .attr(attr!(
                         "class" => "wj-collapsible-button wj-collapsible-button-bottom",
                     ))
-                    .contents(|ctx| {
+                    .inner(|ctx| {
                         // Block is unfolded text
                         ctx.html()
                             .span()

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -103,20 +103,20 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-collapsible-show-text"))
-                        .contents2(show_text);
+                        .contents(show_text);
 
                     // Block is unfolded text
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-collapsible-hide-text"))
-                        .contents2(hide_text);
+                        .contents(hide_text);
                 });
 
             // Content block
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-collapsible-content"))
-                .contents2(elements);
+                .contents(elements);
 
             // Bottom open/close button
             if show_bottom {
@@ -130,7 +130,7 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-collapsible-hide-text"))
-                            .contents2(hide_text);
+                            .contents(hide_text);
                     });
             }
         });

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -103,20 +103,20 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-collapsible-show-text"))
-                        .inner(show_text);
+                        .contents2(show_text);
 
                     // Block is unfolded text
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-collapsible-hide-text"))
-                        .inner(hide_text);
+                        .contents2(hide_text);
                 });
 
             // Content block
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-collapsible-content"))
-                .inner(elements);
+                .contents2(elements);
 
             // Bottom open/close button
             if show_bottom {
@@ -130,7 +130,7 @@ pub fn render_collapsible(ctx: &mut HtmlContext, collapsible: Collapsible) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-collapsible-hide-text"))
-                            .inner(hide_text);
+                            .contents2(hide_text);
                     });
             }
         });

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -27,11 +27,11 @@ pub fn render_container(ctx: &mut HtmlContext, container: &Container) {
     match container.ctype() {
         // We wrap with <rp> around the <rt> contents
         ContainerType::RubyText => {
-            ctx.html().rp().contents2("(");
+            ctx.html().rp().contents("(");
 
             render_container_internal(ctx, container);
 
-            ctx.html().rp().contents2(")");
+            ctx.html().rp().contents(")");
         }
 
         // Render normally
@@ -66,7 +66,7 @@ pub fn render_container_internal(ctx: &mut HtmlContext, container: &Container) {
     };
 
     // Add container internals
-    tag.contents2(container.elements());
+    tag.contents(container.elements());
 }
 
 pub fn render_color(ctx: &mut HtmlContext, color: &str, elements: &[Element]) {
@@ -77,7 +77,7 @@ pub fn render_color(ctx: &mut HtmlContext, color: &str, elements: &[Element]) {
         .attr(attr!(
             "style" => "color: " color ";",
         ))
-        .contents2(elements);
+        .contents(elements);
 }
 
 fn choose_id(ctx: &mut HtmlContext, tag_spec: &HtmlTag) -> Option<String> {

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -27,11 +27,11 @@ pub fn render_container(ctx: &mut HtmlContext, container: &Container) {
     match container.ctype() {
         // We wrap with <rp> around the <rt> contents
         ContainerType::RubyText => {
-            ctx.html().rp().inner("(");
+            ctx.html().rp().contents2("(");
 
             render_container_internal(ctx, container);
 
-            ctx.html().rp().inner(")");
+            ctx.html().rp().contents2(")");
         }
 
         // Render normally
@@ -66,7 +66,7 @@ pub fn render_container_internal(ctx: &mut HtmlContext, container: &Container) {
     };
 
     // Add container internals
-    tag.inner(container.elements());
+    tag.contents2(container.elements());
 }
 
 pub fn render_color(ctx: &mut HtmlContext, color: &str, elements: &[Element]) {
@@ -77,7 +77,7 @@ pub fn render_color(ctx: &mut HtmlContext, color: &str, elements: &[Element]) {
         .attr(attr!(
             "style" => "color: " color ";",
         ))
-        .inner(elements);
+        .contents2(elements);
 }
 
 fn choose_id(ctx: &mut HtmlContext, tag_spec: &HtmlTag) -> Option<String> {

--- a/ftml/src/render/html/element/date.rs
+++ b/ftml/src/render/html/element/date.rs
@@ -49,5 +49,5 @@ pub fn render_date(
             "data-timestamp" => &timestamp,
             "data-delta" => &delta,
         ))
-        .inner(formatted_datetime);
+        .contents2(formatted_datetime);
 }

--- a/ftml/src/render/html/element/date.rs
+++ b/ftml/src/render/html/element/date.rs
@@ -49,5 +49,5 @@ pub fn render_date(
             "data-timestamp" => &timestamp,
             "data-delta" => &delta,
         ))
-        .contents2(formatted_datetime);
+        .contents(formatted_datetime);
 }

--- a/ftml/src/render/html/element/definition_list.rs
+++ b/ftml/src/render/html/element/definition_list.rs
@@ -26,8 +26,8 @@ pub fn render_definition_list(ctx: &mut HtmlContext, items: &[DefinitionListItem
 
     ctx.html().dl().contents(|ctx| {
         for DefinitionListItem { key, value } in items {
-            ctx.html().dt().inner(key);
-            ctx.html().dd().inner(value);
+            ctx.html().dt().contents2(key);
+            ctx.html().dd().contents2(value);
         }
     });
 }

--- a/ftml/src/render/html/element/definition_list.rs
+++ b/ftml/src/render/html/element/definition_list.rs
@@ -26,8 +26,8 @@ pub fn render_definition_list(ctx: &mut HtmlContext, items: &[DefinitionListItem
 
     ctx.html().dl().inner(|ctx| {
         for DefinitionListItem { key, value } in items {
-            ctx.html().dt().contents2(key);
-            ctx.html().dd().contents2(value);
+            ctx.html().dt().contents(key);
+            ctx.html().dd().contents(value);
         }
     });
 }

--- a/ftml/src/render/html/element/definition_list.rs
+++ b/ftml/src/render/html/element/definition_list.rs
@@ -24,7 +24,7 @@ use crate::tree::DefinitionListItem;
 pub fn render_definition_list(ctx: &mut HtmlContext, items: &[DefinitionListItem]) {
     info!("Rendering definition list (length {})", items.len());
 
-    ctx.html().dl().contents(|ctx| {
+    ctx.html().dl().inner(|ctx| {
         for DefinitionListItem { key, value } in items {
             ctx.html().dt().contents2(key);
             ctx.html().dd().contents2(value);

--- a/ftml/src/render/html/element/embed.rs
+++ b/ftml/src/render/html/element/embed.rs
@@ -33,7 +33,7 @@ pub fn render_embed(ctx: &mut HtmlContext, embed: &Embed) {
         .attr(attr!(
             "class" => "wj-embed",
         ))
-        .contents(|ctx| match embed {
+        .inner(|ctx| match embed {
             Embed::Youtube { video_id } => {
                 let url = format!("https://www.youtube.com/embed/{video_id}");
 

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -47,7 +47,7 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
                     "aria-label" => &label,
                     "data-id" => &id,
                 ))
-                .contents2(&id);
+                .contents(&id);
 
             // Tooltip shown on hover.
             // Is aria-hidden due to difficulty in getting a simultaneous
@@ -64,13 +64,13 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-footnote-ref-tooltip-label"))
-                        .contents2(&label);
+                        .contents(&label);
 
                     // Actual tooltip contents
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-footnote-ref-contents"))
-                        .contents2(contents);
+                        .contents(contents);
                 });
         });
 }
@@ -100,7 +100,7 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-title"))
-                .contents2(title);
+                .contents(title);
 
             ctx.html().ol().inner(|ctx| {
                 // TODO make this into a footnote helper method
@@ -131,14 +131,14 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
                                     ctx.html()
                                         .span()
                                         .attr(attr!("class" => "wj-footnote-sep"))
-                                        .contents2(".");
+                                        .contents(".");
                                 });
 
                             // Footnote contents
                             ctx.html()
                                 .span()
                                 .attr(attr!("class" => "wj-footnote-list-item-contents"))
-                                .contents2(contents);
+                                .contents(contents);
                         });
                 }
             });

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -47,7 +47,7 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
                     "aria-label" => &label,
                     "data-id" => &id,
                 ))
-                .inner(&id);
+                .contents2(&id);
 
             // Tooltip shown on hover.
             // Is aria-hidden due to difficulty in getting a simultaneous
@@ -64,13 +64,13 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-footnote-ref-tooltip-label"))
-                        .inner(&label);
+                        .contents2(&label);
 
                     // Actual tooltip contents
                     ctx.html()
                         .span()
                         .attr(attr!("class" => "wj-footnote-ref-contents"))
-                        .inner(contents);
+                        .contents2(contents);
                 });
         });
 }
@@ -100,7 +100,7 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-title"))
-                .inner(title);
+                .contents2(title);
 
             ctx.html().ol().contents(|ctx| {
                 // TODO make this into a footnote helper method
@@ -131,14 +131,14 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
                                     ctx.html()
                                         .span()
                                         .attr(attr!("class" => "wj-footnote-sep"))
-                                        .inner(".");
+                                        .contents2(".");
                                 });
 
                             // Footnote contents
                             ctx.html()
                                 .span()
                                 .attr(attr!("class" => "wj-footnote-list-item-contents"))
-                                .inner(contents);
+                                .contents2(contents);
                         });
                 }
             });

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -37,7 +37,7 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
     ctx.html()
         .span()
         .attr(attr!("class" => "wj-footnote-ref"))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Footnote marker that is hoverable
             ctx.html()
                 .element("wj-footnote-ref-marker")
@@ -59,7 +59,7 @@ pub fn render_footnote(ctx: &mut HtmlContext) {
                     "class" => "wj-footnote-ref-tooltip",
                     "aria-hidden" => "true",
                 ))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     // Tooltip label
                     ctx.html()
                         .span()
@@ -96,13 +96,13 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
     ctx.html()
         .div()
         .attr(attr!("class" => "wj-footnote-list"))
-        .contents(|ctx| {
+        .inner(|ctx| {
             ctx.html()
                 .div()
                 .attr(attr!("class" => "wj-title"))
                 .contents2(title);
 
-            ctx.html().ol().contents(|ctx| {
+            ctx.html().ol().inner(|ctx| {
                 // TODO make this into a footnote helper method
                 for (index, contents) in ctx.footnotes().iter().enumerate() {
                     let index = index + 1;
@@ -115,7 +115,7 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
                             "class" => "wj-footnote-list-item",
                             "data-id" => id,
                         ))
-                        .contents(|ctx| {
+                        .inner(|ctx| {
                             // Number and clickable anchor
                             ctx.html()
                                 .element("wj-footnote-list-item-marker")
@@ -124,7 +124,7 @@ pub fn render_footnote_block(ctx: &mut HtmlContext, title: Option<&str>) {
                                     "type" => "button",
                                     "role" => "link",
                                 ))
-                                .contents(|ctx| {
+                                .inner(|ctx| {
                                     str_write!(ctx, "{index}");
 
                                     // Period after item number. Has special class to permit styling.

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -78,7 +78,7 @@ fn render_image_element(
         .attr(attr!(
             "class" => "wj-image-container" space align_class,
         ))
-        .contents(|ctx| {
+        .inner(|ctx| {
             let build_image = |ctx: &mut HtmlContext| {
                 ctx.html().img().attr(attr!(
                     "class" => "wj-image",
@@ -94,7 +94,7 @@ fn render_image_element(
                     ctx.html()
                         .a()
                         .attr(attr!("href" => &url))
-                        .contents(build_image);
+                        .inner(build_image);
                 }
                 None => build_image(ctx),
             };

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -111,5 +111,5 @@ fn render_image_missing(ctx: &mut HtmlContext) {
     ctx.html()
         .div()
         .attr(attr!("class" => "wj-error-block"))
-        .contents2(message);
+        .contents(message);
 }

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -111,5 +111,5 @@ fn render_image_missing(ctx: &mut HtmlContext) {
     ctx.html()
         .div()
         .attr(attr!("class" => "wj-error-block"))
-        .inner(message);
+        .contents2(message);
 }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -44,7 +44,7 @@ pub fn render_anchor(
             "target" => target_value; if target.is_some();;
             attributes,
         ))
-        .contents2(elements);
+        .contents(elements);
 }
 
 pub fn render_link(
@@ -98,6 +98,6 @@ pub fn render_link(
 
     // Add <a> internals, i.e. the link name
     handle.get_link_label(&site, link, label, |label| {
-        tag.contents2(label);
+        tag.contents(label);
     });
 }

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -44,7 +44,7 @@ pub fn render_anchor(
             "target" => target_value; if target.is_some();;
             attributes,
         ))
-        .inner(elements);
+        .contents2(elements);
 }
 
 pub fn render_link(
@@ -98,6 +98,6 @@ pub fn render_link(
 
     // Add <a> internals, i.e. the link name
     handle.get_link_label(&site, link, label, |label| {
-        tag.inner(label);
+        tag.contents2(label);
     });
 }

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -42,7 +42,7 @@ pub fn render_list(
                     elements,
                     attributes,
                 } => {
-                    ctx.html().li().attr(attr!(;; attributes)).inner(elements);
+                    ctx.html().li().attr(attr!(;; attributes)).contents2(elements);
                 }
                 ListItem::SubList { element } => {
                     render_element(ctx, element);

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -42,7 +42,7 @@ pub fn render_list(
                     elements,
                     attributes,
                 } => {
-                    ctx.html().li().attr(attr!(;; attributes)).contents2(elements);
+                    ctx.html().li().attr(attr!(;; attributes)).contents(elements);
                 }
                 ListItem::SubList { element } => {
                     render_element(ctx, element);

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -35,7 +35,7 @@ pub fn render_list(
     let list_tag = ltype.html_tag();
     let mut tag = ctx.html().tag(list_tag);
 
-    tag.attr(attr!(;; attributes)).contents(|ctx| {
+    tag.attr(attr!(;; attributes)).inner(|ctx| {
         for list_item in list_items {
             match list_item {
                 ListItem::Elements {

--- a/ftml/src/render/html/element/math.rs
+++ b/ftml/src/render/html/element/math.rs
@@ -85,7 +85,7 @@ fn render_latex(
                             .attr(attr!(
                                 "class" => "wj-equation-paren wj-equation-paren-open",
                             ))
-                            .contents2("(");
+                            .contents("(");
 
                         str_write!(ctx, "{index}");
 
@@ -95,7 +95,7 @@ fn render_latex(
                             .attr(attr!(
                                 "class" => "wj-equation-paren wj-equation-paren-close",
                             ))
-                            .contents2(")");
+                            .contents(")");
                     });
             }
 
@@ -107,7 +107,7 @@ fn render_latex(
                     "class" => "wj-math-source wj-hidden",
                     "aria-hidden" => "true",
                 ))
-                .contents2(latex_source);
+                .contents(latex_source);
 
             // Add generated MathML
             cfg_if! {
@@ -129,7 +129,7 @@ fn render_latex(
                             ctx.html()
                                 .span()
                                 .attr(attr!("class" => _error_type))
-                                .contents2(error);
+                                .contents(error);
                         }
                     }
                 }
@@ -152,7 +152,7 @@ pub fn render_equation_reference(ctx: &mut HtmlContext, name: &str) {
                     "type" => "button",
                     "data-name" => name,
                 ))
-                .contents2(name);
+                .contents(name);
 
             // Tooltip shown on hover.
             ctx.html().span().attr(attr!(

--- a/ftml/src/render/html/element/math.rs
+++ b/ftml/src/render/html/element/math.rs
@@ -72,13 +72,13 @@ fn render_latex(
             "class" => "wj-math " wj_type,
             "data-name" => name.unwrap_or(""); if name.is_some(),
         ))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Add equation index
             if let Some(index) = index {
                 ctx.html()
                     .span()
                     .attr(attr!("class" => "wj-equation-number"))
-                    .contents(|ctx| {
+                    .inner(|ctx| {
                         // Open parenthesis
                         ctx.html()
                             .span()
@@ -120,7 +120,7 @@ fn render_latex(
                             ctx.html()
                                 .element("wj-math-ml")
                                 .attr(attr!("class" => "wj-math-ml"))
-                                .contents(|ctx| ctx.push_raw_str(&mathml));
+                                .inner(|ctx| ctx.push_raw_str(&mathml));
                         }
                         Err(error) => {
                             warn!("Error processing LaTeX -> MathML: {error}");
@@ -143,7 +143,7 @@ pub fn render_equation_reference(ctx: &mut HtmlContext, name: &str) {
     ctx.html()
         .span()
         .attr(attr!("class" => "wj-equation-ref"))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Equation marker that is hoverable
             ctx.html()
                 .element("wj-equation-ref-marker")

--- a/ftml/src/render/html/element/math.rs
+++ b/ftml/src/render/html/element/math.rs
@@ -85,7 +85,7 @@ fn render_latex(
                             .attr(attr!(
                                 "class" => "wj-equation-paren wj-equation-paren-open",
                             ))
-                            .inner("(");
+                            .contents2("(");
 
                         str_write!(ctx, "{index}");
 
@@ -95,7 +95,7 @@ fn render_latex(
                             .attr(attr!(
                                 "class" => "wj-equation-paren wj-equation-paren-close",
                             ))
-                            .inner(")");
+                            .contents2(")");
                     });
             }
 
@@ -107,7 +107,7 @@ fn render_latex(
                     "class" => "wj-math-source wj-hidden",
                     "aria-hidden" => "true",
                 ))
-                .inner(latex_source);
+                .contents2(latex_source);
 
             // Add generated MathML
             cfg_if! {
@@ -129,7 +129,7 @@ fn render_latex(
                             ctx.html()
                                 .span()
                                 .attr(attr!("class" => _error_type))
-                                .inner(error);
+                                .contents2(error);
                         }
                     }
                 }
@@ -152,7 +152,7 @@ pub fn render_equation_reference(ctx: &mut HtmlContext, name: &str) {
                     "type" => "button",
                     "data-name" => name,
                 ))
-                .inner(name);
+                .contents2(name);
 
             // Tooltip shown on hover.
             ctx.html().span().attr(attr!(

--- a/ftml/src/render/html/element/style.rs
+++ b/ftml/src/render/html/element/style.rs
@@ -49,7 +49,7 @@ pub fn render_style(ctx: &mut HtmlContext, input_css: &str) {
         }
     };
 
-    ctx.html().style().contents(|ctx| {
+    ctx.html().style().inner(|ctx| {
         // SAFETY: The resultant CSS cannot contain HTML-escaping elements,
         //         as those are invalid and would not be retained during
         //         the parcel_css parsing process.

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -66,7 +66,7 @@ pub fn render_table(ctx: &mut HtmlContext, table: &Table) {
 
                                         &cell.attributes,
                                     ))
-                                    .contents2(elements);
+                                    .contents(elements);
                             }
                         });
                 }

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -66,7 +66,7 @@ pub fn render_table(ctx: &mut HtmlContext, table: &Table) {
 
                                         &cell.attributes,
                                     ))
-                                    .inner(elements);
+                                    .contents2(elements);
                             }
                         });
                 }

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -32,14 +32,14 @@ pub fn render_table(ctx: &mut HtmlContext, table: &Table) {
     ctx.html()
         .table()
         .attr(attr!(;; &table.attributes))
-        .contents(|ctx| {
-            ctx.html().tbody().contents(|ctx| {
+        .inner(|ctx| {
+            ctx.html().tbody().inner(|ctx| {
                 // Each row
                 for row in &table.rows {
                     ctx.html() //
                         .tr()
                         .attr(attr!(;; &row.attributes))
-                        .contents(|ctx| {
+                        .inner(|ctx| {
                             // Each cell in a row
                             for cell in &row.cells {
                                 let elements: &[Element] = &cell.elements;

--- a/ftml/src/render/html/element/tabs.rs
+++ b/ftml/src/render/html/element/tabs.rs
@@ -63,7 +63,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                                 "aria-controls" => &tab_ids[i],
                                 "tabindex" => tab_index,
                             ))
-                            .contents2(&tab.label);
+                            .contents(&tab.label);
                     }
                 });
 
@@ -86,7 +86,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                                 "tabindex" => "0",
                                 "hidden"; if i > 0,
                             ))
-                            .contents2(&tab.elements);
+                            .contents(&tab.elements);
                     }
                 });
         });

--- a/ftml/src/render/html/element/tabs.rs
+++ b/ftml/src/render/html/element/tabs.rs
@@ -63,7 +63,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                                 "aria-controls" => &tab_ids[i],
                                 "tabindex" => tab_index,
                             ))
-                            .inner(&tab.label);
+                            .contents2(&tab.label);
                     }
                 });
 
@@ -86,7 +86,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                                 "tabindex" => "0",
                                 "hidden"; if i > 0,
                             ))
-                            .inner(&tab.elements);
+                            .contents2(&tab.elements);
                     }
                 });
         });

--- a/ftml/src/render/html/element/tabs.rs
+++ b/ftml/src/render/html/element/tabs.rs
@@ -35,7 +35,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
         .attr(attr!(
             "class" => "wj-tabs",
         ))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Tab buttons
             ctx.html()
                 .div()
@@ -43,7 +43,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                     "class" => "wj-tabs-button-list",
                     "role" => "tablist",
                 ))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     for (i, tab) in tabs.iter().enumerate() {
                         let (tab_selected, tab_index) = if i == 0 {
                             ("true", "0")
@@ -73,7 +73,7 @@ pub fn render_tabview(ctx: &mut HtmlContext, tabs: &[Tab]) {
                 .attr(attr!(
                     "class" => "wj-tabs-panel-list",
                 ))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     for (i, tab) in tabs.iter().enumerate() {
                         // Each tab panel
                         ctx.html()

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -28,7 +28,7 @@ pub fn render_wikitext_raw(ctx: &mut HtmlContext, text: &str) {
         .attr(attr!(
             "class" => "wj-raw",
         ))
-        .contents2(text);
+        .contents(text);
 }
 
 pub fn render_email(ctx: &mut HtmlContext, email: &str) {
@@ -40,7 +40,7 @@ pub fn render_email(ctx: &mut HtmlContext, email: &str) {
     ctx.html()
         .span()
         .attr(attr!("class" => "wj-email"))
-        .contents2(email);
+        .contents(email);
 }
 
 pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str) {
@@ -92,12 +92,12 @@ pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str
                         .attr(attr!(
                             "class" => "wj-code-language",
                         ))
-                        .contents2(language.unwrap_or(""));
+                        .contents(language.unwrap_or(""));
                 });
 
             // Code block containing highlighted contents
             ctx.html().pre().inner(|ctx| {
-                ctx.html().code().contents2(contents);
+                ctx.html().code().contents(contents);
             });
         });
 }

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -60,14 +60,14 @@ pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str
     ctx.html()
         .element("wj-code")
         .attr(attr!("class" => &class))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // Panel for holding additional features
             ctx.html()
                 .div()
                 .attr(attr!(
                     "class" => "wj-code-panel",
                 ))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     let button_title = ctx
                         .handle()
                         .get_message(ctx.language(), "button-copy-clipboard");
@@ -80,7 +80,7 @@ pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str
                             "class" => "wj-code-copy",
                             "title" => button_title,
                         ))
-                        .contents(|ctx| {
+                        .inner(|ctx| {
                             ctx.html().sprite("wj-clipboard");
                             // Hidden normally, shown when clicked
                             ctx.html().sprite("wj-clipboard-success");
@@ -96,7 +96,7 @@ pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str
                 });
 
             // Code block containing highlighted contents
-            ctx.html().pre().contents(|ctx| {
+            ctx.html().pre().inner(|ctx| {
                 ctx.html().code().contents2(contents);
             });
         });

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -28,7 +28,7 @@ pub fn render_wikitext_raw(ctx: &mut HtmlContext, text: &str) {
         .attr(attr!(
             "class" => "wj-raw",
         ))
-        .inner(text);
+        .contents2(text);
 }
 
 pub fn render_email(ctx: &mut HtmlContext, email: &str) {
@@ -40,7 +40,7 @@ pub fn render_email(ctx: &mut HtmlContext, email: &str) {
     ctx.html()
         .span()
         .attr(attr!("class" => "wj-email"))
-        .inner(email);
+        .contents2(email);
 }
 
 pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str) {
@@ -92,12 +92,12 @@ pub fn render_code(ctx: &mut HtmlContext, language: Option<&str>, contents: &str
                         .attr(attr!(
                             "class" => "wj-code-language",
                         ))
-                        .inner(language.unwrap_or(""));
+                        .contents2(language.unwrap_or(""));
                 });
 
             // Code block containing highlighted contents
             ctx.html().pre().contents(|ctx| {
-                ctx.html().code().inner(contents);
+                ctx.html().code().contents2(contents);
             });
         });
 }

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -44,12 +44,12 @@ pub fn render_table_of_contents(
             "class" => class_value; if align.is_some();;
             attributes
         ))
-        .contents(|ctx| {
+        .inner(|ctx| {
             // TOC buttons
             ctx.html()
                 .div()
                 .attr(attr!("id" => "wj-toc-action-bar"; if use_true_ids))
-                .contents(|ctx| {
+                .inner(|ctx| {
                     // TODO button
                     ctx.html().a().attr(attr!(
                         "href" => "javascript:;",

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -65,7 +65,7 @@ pub fn render_table_of_contents(
             ctx.html()
                 .div()
                 .attr(attr!("class" => "title"))
-                .contents2(table_of_contents_title);
+                .contents(table_of_contents_title);
 
             // TOC List
             let table_of_contents = ctx.table_of_contents();
@@ -73,6 +73,6 @@ pub fn render_table_of_contents(
             ctx.html()
                 .div()
                 .attr(attr!("id" => "wj-toc-list"; if use_true_ids))
-                .contents2(table_of_contents);
+                .contents(table_of_contents);
         });
 }

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -65,7 +65,7 @@ pub fn render_table_of_contents(
             ctx.html()
                 .div()
                 .attr(attr!("class" => "title"))
-                .inner(table_of_contents_title);
+                .contents2(table_of_contents_title);
 
             // TOC List
             let table_of_contents = ctx.table_of_contents();
@@ -73,6 +73,6 @@ pub fn render_table_of_contents(
             ctx.html()
                 .div()
                 .attr(attr!("id" => "wj-toc-list"; if use_true_ids))
-                .inner(table_of_contents);
+                .contents2(table_of_contents);
         });
 }

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -61,7 +61,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-user-info-name"))
-                            .inner(&info.user_name);
+                            .contents2(&info.user_name);
                     });
             }
             None => {
@@ -92,7 +92,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-user-info-name"))
-                            .inner(name);
+                            .contents2(name);
                     });
             }
         });

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -61,7 +61,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-user-info-name"))
-                            .contents2(&info.user_name);
+                            .contents(&info.user_name);
                     });
             }
             None => {
@@ -92,7 +92,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                         ctx.html()
                             .span()
                             .attr(attr!("class" => "wj-user-info-name"))
-                            .contents2(name);
+                            .contents(name);
                     });
             }
         });

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -26,7 +26,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
     ctx.html()
         .span()
         .attr(attr!("class" => "wj-user-info"))
-        .contents(|ctx| match ctx.handle().get_user_info(name) {
+        .inner(|ctx| match ctx.handle().get_user_info(name) {
             Some(info) => {
                 debug!(
                     "Got user information (user id {}, name {})",
@@ -40,7 +40,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                         "class" => "wj-user-info-link",
                         "href" => &info.user_profile_url,
                     ))
-                    .contents(|ctx| {
+                    .inner(|ctx| {
                         if show_avatar {
                             ctx.html()
                                 .span()
@@ -48,7 +48,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                                     "class" => "wj-karma",
                                     "data-karma" => &info.user_karma.to_string(),
                                 ))
-                                .contents(|ctx| {
+                                .inner(|ctx| {
                                     ctx.html().sprite("wj-karma");
                                 });
 
@@ -70,7 +70,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                 ctx.html()
                     .span()
                     .attr(attr!("class" => "wj-error-inline"))
-                    .contents(|ctx| {
+                    .inner(|ctx| {
                         if show_avatar {
                             // Karma SVG
                             ctx.html()
@@ -79,7 +79,7 @@ pub fn render_user(ctx: &mut HtmlContext, name: &str, show_avatar: bool) {
                                     "class" => "wj-karma",
                                     "data-karma" => "0",
                                 ))
-                                .contents(|ctx| {
+                                .inner(|ctx| {
                                     ctx.html().sprite("wj-karma");
                                 });
 

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -79,7 +79,7 @@ impl Render for HtmlRender {
         ctx.html()
             .element("wj-body")
             .attr(attr!("class" => "wj-body"))
-            .contents2(&tree.elements);
+            .contents(&tree.elements);
 
         // Build and return HtmlOutput
         ctx.into()

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -79,7 +79,7 @@ impl Render for HtmlRender {
         ctx.html()
             .element("wj-body")
             .attr(attr!("class" => "wj-body"))
-            .inner(&tree.elements);
+            .contents2(&tree.elements);
 
         // Build and return HtmlOutput
         ctx.into()


### PR DESCRIPTION
As discussed on the issue, in the ftml HTML builder, `inner()` is a better fit for what `contents()` does and vice eversa, so this PR swaps them.