### PR TITLE
Upgrade chrono

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -679,9 +679,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/deepwell/src/utils/time.rs
+++ b/deepwell/src/utils/time.rs
@@ -22,11 +22,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 
 pub type DateTimeWithTimeZone = DateTime<FixedOffset>;
 
-lazy_static! {
-    pub static ref UTC: FixedOffset = FixedOffset::east(0);
-}
-
 #[inline]
 pub fn now() -> DateTimeWithTimeZone {
-    Utc::now().with_timezone(&*UTC)
+    Utc::now().into()
 }

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/ftml/src/parsing/rule/impls/block/blocks/date.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/date.rs
@@ -99,8 +99,11 @@ fn parse_date(value: &str) -> Result<Date, DateParseError> {
     // Try UNIX timestamp (e.g. 1398763929)
     if let Ok(timestamp) = value.parse::<i64>() {
         debug!("Was UNIX timestamp '{timestamp}'");
-        let date = NaiveDateTime::from_timestamp(timestamp, 0);
-        return Ok(date.into());
+        let date = NaiveDateTime::from_timestamp_opt(timestamp, 0);
+        return match date {
+            Some(date) => Ok(date.into()),
+            None => Err(DateParseError),
+        };
     }
 
     // Try date strings

--- a/ftml/src/parsing/rule/impls/block/blocks/date.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/date.rs
@@ -180,7 +180,7 @@ fn parse_timezone(value: &str) -> Result<FixedOffset, DateParseError> {
         let seconds = sign * (hour * 3600 + minute * 60);
 
         debug!("Was offset via +HH:MM (sign {sign}, hour {hour}, minute {minute})");
-        return Ok(FixedOffset::east(seconds));
+        return get_offset(seconds);
     }
 
     // Try number of seconds
@@ -189,7 +189,7 @@ fn parse_timezone(value: &str) -> Result<FixedOffset, DateParseError> {
     // such as "0800".
     if let Ok(seconds) = value.parse::<i32>() {
         debug!("Was offset in seconds ({seconds})");
-        return Ok(FixedOffset::east(seconds));
+        return get_offset(seconds);
     }
 
     // Exhausted all cases, failing
@@ -202,6 +202,11 @@ struct DateParseError;
 #[inline]
 fn now() -> Date {
     Utc::now().naive_utc().into()
+}
+
+#[inline]
+fn get_offset(seconds: i32) -> Result<FixedOffset, DateParseError> {
+    FixedOffset::east_opt(seconds).ok_or(DateParseError)
 }
 
 // Tests

--- a/ftml/src/tree/date.rs
+++ b/ftml/src/tree/date.rs
@@ -46,7 +46,10 @@ impl Date {
 
     pub fn timestamp(self) -> i64 {
         match self {
-            Date::Date(date) => date.and_hms(0, 0, 0).timestamp(),
+            Date::Date(date) => date
+                .and_hms_opt(0, 0, 0)
+                .expect("Invalid time values")
+                .timestamp(),
             Date::DateTime(datetime) => datetime.timestamp(),
             Date::DateTimeTz(datetime_tz) => datetime_tz.timestamp(),
         }
@@ -115,7 +118,7 @@ impl From<DateTime<FixedOffset>> for Date {
 
 #[inline]
 fn to_datetime(date: NaiveDate) -> NaiveDateTime {
-    date.and_hms(0, 0, 0)
+    date.and_hms_opt(0, 0, 0).expect("Invalid time values")
 }
 
 #[inline]
@@ -130,7 +133,11 @@ cfg_if! {
         /// We need a consistent date for render tests to not constantly expire.
         #[inline]
         fn now() -> Date {
-            NaiveDate::from_ymd(2010, 01, 01).and_hms(08, 10, 00).into()
+            NaiveDate::from_ymd_opt(2010, 01, 01)
+                .expect("Invalid date values")
+                .and_hms_opt(08, 10, 00)
+                .expect("Invalid time values")
+                .into()
         }
     } else {
         /// Helper function to get the current date and time, UTC.


### PR DESCRIPTION
Supersedes #1273, #1274

This version deprecates some methods, so I change assertions to either be more explicit, add checking, or avoid the methods altogether.