### PR TITLE
Deny [[iframe]]s which specify a non-URL

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "built",
  "cfg-if",

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikidot", "wikijump", "ftml", "parsing", "html"]
 categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "1.19.0"
+version = "1.20.0"
 authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -44,7 +44,7 @@ fn parse_fn<'r, 't>(
 
     let (url, arguments) = parser.get_head_name_map(&BLOCK_IFRAME, in_head)?;
     if !is_url(url) {
-        warn!("Iframe block references non-URL");
+        warn!("Iframe block references non-URL: {url}");
         return Err(parser.make_err(ParseErrorKind::BlockMalformedArguments));
     }
 

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -19,6 +19,7 @@
  */
 
 use super::prelude::*;
+use crate::url::is_url;
 
 pub const BLOCK_IFRAME: BlockRule = BlockRule {
     name: "block-iframe",
@@ -42,6 +43,11 @@ fn parse_fn<'r, 't>(
     assert_block_name(&BLOCK_IFRAME, name);
 
     let (url, arguments) = parser.get_head_name_map(&BLOCK_IFRAME, in_head)?;
+    if !is_url(url) {
+        warn!("Iframe block references non-URL");
+        return Err(parser.make_err(ParseErrorKind::BlockMalformedArguments));
+    }
+
     let element = Element::Iframe {
         url: cow!(url),
         attributes: arguments.to_attribute_map(parser.settings()),

--- a/ftml/test/iframe-xss.html
+++ b/ftml/test/iframe-xss.html
@@ -1,0 +1,1 @@
+<wj-body class="wj-body"><p>[[iframe javascript:alert(1)]]</p></wj-body>

--- a/ftml/test/iframe-xss.json
+++ b/ftml/test/iframe-xss.json
@@ -1,0 +1,89 @@
+{
+    "input": "[[iframe javascript:alert(1)]]",
+    "tree": {
+        "elements": [
+            {
+                "element": "container",
+                "data": {
+                    "type": "paragraph",
+                    "attributes": {},
+                    "elements": [
+                        {
+                            "element": "text",
+                            "data": "[["
+                        },
+                        {
+                            "element": "text",
+                            "data": "iframe"
+                        },
+                        {
+                            "element": "text",
+                            "data": " "
+                        },
+                        {
+                            "element": "text",
+                            "data": "javascript"
+                        },
+                        {
+                            "element": "text",
+                            "data": ":"
+                        },
+                        {
+                            "element": "text",
+                            "data": "alert"
+                        },
+                        {
+                            "element": "text",
+                            "data": "("
+                        },
+                        {
+                            "element": "text",
+                            "data": "1"
+                        },
+                        {
+                            "element": "text",
+                            "data": ")"
+                        },
+                        {
+                            "element": "text",
+                            "data": "]]"
+                        }
+                    ]
+                }
+            },
+            {
+                "element": "footnote-block",
+                "data": {
+                    "title": null,
+                    "hide": false
+                }
+            }
+        ],
+        "table-of-contents": [
+        ],
+        "footnotes": [
+        ],
+        "bibliographies": [
+        ]
+    },
+    "errors": [
+        {
+            "token": "input-end",
+            "rule": "block-iframe",
+            "span": [30, 30],
+            "kind": "block-malformed-arguments"
+        },
+        {
+            "token": "left-block",
+            "rule": "fallback",
+            "span": [0, 2],
+            "kind": "no-rules-match"
+        },
+        {
+            "token": "right-block",
+            "rule": "fallback",
+            "span": [28, 30],
+            "kind": "no-rules-match"
+        }
+    ]
+}

--- a/ftml/test/iframe-xss.txt
+++ b/ftml/test/iframe-xss.txt
@@ -1,0 +1,1 @@
+[[iframe javascript:alert(1)]]


### PR DESCRIPTION
As a means of XSS prevention, using the `is_url()` helper function. Bumps version so we can ensure dependents have the fix.