### PR TITLE
[WJ-1084] Timeout ftml calls that take too long

### DIFF
--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -20,6 +20,7 @@
 
 use super::error::Result;
 use crate::api::{ApiRequest, ApiServerState};
+use crate::config::Config;
 use cuid::cuid;
 use s3::bucket::Bucket;
 use sea_orm::DatabaseTransaction;
@@ -48,6 +49,11 @@ impl<'txn> ServiceContext<'txn> {
     }
 
     // Getters
+    #[inline]
+    pub fn config(&self) -> &Config {
+        &self.state.config
+    }
+
     #[inline]
     pub fn s3_bucket(&self) -> &Bucket {
         &self.state.s3_bucket

--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
     #[error("A request to a remote service returned an error")]
     RemoteOperationFailed,
 
+    #[error("Attempting to perform a wikitext parse and render has timed out")]
+    RenderTimeout,
+
     #[error("The request is in some way malformed or incorrect")]
     BadRequest,
 
@@ -95,7 +98,7 @@ impl Error {
             Error::InvalidEnumValue => {
                 TideError::from_str(StatusCode::InternalServerError, "")
             }
-            Error::RemoteOperationFailed => {
+            Error::RemoteOperationFailed | Error::RenderTimeout => {
                 TideError::from_str(StatusCode::InternalServerError, "")
             }
             Error::BadRequest => TideError::from_str(StatusCode::BadRequest, ""),

--- a/deepwell/src/services/render/mod.rs
+++ b/deepwell/src/services/render/mod.rs
@@ -24,7 +24,7 @@ mod prelude {
     pub use ftml::{
         self,
         data::PageInfo,
-        info::VERSION,
+        info::VERSION as FTML_VERSION,
         parsing::ParseError,
         render::html::{HtmlOutput, HtmlRender},
         render::Render,

--- a/deepwell/src/services/render/service.rs
+++ b/deepwell/src/services/render/service.rs
@@ -32,7 +32,7 @@ impl RenderService {
         page_info: &PageInfo<'_>,
         settings: &WikitextSettings,
     ) -> Result<RenderOutput> {
-        let compiled_generator = VERSION.clone();
+        let compiled_generator = FTML_VERSION.clone();
 
         // Isolate the actual render task.
         // This way we can cut it off if it times out.


### PR DESCRIPTION
As a safety precaution (in case of a bug in the parser, some kind of malicious input, or just a very unusual processing delay), if rendering takes too long, then it should be prematurely terminated.

This PR adds this capability, returning an error if `RenderService::render()` takes longer than the configured amount of time (default 2000ms).