### PR TITLE
[WJ-1081] Allow invalid escapes

### DIFF
--- a/ftml/src/parsing/lexer.pest
+++ b/ftml/src/parsing/lexer.pest
@@ -216,7 +216,7 @@ variable = @{ "{$" ~ identifier ~ "}" }
 
 char = _{
     (!(NEWLINE | "\"" | "\\") ~ ANY) |
-    "\\" ~ ("\"" | "\\" | "r" | "n" | "t" | "'")
+    "\\" ~ !NEWLINE ~ ANY
 }
 
 string = @{ "\"" ~ char* ~ "\"" }

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -151,17 +151,32 @@ fn test_parse_string() {
         "abc \t (\\\t) \r (\\\r) def",
         Owned,
     );
+    test!(
+        r#""abc \t \x \y \z \n""#,
+        "abc \t \\x \\y \\z \n",
+        Owned,
+    );
+    test!("'abc'", "'abc'", Borrowed);
+    test!("\"abc", "\"abc", Borrowed);
+    test!("foo", "foo", Borrowed);
 }
 
 #[test]
 fn test_slice_middle() {
     macro_rules! test {
         ($input:expr, $expected:expr $(,)?) => {{
-            let actual = slice_middle($input);
+            let actual = slice_middle($input).expect("Invalid string input");
 
             assert_eq!(
                 actual, $expected,
                 "Actual (left) doesn't match expected (right)",
+            );
+        }};
+
+        ($input:expr $(,)?) => {{
+            assert!(
+                slice_middle($input).is_none(),
+                "Invalid string was sliced",
             );
         }};
     }
@@ -170,4 +185,9 @@ fn test_slice_middle() {
     test!(r#""!""#, "!");
     test!(r#""abc""#, "abc");
     test!(r#""apple banana cherry""#, "apple banana cherry");
+
+    test!("\"");
+    test!("\"'");
+    test!("''");
+    test!("[]");
 }

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -75,13 +75,22 @@ pub fn parse_string(input: &str) -> Cow<str> {
     Cow::Owned(output)
 }
 
-/// Slices the first and last characters off of the string.
-/// Assumes there are codepoint boundaries there.
-fn slice_middle(input: &str) -> &str {
+/// Remove the contents of a string if it is one.
+///
+/// Checks if the first and last characters are ASCII `"`,
+/// and if so, slices the first and last characters off of them.
+/// Does not make any assumptions about codepoints.
+fn slice_middle(input: &str) -> Option<&str> {
+    // Starts and ends with "
+    if input.chars().next() != Some('"') && input.chars().next_back() != Some('"') {
+        return None;
+    }
+
+    // Okay, we know the first and last chars are ASCII, it's safe to slice
     let len = input.len();
     let last = len - 1;
 
-    &input[1..last]
+    Some(&input[1..last])
 }
 
 /// Helper function to convert escapes to the actual character.

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -101,10 +101,7 @@ fn slice_middle(input: &str) -> Option<&str> {
     // so any other irregular pattern must be *at least* that.
     //
     // If shorter, it cannot be valid.
-    if input.len() < 2
-        || input.chars().next() != Some('"')
-        || input.chars().next_back() != Some('"')
-    {
+    if input.len() < 2 || !input.starts_with('"') || !input.ends_with('"') {
         return None;
     }
 

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -36,21 +36,6 @@ use std::borrow::Cow;
 /// is returned. So for `\$`, it will emit a
 /// `\` followed by a `$`.
 pub fn parse_string(input: &str) -> Cow<str> {
-    /// Helper function to convert escapes to the actual character.
-    fn escape_char(ch: char) -> Option<char> {
-        let escaped = match ch {
-            '\\' => '\\',
-            '\"' => '\"',
-            '\'' => '\'',
-            'r' => '\r',
-            'n' => '\n',
-            't' => '\t',
-             _ => return None,
-        };
-
-        Some(escaped)
-    }
-
     // We could do an iteration thing, but tracking
     // the index across replacements is complicated.
     //
@@ -99,6 +84,21 @@ fn slice_middle(input: &str) -> &str {
     &input[1..last]
 }
 
+/// Helper function to convert escapes to the actual character.
+fn escape_char(ch: char) -> Option<char> {
+    let escaped = match ch {
+        '\\' => '\\',
+        '\"' => '\"',
+        '\'' => '\'',
+        'r' => '\r',
+        'n' => '\n',
+        't' => '\t',
+         _ => return None,
+    };
+
+    Some(escaped)
+}
+
 #[test]
 fn test_parse_string() {
     macro_rules! test {
@@ -129,18 +129,6 @@ fn test_parse_string() {
         "abc \t (\\\t) \r (\\\r) def",
         Owned,
     );
-}
-
-#[test]
-#[should_panic]
-fn test_parse_string_escape() {
-    // This shouldn't happen in real code, since
-    // any invalid string constructions are caught at the
-    // tokenization stage.
-    //
-    // However we're testing this to ensure high code coverage.
-
-    let _ = parse_string(r#""Invalid escape! \z""#);
 }
 
 #[test]

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -41,9 +41,22 @@ pub fn parse_string(input: &str) -> Cow<str> {
     //
     // So we check if there are any possible escapes,
     // and if so, build a new string.
+    //
+    // This removes the double quotes on either end
+    // and lets us only deal with the center.
+    // If it's not a string (i.e. doesn't start/end with ")
+    // then it just quits.
 
-    let input = slice_middle(input);
+    let input = match slice_middle(input) {
+        Some(input) => input,
+        None => {
+            warn!("Not a 'string', returning as-is: {:?}", input);
+            return Cow::Borrowed(input);
+        }
+    };
+
     if !input.contains('\\') {
+        trace!("No escapes, returning as-is: {:?}", input);
         return Cow::Borrowed(input);
     }
 


### PR DESCRIPTION
In the interest of being more permissive with inputs (like Wikidot), strings do not require that only valid escapes are given, and any will be repeated as-is. So for instance `"a \n \z"` will return `a <newline> \z`. This also loosens up other checks which previously assumed ASCII boundaries (depending on the lexer to validate for it).