### PR TITLE
[WJ-1097] Minor ftml buffer optimization

### DIFF
--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -135,6 +135,7 @@ where
                 table_of_contents,
                 footnotes,
                 bibliographies,
+                tokenization.full_text().len(),
             )
         }
         Err(error) => {
@@ -157,6 +158,7 @@ where
                 table_of_contents,
                 footnotes,
                 bibliographies,
+                tokenization.full_text().len(),
             )
         }
     }

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -215,7 +215,7 @@ impl<'r, 't> Parser<'r, 't> {
 
         // Render name as text, so it lacks formatting
         let name =
-            TextRender.render_partial(name_elements, self.page_info, self.settings);
+            TextRender.render_partial(name_elements, self.page_info, self.settings, 0);
 
         self.table_of_contents.borrow_mut().push((level, name));
     }

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -89,7 +89,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         wikitext_len: usize,
     ) -> Self {
         HtmlContext {
-            body: String::new(),
+            body: String::with_capacity(wikitext_len),
             meta: Self::initial_metadata(info),
             backlinks: Backlinks::new(),
             info,

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -95,7 +95,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         // being small inputs.
         let capacity = {
             let input = wikitext_len as f32;
-            let output = input * 1.2;
+            let output = input * 1.12;
 
             // Basic sanity check, if this fails
             // just return 0 to avoid weirdness.

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -86,6 +86,7 @@ impl<'i, 'h, 'e, 't> HtmlContext<'i, 'h, 'e, 't> {
         table_of_contents: &'e [Element<'t>],
         footnotes: &'e [Vec<Element<'t>>],
         bibliographies: &'e BibliographyList<'t>,
+        wikitext_len: usize,
     ) -> Self {
         HtmlContext {
             body: String::new(),

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -74,6 +74,7 @@ impl Render for HtmlRender {
             &tree.table_of_contents,
             &tree.footnotes,
             &tree.bibliographies,
+            tree.wikitext_len,
         );
 
         // Crawl through elements and generate HTML

--- a/ftml/src/render/html/test.rs
+++ b/ftml/src/render/html/test.rs
@@ -32,7 +32,7 @@ fn html() {
         vec![],
         vec![],
         BibliographyList::new(),
-        0
+        0,
     );
     let (tree, _) = result.into();
     let _output = HtmlRender.render(&tree, &page_info, &settings);

--- a/ftml/src/render/html/test.rs
+++ b/ftml/src/render/html/test.rs
@@ -26,16 +26,14 @@ use crate::tree::BibliographyList;
 fn html() {
     let page_info = PageInfo::dummy();
     let settings = WikitextSettings::from_mode(WikitextMode::Page);
-
     let result = SyntaxTree::from_element_result(
         vec![],
         vec![],
         vec![],
         vec![],
         BibliographyList::new(),
+        0
     );
     let (tree, _) = result.into();
-    if false {
-        let _output = HtmlRender.render(&tree, &page_info, &settings);
-    }
+    let _output = HtmlRender.render(&tree, &page_info, &settings);
 }

--- a/ftml/src/render/null.rs
+++ b/ftml/src/render/null.rs
@@ -53,6 +53,7 @@ fn null() {
         vec![],
         vec![],
         BibliographyList::new(),
+        0,
     );
     let (tree, _) = result.into();
     let output = NullRender.render(&tree, &page_info, &settings);

--- a/ftml/src/render/text/context.rs
+++ b/ftml/src/render/text/context.rs
@@ -81,9 +81,10 @@ where
         table_of_contents: &'e [Element<'t>],
         footnotes: &'e [Vec<Element<'t>>],
         bibliographies: &'e BibliographyList<'t>,
+        wikitext_len: usize,
     ) -> Self {
         TextContext {
-            output: String::new(),
+            output: String::with_capacity(wikitext_len),
             info,
             handle,
             settings,

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -38,6 +38,7 @@ impl TextRender {
         elements: &[Element],
         page_info: &PageInfo,
         settings: &WikitextSettings,
+        wikitext_len: usize,
     ) -> String {
         self.render_partial_direct(
             elements,
@@ -46,6 +47,7 @@ impl TextRender {
             &[],
             &[],
             &BibliographyList::new(),
+            wikitext_len,
         )
     }
 
@@ -57,6 +59,7 @@ impl TextRender {
         table_of_contents: &[Element],
         footnotes: &[Vec<Element>],
         bibliographies: &BibliographyList,
+        wikitext_len: usize,
     ) -> String {
         info!(
             "Rendering text (site {}, page {}, category {})",
@@ -108,6 +111,7 @@ impl Render for TextRender {
             &tree.table_of_contents,
             &tree.footnotes,
             &tree.bibliographies,
+            tree.wikitext_len,
         )
     }
 }

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -78,6 +78,7 @@ impl TextRender {
             table_of_contents,
             footnotes,
             bibliographies,
+            wikitext_len,
         );
         render_elements(&mut ctx, elements);
 

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -40,26 +40,28 @@ impl TextRender {
         settings: &WikitextSettings,
         wikitext_len: usize,
     ) -> String {
-        self.render_partial_direct(
+        self.render_partial_direct(RenderPartial {
             elements,
             page_info,
             settings,
-            &[],
-            &[],
-            &BibliographyList::new(),
+            table_of_contents: &[],
+            footnotes: &[],
+            bibliographies: &BibliographyList::new(),
             wikitext_len,
-        )
+        })
     }
 
     fn render_partial_direct(
         &self,
-        elements: &[Element],
-        page_info: &PageInfo,
-        settings: &WikitextSettings,
-        table_of_contents: &[Element],
-        footnotes: &[Vec<Element>],
-        bibliographies: &BibliographyList,
-        wikitext_len: usize,
+        RenderPartial {
+            elements,
+            page_info,
+            settings,
+            table_of_contents,
+            footnotes,
+            bibliographies,
+            wikitext_len,
+        }: RenderPartial,
     ) -> String {
         info!(
             "Rendering text (site {}, page {}, category {})",
@@ -105,14 +107,29 @@ impl Render for TextRender {
         page_info: &PageInfo,
         settings: &WikitextSettings,
     ) -> String {
-        self.render_partial_direct(
-            &tree.elements,
+        self.render_partial_direct(RenderPartial {
+            elements: &tree.elements,
             page_info,
             settings,
-            &tree.table_of_contents,
-            &tree.footnotes,
-            &tree.bibliographies,
-            tree.wikitext_len,
-        )
+            table_of_contents: &tree.table_of_contents,
+            footnotes: &tree.footnotes,
+            bibliographies: &tree.bibliographies,
+            wikitext_len: tree.wikitext_len,
+        })
     }
+}
+
+/// Helper structure to pass in values for `render_partial_direct()`.
+///
+/// This exists because otherwise the function would take an excessive
+/// number of parameters, which Clippy dislikes.
+#[derive(Debug)]
+struct RenderPartial<'a> {
+    elements: &'a [Element<'a>],
+    page_info: &'a PageInfo<'a>,
+    settings: &'a WikitextSettings,
+    table_of_contents: &'a [Element<'a>],
+    footnotes: &'a [Vec<Element<'a>>],
+    bibliographies: &'a BibliographyList<'a>,
+    wikitext_len: usize,
 }

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -220,7 +220,8 @@ impl Test<'_> {
         crate::preprocess(&mut text);
         let tokens = crate::tokenize(&text);
         let result = crate::parse(&tokens, &page_info, &settings);
-        let (tree, errors) = result.into();
+        let (mut tree, errors) = result.into();
+        tree.wikitext_len = self.tree.wikitext_len; // not stored in the JSON
         let html_output = HtmlRender.render(&tree, &page_info, &settings);
 
         fn json<T>(object: &T) -> String

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -401,12 +401,14 @@ fn arb_tree() -> impl Strategy<Value = SyntaxTree<'static>> {
         proptest::collection::vec(footnote, 0..2),
         0..250usize,
     )
-        .prop_map(|(elements, table_of_contents, footnotes, wikitext_len)| SyntaxTree {
-            elements,
-            table_of_contents,
-            footnotes,
-            bibliographies: BibliographyList::new(), // not bothering right now
-            wikitext_len,
+        .prop_map(|(elements, table_of_contents, footnotes, wikitext_len)| {
+            SyntaxTree {
+                elements,
+                table_of_contents,
+                footnotes,
+                bibliographies: BibliographyList::new(), // not bothering right now
+                wikitext_len,
+            }
         })
 }
 

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -399,12 +399,14 @@ fn arb_tree() -> impl Strategy<Value = SyntaxTree<'static>> {
         proptest::collection::vec(element, 1..100),
         proptest::collection::vec(toc_heading, 0..2),
         proptest::collection::vec(footnote, 0..2),
+        0..250usize,
     )
-        .prop_map(|(elements, table_of_contents, footnotes)| SyntaxTree {
+        .prop_map(|(elements, table_of_contents, footnotes, wikitext_len)| SyntaxTree {
             elements,
             table_of_contents,
             footnotes,
             bibliographies: BibliographyList::new(), // not bothering right now
+            wikitext_len,
         })
 }
 

--- a/ftml/src/text.rs
+++ b/ftml/src/text.rs
@@ -99,6 +99,12 @@ impl<'t> FullText<'t> {
 
         &self.text[start..end]
     }
+
+    /// Gives the length in bytes of the text.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.text.len()
+    }
 }
 
 #[test]

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -88,6 +88,12 @@ pub struct SyntaxTree<'t> {
 
     /// The full list of bibliographies for this page.
     pub bibliographies: BibliographyList<'t>,
+
+    /// Hint for the size of the wikitext input.
+    ///
+    /// This is an optimization to make rendering large parges slightly faster.
+    #[serde(default)]
+    pub wikitext_len: usize,
 }
 
 impl<'t> SyntaxTree<'t> {
@@ -97,12 +103,14 @@ impl<'t> SyntaxTree<'t> {
         table_of_contents: Vec<Element<'t>>,
         footnotes: Vec<Vec<Element<'t>>>,
         bibliographies: BibliographyList<'t>,
+        wikitext_len: usize,
     ) -> ParseOutcome<Self> {
         let tree = SyntaxTree {
             elements,
             table_of_contents,
             footnotes,
             bibliographies,
+            wikitext_len,
         };
         ParseOutcome::new(tree, errors)
     }
@@ -113,6 +121,7 @@ impl<'t> SyntaxTree<'t> {
             table_of_contents: elements_to_owned(&self.table_of_contents),
             footnotes: elements_lists_to_owned(&self.footnotes),
             bibliographies: self.bibliographies.to_owned(),
+            wikitext_len: self.wikitext_len,
         }
     }
 }


### PR DESCRIPTION
Minor optimization: strings in Rust start allocation at zero (no allocation), and after they are first appended to they begin growing, doubling capacity each time. However since we know that the input wikitext length is correlated with the output HTML length, we can avoid excessive re-allocation (especially early on when the value is small) by basing our initial buffer size based on the input length in bytes.

I ran a script to look at our `test/` files, and I saw that, typically, the output HTML size stays below ~12% of the input wikitext byte length. (Though a value of 10% would likely also be fine.) So, during `HtmlContext` initialization, I use `String::with_capacity` with 112% of the input string's size, which should make allocations at all during the rendering process uncommon.

The `TextContext` initialization is similar, but it matches the input size (i.e. 100% of the value).

In various edge cases (and when retrieving from test files) this value is set to 0, since there is no change in correctness, just a (slight) decrease in speed.