### PR TITLE
[WJ-1113] Add email filter

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -411,6 +411,7 @@ CREATE TABLE filter (
     deleted_at TIMESTAMP WITH TIME ZONE,
     site_id BIGINT REFERENCES site(site_id),
     affects_user BOOLEAN NOT NULL DEFAULT false,
+    affects_email BOOLEAN NOT NULL DEFAULT false,
     affects_page BOOLEAN NOT NULL DEFAULT false,
     affects_file BOOLEAN NOT NULL DEFAULT false,
     affects_forum BOOLEAN NOT NULL DEFAULT false,

--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -181,6 +181,18 @@
     },
     {
         "site": null,
+        "regex": "^sudo$",
+        "description": "Reserved name (sudo)",
+        "user": true
+    },
+    {
+        "site": null,
+        "regex": "^wheel$",
+        "description": "Reserved name (wheel)",
+        "user": true
+    },
+    {
+        "site": null,
         "regex": "^anon(ymous)?$",
         "description": "Reserved name (anon / anonymous)",
         "user": true

--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -1,5 +1,23 @@
 [
     {
+        "site": "www",
+        "regex": "^alice$",
+        "description": "Users named Alice cannot join (example)",
+        "user": true
+    },
+    {
+        "site": "www",
+        "regex": "^bob$",
+        "description": "Users named Bob cannot join (example)",
+        "user": true
+    },
+    {
+        "site": null,
+        "regex": "^.*@example\\.com$",
+        "description": "Cannot join using example.com emails (example)",
+        "email": true
+    },
+    {
         "site": null,
         "regex": "wikidot",
         "description": "Reserved name (wikidot)",

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -142,6 +142,9 @@ pub struct Filter {
     pub user: bool,
 
     #[serde(default)]
+    pub email: bool,
+
+    #[serde(default)]
     pub page: bool,
 
     #[serde(default)]

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -201,6 +201,7 @@ pub async fn seed(state: &ApiServerState) -> Result<()> {
             site_id,
             CreateFilter {
                 affects_user: filter.user,
+                affects_email: filter.email,
                 affects_page: filter.page,
                 affects_file: filter.file,
                 affects_forum: filter.forum,

--- a/deepwell/src/models/filter.rs
+++ b/deepwell/src/models/filter.rs
@@ -13,6 +13,7 @@ pub struct Model {
     pub deleted_at: Option<DateTimeWithTimeZone>,
     pub site_id: Option<i64>,
     pub affects_user: bool,
+    pub affects_email: bool,
     pub affects_page: bool,
     pub affects_file: bool,
     pub affects_forum: bool,

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -31,6 +31,7 @@ impl FilterService {
         site_id: Option<i64>,
         CreateFilter {
             affects_user,
+            affects_email,
             affects_page,
             affects_file,
             affects_forum,
@@ -54,6 +55,7 @@ impl FilterService {
         let model = filter::ActiveModel {
             site_id: Set(site_id),
             affects_user: Set(affects_user),
+            affects_email: Set(affects_email),
             affects_page: Set(affects_page),
             affects_file: Set(affects_file),
             affects_forum: Set(affects_forum),
@@ -71,6 +73,7 @@ impl FilterService {
         UpdateFilter {
             filter_id,
             affects_user,
+            affects_email,
             affects_page,
             affects_file,
             affects_forum,
@@ -91,6 +94,10 @@ impl FilterService {
         // Set fields
         if let ProvidedValue::Set(affects) = affects_user {
             model.affects_user = Set(affects);
+        }
+
+        if let ProvidedValue::Set(affects) = affects_email {
+            model.affects_email = Set(affects);
         }
 
         if let ProvidedValue::Set(affects) = affects_page {

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -109,6 +109,12 @@ pub enum FilterType {
     /// * For a site filter, prevent joining of a user with this name or slug.
     User,
 
+    /// Filters on user's email address.
+    ///
+    /// * For a system filter, prevent registration of a user with this email address.
+    /// * For a site filter, prevent joining of a user with this email address.
+    Email,
+
     /// Filters on pages.
     /// Prevents a page edit from going through if it trips this filter.
     Page,
@@ -134,6 +140,7 @@ impl From<FilterType> for filter::Column {
     fn from(filter_type: FilterType) -> filter::Column {
         match filter_type {
             FilterType::User => filter::Column::AffectsUser,
+            FilterType::Email => filter::Column::AffectsEmail,
             FilterType::Page => filter::Column::AffectsPage,
             FilterType::File => filter::Column::AffectsFile,
             FilterType::Forum => filter::Column::AffectsForum,
@@ -144,6 +151,7 @@ impl From<FilterType> for filter::Column {
 #[derive(Deserialize, Debug, Clone)]
 pub struct CreateFilter {
     pub affects_user: bool,
+    pub affects_email: bool,
     pub affects_page: bool,
     pub affects_file: bool,
     pub affects_forum: bool,
@@ -155,6 +163,7 @@ pub struct CreateFilter {
 pub struct UpdateFilter {
     pub filter_id: i64,
     pub affects_user: ProvidedValue<bool>,
+    pub affects_email: ProvidedValue<bool>,
     pub affects_page: ProvidedValue<bool>,
     pub affects_file: ProvidedValue<bool>,
     pub affects_forum: ProvidedValue<bool>,


### PR DESCRIPTION
This adds a new email filter type, which allows regular expressions to deny emails from known bad hosts. It operates on the same principle as other filters, but applies to user's registration emails.