### PR TITLE
Update dependabot directory for npm

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ version: 2
 updates:
   # Frontend
   - package-ecosystem: npm
-    directory: "/web"
+    directory: "/framerail"
     schedule:
       interval: weekly
 


### PR DESCRIPTION
`/web` is being moved over to `/framerail`, as discussed, and does not need dependency upgrades (like `/legacy`).