### PR TITLE
Update listed stable rustc version

### DIFF
--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -51,7 +51,7 @@ The routes are defined in `api/`, with their implementations in `methods/`, and 
 
 ### Compilation
 
-This executable targets the latest stable Rust. At time of writing, that is `1.65.0`.
+This executable targets the latest stable Rust. At time of writing, that is `1.66.0`.
 
 ```sh
 $ cargo build --release

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -30,7 +30,7 @@ Available under the terms of the GNU Affero General Public License. See [LICENSE
 
 ### Compilation
 
-This library targets the latest stable Rust. At time of writing, that is `1.65.0`.
+This library targets the latest stable Rust. At time of writing, that is `1.66.0`.
 
 ```sh
 $ cargo build --release


### PR DESCRIPTION
[Rust 1.66 announcement](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)