### PR TITLE
[WJ-1126] Update copyright years to 2023

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Wikijump - FOSS Wiki Software for Writing Communities
-Copyright (c) 2020-2022, Wikijump Team
+Copyright (c) 2020-2023, Wikijump Team
 
 Based on Wikidot - free wiki collaboration software
 Copyright (c) 2008, Wikidot Inc.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Wikijump is available under the same license as Wikidot, the [GNU Affero General
 
 ```
 Wikijump - FOSS Wiki Software for Writing Communities
-Copyright (c) 2019-2022, Wikijump Team
+Copyright (c) 2019-2023, Wikijump Team
 
 Based on Wikidot - free wiki collaboration software
 Copyright (c) 2008, Wikidot Inc.

--- a/deepwell/misc/header.txt
+++ b/deepwell/misc/header.txt
@@ -2,7 +2,7 @@
  * (FILENAME)
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -2,7 +2,7 @@
  * api.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/config.rs
+++ b/deepwell/src/config.rs
@@ -2,7 +2,7 @@
  * config.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/constants.rs
+++ b/deepwell/src/constants.rs
@@ -2,7 +2,7 @@
  * constants.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/database/mod.rs
+++ b/deepwell/src/database/mod.rs
@@ -2,7 +2,7 @@
  * database/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -2,7 +2,7 @@
  * database/seeder/data.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -2,7 +2,7 @@
  * database/seeder/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/hash.rs
+++ b/deepwell/src/hash.rs
@@ -2,7 +2,7 @@
  * hash.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/info.rs
+++ b/deepwell/src/info.rs
@@ -2,7 +2,7 @@
  * info.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/locales/arguments.rs
+++ b/deepwell/src/locales/arguments.rs
@@ -2,7 +2,7 @@
  * locales/arguments.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/locales/error.rs
+++ b/deepwell/src/locales/error.rs
@@ -2,7 +2,7 @@
  * locales/error.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -2,7 +2,7 @@
  * locales/fluent.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/locales/mod.rs
+++ b/deepwell/src/locales/mod.rs
@@ -2,7 +2,7 @@
  * locales/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/macros.rs
+++ b/deepwell/src/macros.rs
@@ -2,7 +2,7 @@
  * macros.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -2,7 +2,7 @@
  * main.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/auth.rs
+++ b/deepwell/src/methods/auth.rs
@@ -2,7 +2,7 @@
  * methods/auth.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/category.rs
+++ b/deepwell/src/methods/category.rs
@@ -2,7 +2,7 @@
  * methods/category.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/file.rs
+++ b/deepwell/src/methods/file.rs
@@ -2,7 +2,7 @@
  * methods/file.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/file_revision.rs
+++ b/deepwell/src/methods/file_revision.rs
@@ -2,7 +2,7 @@
  * methods/file_revision.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/link.rs
+++ b/deepwell/src/methods/link.rs
@@ -2,7 +2,7 @@
  * methods/link.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/locale.rs
+++ b/deepwell/src/methods/locale.rs
@@ -2,7 +2,7 @@
  * methods/locales.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/misc.rs
+++ b/deepwell/src/methods/misc.rs
@@ -2,7 +2,7 @@
  * methods/misc.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/mod.rs
+++ b/deepwell/src/methods/mod.rs
@@ -2,7 +2,7 @@
  * methods/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/page.rs
+++ b/deepwell/src/methods/page.rs
@@ -2,7 +2,7 @@
  * methods/page.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/page_revision.rs
+++ b/deepwell/src/methods/page_revision.rs
@@ -2,7 +2,7 @@
  * methods/page_revision.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/parent.rs
+++ b/deepwell/src/methods/parent.rs
@@ -2,7 +2,7 @@
  * methods/parent.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/site.rs
+++ b/deepwell/src/methods/site.rs
@@ -2,7 +2,7 @@
  * methods/site.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/text.rs
+++ b/deepwell/src/methods/text.rs
@@ -2,7 +2,7 @@
  * methods/text.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/user.rs
+++ b/deepwell/src/methods/user.rs
@@ -2,7 +2,7 @@
  * methods/user.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/user_bot.rs
+++ b/deepwell/src/methods/user_bot.rs
@@ -2,7 +2,7 @@
  * methods/user_bot.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/methods/vote.rs
+++ b/deepwell/src/methods/vote.rs
@@ -2,7 +2,7 @@
  * methods/vote.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/authentication/mod.rs
+++ b/deepwell/src/services/authentication/mod.rs
@@ -2,7 +2,7 @@
  * services/authentication/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/authentication/service.rs
+++ b/deepwell/src/services/authentication/service.rs
@@ -2,7 +2,7 @@
  * services/authentication/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/authentication/structs.rs
+++ b/deepwell/src/services/authentication/structs.rs
@@ -2,7 +2,7 @@
  * services/authentication/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/blob/mime.rs
+++ b/deepwell/src/services/blob/mime.rs
@@ -2,7 +2,7 @@
  * services/blob/mime.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/blob/mod.rs
+++ b/deepwell/src/services/blob/mod.rs
@@ -2,7 +2,7 @@
  * services/blob/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -2,7 +2,7 @@
  * services/blob/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/blob/structs.rs
+++ b/deepwell/src/services/blob/structs.rs
@@ -2,7 +2,7 @@
  * services/blob/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/category/mod.rs
+++ b/deepwell/src/services/category/mod.rs
@@ -2,7 +2,7 @@
  * services/category/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/category/service.rs
+++ b/deepwell/src/services/category/service.rs
@@ -2,7 +2,7 @@
  * services/category/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/category/structs.rs
+++ b/deepwell/src/services/category/structs.rs
@@ -2,7 +2,7 @@
  * services/category/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -2,7 +2,7 @@
  * services/context.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -2,7 +2,7 @@
  * services/error.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file/mod.rs
+++ b/deepwell/src/services/file/mod.rs
@@ -2,7 +2,7 @@
  * services/file/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -2,7 +2,7 @@
  * services/file/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -2,7 +2,7 @@
  * services/file/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file_revision/mod.rs
+++ b/deepwell/src/services/file_revision/mod.rs
@@ -2,7 +2,7 @@
  * services/file_revision/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -2,7 +2,7 @@
  * services/file_revision/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -2,7 +2,7 @@
  * services/file_revision/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -2,7 +2,7 @@
  * services/filter/matcher.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/filter/mod.rs
+++ b/deepwell/src/services/filter/mod.rs
@@ -2,7 +2,7 @@
  * services/filter/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -2,7 +2,7 @@
  * services/filter/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -2,7 +2,7 @@
  * services/filter/struct.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/job/mod.rs
+++ b/deepwell/src/services/job/mod.rs
@@ -2,7 +2,7 @@
  * services/job/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/job/service.rs
+++ b/deepwell/src/services/job/service.rs
@@ -2,7 +2,7 @@
  * services/job/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/job/structs.rs
+++ b/deepwell/src/services/job/structs.rs
@@ -2,7 +2,7 @@
  * services/job/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/link/macros.rs
+++ b/deepwell/src/services/link/macros.rs
@@ -2,7 +2,7 @@
  * services/link/macros.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/link/mod.rs
+++ b/deepwell/src/services/link/mod.rs
@@ -2,7 +2,7 @@
  * services/link/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/link/service.rs
+++ b/deepwell/src/services/link/service.rs
@@ -2,7 +2,7 @@
  * services/link/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/link/structs.rs
+++ b/deepwell/src/services/link/structs.rs
@@ -2,7 +2,7 @@
  * services/link/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/mfa/mod.rs
+++ b/deepwell/src/services/mfa/mod.rs
@@ -2,7 +2,7 @@
  * services/mfa/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/mfa/service.rs
+++ b/deepwell/src/services/mfa/service.rs
@@ -2,7 +2,7 @@
  * services/mfa/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/mfa/structs.rs
+++ b/deepwell/src/services/mfa/structs.rs
@@ -2,7 +2,7 @@
  * services/mfa/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/mod.rs
+++ b/deepwell/src/services/mod.rs
@@ -2,7 +2,7 @@
  * services/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/outdate.rs
+++ b/deepwell/src/services/outdate.rs
@@ -2,7 +2,7 @@
  * services/outdate.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/page/mod.rs
+++ b/deepwell/src/services/page/mod.rs
@@ -2,7 +2,7 @@
  * services/page/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -2,7 +2,7 @@
  * services/page/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -2,7 +2,7 @@
  * services/page/struct.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/parent/mod.rs
+++ b/deepwell/src/services/parent/mod.rs
@@ -2,7 +2,7 @@
  * services/parent/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/parent/service.rs
+++ b/deepwell/src/services/parent/service.rs
@@ -2,7 +2,7 @@
  * services/parent/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/parent/structs.rs
+++ b/deepwell/src/services/parent/structs.rs
@@ -2,7 +2,7 @@
  * services/parent/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/password.rs
+++ b/deepwell/src/services/password.rs
@@ -2,7 +2,7 @@
  * services/password.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/render/mod.rs
+++ b/deepwell/src/services/render/mod.rs
@@ -2,7 +2,7 @@
  * services/render/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/render/service.rs
+++ b/deepwell/src/services/render/service.rs
@@ -2,7 +2,7 @@
  * services/render/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/render/structs.rs
+++ b/deepwell/src/services/render/structs.rs
@@ -2,7 +2,7 @@
  * services/render/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/revision/mod.rs
+++ b/deepwell/src/services/revision/mod.rs
@@ -2,7 +2,7 @@
  * services/revision/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/revision/service.rs
+++ b/deepwell/src/services/revision/service.rs
@@ -2,7 +2,7 @@
  * services/revision/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/revision/structs.rs
+++ b/deepwell/src/services/revision/structs.rs
@@ -2,7 +2,7 @@
  * services/revision/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/revision/tasks.rs
+++ b/deepwell/src/services/revision/tasks.rs
@@ -2,7 +2,7 @@
  * services/revision/tasks.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/impls/mean.rs
+++ b/deepwell/src/services/score/impls/mean.rs
@@ -2,7 +2,7 @@
  * services/score/impls/mean.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/impls/mod.rs
+++ b/deepwell/src/services/score/impls/mod.rs
@@ -2,7 +2,7 @@
  * services/score/impls/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/impls/null.rs
+++ b/deepwell/src/services/score/impls/null.rs
@@ -2,7 +2,7 @@
  * services/score/impls/null.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/impls/percent.rs
+++ b/deepwell/src/services/score/impls/percent.rs
@@ -2,7 +2,7 @@
  * services/score/impls/percent.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/impls/sum.rs
+++ b/deepwell/src/services/score/impls/sum.rs
@@ -2,7 +2,7 @@
  * services/score/impls/sum.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/mean.rs
+++ b/deepwell/src/services/score/mean.rs
@@ -2,7 +2,7 @@
  * services/score/impls/mean.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/mod.rs
+++ b/deepwell/src/services/score/mod.rs
@@ -2,7 +2,7 @@
  * services/score/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/scorer.rs
+++ b/deepwell/src/services/score/scorer.rs
@@ -2,7 +2,7 @@
  * services/score/scorer.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/service.rs
+++ b/deepwell/src/services/score/service.rs
@@ -2,7 +2,7 @@
  * services/score/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/score/structs.rs
+++ b/deepwell/src/services/score/structs.rs
@@ -2,7 +2,7 @@
  * services/score/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/session/mod.rs
+++ b/deepwell/src/services/session/mod.rs
@@ -2,7 +2,7 @@
  * services/session/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/session/service.rs
+++ b/deepwell/src/services/session/service.rs
@@ -2,7 +2,7 @@
  * services/session/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/session/structs.rs
+++ b/deepwell/src/services/session/structs.rs
@@ -2,7 +2,7 @@
  * services/session/struct.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/site/mod.rs
+++ b/deepwell/src/services/site/mod.rs
@@ -2,7 +2,7 @@
  * services/site/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -2,7 +2,7 @@
  * services/site/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/site/structs.rs
+++ b/deepwell/src/services/site/structs.rs
@@ -2,7 +2,7 @@
  * services/site/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/text.rs
+++ b/deepwell/src/services/text.rs
@@ -2,7 +2,7 @@
  * services/text.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user/mod.rs
+++ b/deepwell/src/services/user/mod.rs
@@ -2,7 +2,7 @@
  * services/user/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -2,7 +2,7 @@
  * services/user/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user/structs.rs
+++ b/deepwell/src/services/user/structs.rs
@@ -2,7 +2,7 @@
  * services/user/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_alias/mod.rs
+++ b/deepwell/src/services/user_alias/mod.rs
@@ -2,7 +2,7 @@
  * services/user_alias/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_alias/service.rs
+++ b/deepwell/src/services/user_alias/service.rs
@@ -2,7 +2,7 @@
  * services/user_alias/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_alias/structs.rs
+++ b/deepwell/src/services/user_alias/structs.rs
@@ -2,7 +2,7 @@
  * services/user_alias/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_bot_owner/mod.rs
+++ b/deepwell/src/services/user_bot_owner/mod.rs
@@ -2,7 +2,7 @@
  * services/user_bot_owner/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_bot_owner/service.rs
+++ b/deepwell/src/services/user_bot_owner/service.rs
@@ -2,7 +2,7 @@
  * services/user_bot_owner/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/user_bot_owner/structs.rs
+++ b/deepwell/src/services/user_bot_owner/structs.rs
@@ -2,7 +2,7 @@
  * services/user_bot_owner/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/vote/mod.rs
+++ b/deepwell/src/services/vote/mod.rs
@@ -2,7 +2,7 @@
  * services/vote/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/vote/service.rs
+++ b/deepwell/src/services/vote/service.rs
@@ -2,7 +2,7 @@
  * services/vote/service.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/services/vote/structs.rs
+++ b/deepwell/src/services/vote/structs.rs
@@ -2,7 +2,7 @@
  * services/vote/structs.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/category.rs
+++ b/deepwell/src/utils/category.rs
@@ -2,7 +2,7 @@
  * utils/category.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/crypto.rs
+++ b/deepwell/src/utils/crypto.rs
@@ -2,7 +2,7 @@
  * utils/crypto.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/error.rs
+++ b/deepwell/src/utils/error.rs
@@ -2,7 +2,7 @@
  * utils/error.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/locale.rs
+++ b/deepwell/src/utils/locale.rs
@@ -2,7 +2,7 @@
  * utils/locale.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/mod.rs
+++ b/deepwell/src/utils/mod.rs
@@ -2,7 +2,7 @@
  * utils/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -2,7 +2,7 @@
  * utils/string.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/tide.rs
+++ b/deepwell/src/utils/tide.rs
@@ -2,7 +2,7 @@
  * utils/tide.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/time.rs
+++ b/deepwell/src/utils/time.rs
@@ -2,7 +2,7 @@
  * utils/time.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/utils/user.rs
+++ b/deepwell/src/utils/user.rs
@@ -2,7 +2,7 @@
  * utils/user.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/connection_type.rs
+++ b/deepwell/src/web/connection_type.rs
@@ -2,7 +2,7 @@
  * web/connection_type.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/fetch_direction.rs
+++ b/deepwell/src/web/fetch_direction.rs
@@ -2,7 +2,7 @@
  * web/fetch_direction.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/fetch_limit/de.rs
+++ b/deepwell/src/web/fetch_limit/de.rs
@@ -2,7 +2,7 @@
  * web/fetch_limit/de.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/fetch_limit/mod.rs
+++ b/deepwell/src/web/fetch_limit/mod.rs
@@ -2,7 +2,7 @@
  * web/fetch_limit/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/file_details.rs
+++ b/deepwell/src/web/file_details.rs
@@ -2,7 +2,7 @@
  * web/file_details.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/mod.rs
+++ b/deepwell/src/web/mod.rs
@@ -2,7 +2,7 @@
  * web/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/page_details.rs
+++ b/deepwell/src/web/page_details.rs
@@ -2,7 +2,7 @@
  * web/page_details.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/page_order.rs
+++ b/deepwell/src/web/page_order.rs
@@ -2,7 +2,7 @@
  * web/page_order.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/provided_value.rs
+++ b/deepwell/src/web/provided_value.rs
@@ -2,7 +2,7 @@
  * web/provided_value.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/reference/cuid.rs
+++ b/deepwell/src/web/reference/cuid.rs
@@ -2,7 +2,7 @@
  * web/reference/file.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/reference/id.rs
+++ b/deepwell/src/web/reference/id.rs
@@ -2,7 +2,7 @@
  * web/reference/id.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/reference/mod.rs
+++ b/deepwell/src/web/reference/mod.rs
@@ -2,7 +2,7 @@
  * web/reference.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/unwrap.rs
+++ b/deepwell/src/web/unwrap.rs
@@ -2,7 +2,7 @@
  * web/unwrap.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/user_details.rs
+++ b/deepwell/src/web/user_details.rs
@@ -2,7 +2,7 @@
  * web/user_details.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/deepwell/src/web/user_id.rs
+++ b/deepwell/src/web/user_id.rs
@@ -2,7 +2,7 @@
  * web/user_id.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/docs/Blocks.md
+++ b/ftml/docs/Blocks.md
@@ -237,7 +237,7 @@ Value &mdash; (String) The HTML entity to place here.
 Example:
 
 ```
-This file is [[char copy]] 2019-2022 Team Wikijump.
+This file is [[char copy]] 2019-2023 Team Wikijump.
 ```
 
 ### Checkbox

--- a/ftml/examples/validate_json.rs
+++ b/ftml/examples/validate_json.rs
@@ -2,7 +2,7 @@
  * examples/validate_json.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/misc/header.txt
+++ b/ftml/misc/header.txt
@@ -2,7 +2,7 @@
  * (FILENAME)
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/backlinks.rs
+++ b/ftml/src/data/backlinks.rs
@@ -2,7 +2,7 @@
  * render/backlinks.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/karma.rs
+++ b/ftml/src/data/karma.rs
@@ -2,7 +2,7 @@
  * data/karma.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/mod.rs
+++ b/ftml/src/data/mod.rs
@@ -2,7 +2,7 @@
  * data/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/page_info.rs
+++ b/ftml/src/data/page_info.rs
@@ -2,7 +2,7 @@
  * data/page_info.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/page_ref.rs
+++ b/ftml/src/data/page_ref.rs
@@ -2,7 +2,7 @@
  * data/page_ref.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/score.rs
+++ b/ftml/src/data/score.rs
@@ -2,7 +2,7 @@
  * data/score.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/data/user_info.rs
+++ b/ftml/src/data/user_info.rs
@@ -2,7 +2,7 @@
  * data/user_info.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/id_prefix.rs
+++ b/ftml/src/id_prefix.rs
@@ -2,7 +2,7 @@
  * id_prefix.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/grammar.pest
+++ b/ftml/src/includes/grammar.pest
@@ -2,7 +2,7 @@
 // include/grammar.pest
 //
 // ftml - Library to parse Wikidot text
-// Copyright (C) 2019-2022 Wikijump Team
+// Copyright (C) 2019-2023 Wikijump Team
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/include_ref.rs
+++ b/ftml/src/includes/include_ref.rs
@@ -2,7 +2,7 @@
  * includes/include_ref.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/includer/debug.rs
+++ b/ftml/src/includes/includer/debug.rs
@@ -2,7 +2,7 @@
  * includes/includer/debug.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/includer/mod.rs
+++ b/ftml/src/includes/includer/mod.rs
@@ -2,7 +2,7 @@
  * includes/includer/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/includer/null.rs
+++ b/ftml/src/includes/includer/null.rs
@@ -2,7 +2,7 @@
  * includes/includer/null.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -2,7 +2,7 @@
  * includes/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/parse.rs
+++ b/ftml/src/includes/parse.rs
@@ -2,7 +2,7 @@
  * includes/parse.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/includes/test.rs
+++ b/ftml/src/includes/test.rs
@@ -2,7 +2,7 @@
  * includes/test.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/info.rs
+++ b/ftml/src/info.rs
@@ -2,7 +2,7 @@
  * info.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -2,7 +2,7 @@
  * lib.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/macros.rs
+++ b/ftml/src/macros.rs
@@ -2,7 +2,7 @@
  * macros.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/next_index.rs
+++ b/ftml/src/next_index.rs
@@ -2,7 +2,7 @@
  * next_index.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/non_empty_vec.rs
+++ b/ftml/src/non_empty_vec.rs
@@ -2,7 +2,7 @@
  * non_empty_vec.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/boolean.rs
+++ b/ftml/src/parsing/boolean.rs
@@ -2,7 +2,7 @@
  * parsing/boolean.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/check_step.rs
+++ b/ftml/src/parsing/check_step.rs
@@ -2,7 +2,7 @@
  * parsing/check_step.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/collect/consume.rs
+++ b/ftml/src/parsing/collect/consume.rs
@@ -2,7 +2,7 @@
  * parsing/collect/consume.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/collect/container.rs
+++ b/ftml/src/parsing/collect/container.rs
@@ -2,7 +2,7 @@
  * parsing/collect/container.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/collect/generic.rs
+++ b/ftml/src/parsing/collect/generic.rs
@@ -2,7 +2,7 @@
  * parsing/collect/generic.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/collect/mod.rs
+++ b/ftml/src/parsing/collect/mod.rs
@@ -2,7 +2,7 @@
  * parsing/collect/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/collect/text.rs
+++ b/ftml/src/parsing/collect/text.rs
@@ -2,7 +2,7 @@
  * parsing/collect/text.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/condition.rs
+++ b/ftml/src/parsing/condition.rs
@@ -2,7 +2,7 @@
  * parsing/condition.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/consume.rs
+++ b/ftml/src/parsing/consume.rs
@@ -2,7 +2,7 @@
  * parsing/consume.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/depth.rs
+++ b/ftml/src/parsing/depth.rs
@@ -2,7 +2,7 @@
  * parsing/depth.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/element_condition.rs
+++ b/ftml/src/parsing/element_condition.rs
@@ -2,7 +2,7 @@
  * parsing/element_condition.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/error.rs
+++ b/ftml/src/parsing/error.rs
@@ -2,7 +2,7 @@
  * parsing/exception.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/lexer.pest
+++ b/ftml/src/parsing/lexer.pest
@@ -2,7 +2,7 @@
 // parse/lexer.pest
 //
 // ftml - Library to parse Wikidot text
-// Copyright (C) 2019-2022 Wikijump Team
+// Copyright (C) 2019-2023 Wikijump Team
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/macros.rs
+++ b/ftml/src/parsing/macros.rs
@@ -2,7 +2,7 @@
  * parsing/macros.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/mod.rs
+++ b/ftml/src/parsing/mod.rs
@@ -2,7 +2,7 @@
  * parsing/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/outcome.rs
+++ b/ftml/src/parsing/outcome.rs
@@ -2,7 +2,7 @@
  * parsing/outcome.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/paragraph/mod.rs
+++ b/ftml/src/parsing/paragraph/mod.rs
@@ -2,7 +2,7 @@
  * parsing/paragraph/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/paragraph/stack.rs
+++ b/ftml/src/parsing/paragraph/stack.rs
@@ -2,7 +2,7 @@
  * parsing/paragraph/stack.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/parser.rs
+++ b/ftml/src/parsing/parser.rs
@@ -2,7 +2,7 @@
  * parsing/parser.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/parser_wrap.rs
+++ b/ftml/src/parsing/parser_wrap.rs
@@ -2,7 +2,7 @@
  * parsing/parser_wrap.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/result.rs
+++ b/ftml/src/parsing/result.rs
@@ -2,7 +2,7 @@
  * parsing/result.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/anchor.rs
+++ b/ftml/src/parsing/rule/impls/anchor.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/anchor.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/bibcite.rs
+++ b/ftml/src/parsing/rule/impls/bibcite.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/bibcite.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/arguments.rs
+++ b/ftml/src/parsing/rule/impls/block/arguments.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/arguments.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/align.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/align.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/align_center.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align_center.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/align_center.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/align_justify.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align_justify.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/align_justify.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/align_left.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align_left.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/align_left.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/align_right.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/align_right.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/align_right.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/anchor.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/anchor.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/bibcite.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bibcite.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/bibcite.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/bibliography.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bibliography.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/bibliography.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/blockquote.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/blockquote.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/bold.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/bold.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/bold.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/char.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/checkbox.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/checkbox.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/code.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/code.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/code.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/collapsible.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/collapsible.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/date.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/date.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/date.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/del.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/del.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/del.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/div.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/div.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/div.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/embed.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/embed.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/embed.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/equation_ref.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/equation_ref.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/equation_ref.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/footnote.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/footnote.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/footnote.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/hidden.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/hidden.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/html.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/html.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/html.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/ifcategory.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ifcategory.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/ifcategory.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iframe.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/iframe.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/iftags.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/iftags.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/iftags.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/image.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/image.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/image.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/include_elements.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include_elements.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/include_elements.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/include_messy.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/include_messy.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/ins.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ins.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/ins.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/invisible.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/invisible.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/italics.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/italics.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/italics.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/later.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/later.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/later.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/lines.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/lines.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/lines.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/list.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/list.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/mark.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mark.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/mark.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/math.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/math.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/math.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/mapping.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/backlinks.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/backlinks.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/categories.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/categories.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/css.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/css.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/join.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/join.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/page_tree.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/page_tree.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/modules/rate.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/modules/rate.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/output.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/output.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/output.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/parser.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/parser.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/rule.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/module/rule.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/monospace.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/monospace.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/paragraph.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/paragraph.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/radio.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/radio.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/radio.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/ruby.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/ruby.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/ruby.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/size.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/size.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/size.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/span.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/span.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/span.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/strikethrough.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/strikethrough.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/subscript.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/subscript.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/superscript.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/superscript.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/table.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/table.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/table.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/tabs.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/tabs.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/tabs.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/target.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/target.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/target.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/toc.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/toc.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/toc.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/underline.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/underline.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/underline.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/blocks/user.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/user.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/blocks/user.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/mapping.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/mod.rs
+++ b/ftml/src/parsing/rule/impls/block/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/parser.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/block/rule.rs
+++ b/ftml/src/parsing/rule/impls/block/rule.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/block/rule.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/blockquote.rs
+++ b/ftml/src/parsing/rule/impls/blockquote.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/blockquote.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/bold.rs
+++ b/ftml/src/parsing/rule/impls/bold.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/bold.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/center.rs
+++ b/ftml/src/parsing/rule/impls/center.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/center.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/clear_float.rs
+++ b/ftml/src/parsing/rule/impls/clear_float.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/clear_float.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/color.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/comment.rs
+++ b/ftml/src/parsing/rule/impls/comment.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/comment.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/dash.rs
+++ b/ftml/src/parsing/rule/impls/dash.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/dash.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/definition_list.rs
+++ b/ftml/src/parsing/rule/impls/definition_list.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/definition_list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/double_angle.rs
+++ b/ftml/src/parsing/rule/impls/double_angle.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/double_angle.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/email.rs
+++ b/ftml/src/parsing/rule/impls/email.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/email.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/fallback.rs
+++ b/ftml/src/parsing/rule/impls/fallback.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/fallback.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/header.rs
+++ b/ftml/src/parsing/rule/impls/header.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/header.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/horizontal_rule.rs
+++ b/ftml/src/parsing/rule/impls/horizontal_rule.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/horizontal_rule.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/italics.rs
+++ b/ftml/src/parsing/rule/impls/italics.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/italics.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/line_break.rs
+++ b/ftml/src/parsing/rule/impls/line_break.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/line_break.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/link_anchor.rs
+++ b/ftml/src/parsing/rule/impls/link_anchor.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/link_anchor.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/link_single.rs
+++ b/ftml/src/parsing/rule/impls/link_single.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/link_single.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/link_triple.rs
+++ b/ftml/src/parsing/rule/impls/link_triple.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/link_triple.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/list.rs
+++ b/ftml/src/parsing/rule/impls/list.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/math.rs
+++ b/ftml/src/parsing/rule/impls/math.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/math.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/mod.rs
+++ b/ftml/src/parsing/rule/impls/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/monospace.rs
+++ b/ftml/src/parsing/rule/impls/monospace.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/monospace.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/null.rs
+++ b/ftml/src/parsing/rule/impls/null.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/null.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/page.rs
+++ b/ftml/src/parsing/rule/impls/page.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/page.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/raw.rs
+++ b/ftml/src/parsing/rule/impls/raw.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/raw.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/strikethrough.rs
+++ b/ftml/src/parsing/rule/impls/strikethrough.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/strikethrough.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/subscript.rs
+++ b/ftml/src/parsing/rule/impls/subscript.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/subscript.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/superscript.rs
+++ b/ftml/src/parsing/rule/impls/superscript.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/superscript.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/table.rs
+++ b/ftml/src/parsing/rule/impls/table.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/table.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/text.rs
+++ b/ftml/src/parsing/rule/impls/text.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/text.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/underline.rs
+++ b/ftml/src/parsing/rule/impls/underline.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/underline.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/underscore_line_break.rs
+++ b/ftml/src/parsing/rule/impls/underscore_line_break.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/underscore_line_break.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/url.rs
+++ b/ftml/src/parsing/rule/impls/url.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/url.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/impls/variable.rs
+++ b/ftml/src/parsing/rule/impls/variable.rs
@@ -2,7 +2,7 @@
  * parsing/rule/impls/variable.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/mapping.rs
+++ b/ftml/src/parsing/rule/mapping.rs
@@ -2,7 +2,7 @@
  * parsing/rule/mapping.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/rule/mod.rs
+++ b/ftml/src/parsing/rule/mod.rs
@@ -2,7 +2,7 @@
  * parsing/rule/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/string.rs
+++ b/ftml/src/parsing/string.rs
@@ -2,7 +2,7 @@
  * parsing/string.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/strip.rs
+++ b/ftml/src/parsing/strip.rs
@@ -2,7 +2,7 @@
  * parsing/strip.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/token/mod.rs
+++ b/ftml/src/parsing/token/mod.rs
@@ -2,7 +2,7 @@
  * parsing/token/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/parsing/token/test.rs
+++ b/ftml/src/parsing/token/test.rs
@@ -2,7 +2,7 @@
  * parsing/token/test.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/preproc/mod.rs
+++ b/ftml/src/preproc/mod.rs
@@ -2,7 +2,7 @@
  * preproc/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/preproc/test.rs
+++ b/ftml/src/preproc/test.rs
@@ -2,7 +2,7 @@
  * preproc/test.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -2,7 +2,7 @@
  * preproc/typography.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -2,7 +2,7 @@
  * preproc/whitespace.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/debug.rs
+++ b/ftml/src/render/debug.rs
@@ -2,7 +2,7 @@
  * render/debug.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/handle.rs
+++ b/ftml/src/render/handle.rs
@@ -2,7 +2,7 @@
  * render/handle.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/attributes.rs
+++ b/ftml/src/render/html/attributes.rs
@@ -2,7 +2,7 @@
  * render/html/attributes.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/builder.rs
+++ b/ftml/src/render/html/builder.rs
@@ -2,7 +2,7 @@
  * render/html/builder.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/context.rs
+++ b/ftml/src/render/html/context.rs
@@ -2,7 +2,7 @@
  * render/html/context.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/bibliography.rs
+++ b/ftml/src/render/html/element/bibliography.rs
@@ -2,7 +2,7 @@
  * render/html/element/bibliography.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/collapsible.rs
+++ b/ftml/src/render/html/element/collapsible.rs
@@ -2,7 +2,7 @@
  * render/html/element/collapsible.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/container.rs
+++ b/ftml/src/render/html/element/container.rs
@@ -2,7 +2,7 @@
  * render/html/element/container.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/date.rs
+++ b/ftml/src/render/html/element/date.rs
@@ -2,7 +2,7 @@
  * render/html/element/date.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/definition_list.rs
+++ b/ftml/src/render/html/element/definition_list.rs
@@ -2,7 +2,7 @@
  * render/html/element/definition_list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/embed.rs
+++ b/ftml/src/render/html/element/embed.rs
@@ -2,7 +2,7 @@
  * render/html/element/embed.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/footnotes.rs
+++ b/ftml/src/render/html/element/footnotes.rs
@@ -2,7 +2,7 @@
  * render/html/element/footnotes.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/iframe.rs
+++ b/ftml/src/render/html/element/iframe.rs
@@ -2,7 +2,7 @@
  * render/html/element/iframe.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/image.rs
+++ b/ftml/src/render/html/element/image.rs
@@ -2,7 +2,7 @@
  * render/html/element/image.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/include.rs
+++ b/ftml/src/render/html/element/include.rs
@@ -2,7 +2,7 @@
  * render/html/element/include.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/input.rs
+++ b/ftml/src/render/html/element/input.rs
@@ -2,7 +2,7 @@
  * render/html/element/input.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/link.rs
+++ b/ftml/src/render/html/element/link.rs
@@ -2,7 +2,7 @@
  * render/html/element/link.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/list.rs
+++ b/ftml/src/render/html/element/list.rs
@@ -2,7 +2,7 @@
  * render/html/element/list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/math.rs
+++ b/ftml/src/render/html/element/math.rs
@@ -2,7 +2,7 @@
  * render/html/element/math.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/mod.rs
+++ b/ftml/src/render/html/element/mod.rs
@@ -2,7 +2,7 @@
  * render/html/element/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/style.rs
+++ b/ftml/src/render/html/element/style.rs
@@ -2,7 +2,7 @@
  * render/html/element/style.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/table.rs
+++ b/ftml/src/render/html/element/table.rs
@@ -2,7 +2,7 @@
  * render/html/element/table.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/tabs.rs
+++ b/ftml/src/render/html/element/tabs.rs
@@ -2,7 +2,7 @@
  * render/html/element/tabs.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/text.rs
+++ b/ftml/src/render/html/element/text.rs
@@ -2,7 +2,7 @@
  * render/html/element/text.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/toc.rs
+++ b/ftml/src/render/html/element/toc.rs
@@ -2,7 +2,7 @@
  * render/html/element/toc.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/element/user.rs
+++ b/ftml/src/render/html/element/user.rs
@@ -2,7 +2,7 @@
  * render/html/element/user.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/escape.rs
+++ b/ftml/src/render/html/escape.rs
@@ -2,7 +2,7 @@
  * render/html/escape.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/meta.rs
+++ b/ftml/src/render/html/meta.rs
@@ -2,7 +2,7 @@
  * render/html/meta.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/mod.rs
+++ b/ftml/src/render/html/mod.rs
@@ -2,7 +2,7 @@
  * render/html/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/output.rs
+++ b/ftml/src/render/html/output.rs
@@ -2,7 +2,7 @@
  * render/html/output.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/random.rs
+++ b/ftml/src/render/html/random.rs
@@ -2,7 +2,7 @@
  * render/html/random.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/render.rs
+++ b/ftml/src/render/html/render.rs
@@ -2,7 +2,7 @@
  * render/html/render.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/html/test.rs
+++ b/ftml/src/render/html/test.rs
@@ -2,7 +2,7 @@
  * render/html/test.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/mod.rs
+++ b/ftml/src/render/mod.rs
@@ -2,7 +2,7 @@
  * render/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/null.rs
+++ b/ftml/src/render/null.rs
@@ -2,7 +2,7 @@
  * render/null.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/text/context.rs
+++ b/ftml/src/render/text/context.rs
@@ -2,7 +2,7 @@
  * render/text/context.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/text/elements.rs
+++ b/ftml/src/render/text/elements.rs
@@ -2,7 +2,7 @@
  * render/text/elements.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/render/text/mod.rs
+++ b/ftml/src/render/text/mod.rs
@@ -2,7 +2,7 @@
  * render/text/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/settings/interwiki.rs
+++ b/ftml/src/settings/interwiki.rs
@@ -2,7 +2,7 @@
  * settings/interwiki.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/settings/mod.rs
+++ b/ftml/src/settings/mod.rs
@@ -2,7 +2,7 @@
  * settings/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -2,7 +2,7 @@
  * test/ast.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/id_prefix.rs
+++ b/ftml/src/test/id_prefix.rs
@@ -2,7 +2,7 @@
  * test/id_prefix.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/includer.rs
+++ b/ftml/src/test/includer.rs
@@ -2,7 +2,7 @@
  * test/includer.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/large.rs
+++ b/ftml/src/test/large.rs
@@ -2,7 +2,7 @@
  * test/large.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/mod.rs
+++ b/ftml/src/test/mod.rs
@@ -2,7 +2,7 @@
  * test/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -2,7 +2,7 @@
  * test/prop.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/test/settings.rs
+++ b/ftml/src/test/settings.rs
@@ -2,7 +2,7 @@
  * test/settings.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/text.rs
+++ b/ftml/src/text.rs
@@ -2,7 +2,7 @@
  * text.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tokenizer.rs
+++ b/ftml/src/tokenizer.rs
@@ -2,7 +2,7 @@
  * tokenizer.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/align.rs
+++ b/ftml/src/tree/align.rs
@@ -2,7 +2,7 @@
  * tree/align.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/anchor.rs
+++ b/ftml/src/tree/anchor.rs
@@ -2,7 +2,7 @@
  * tree/anchor.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/attribute/mod.rs
+++ b/ftml/src/tree/attribute/mod.rs
@@ -2,7 +2,7 @@
  * tree/attribute/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -2,7 +2,7 @@
  * tree/attribute/safe.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/bibliography.rs
+++ b/ftml/src/tree/bibliography.rs
@@ -2,7 +2,7 @@
  * bibliography.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/clear_float.rs
+++ b/ftml/src/tree/clear_float.rs
@@ -2,7 +2,7 @@
  * tree/clear_float.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/clone.rs
+++ b/ftml/src/tree/clone.rs
@@ -2,7 +2,7 @@
  * tree/clone.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/container.rs
+++ b/ftml/src/tree/container.rs
@@ -2,7 +2,7 @@
  * tree/container.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/date.rs
+++ b/ftml/src/tree/date.rs
@@ -2,7 +2,7 @@
  * tree/date.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/definition_list.rs
+++ b/ftml/src/tree/definition_list.rs
@@ -2,7 +2,7 @@
  * tree/definition_list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/element/collection.rs
+++ b/ftml/src/tree/element/collection.rs
@@ -2,7 +2,7 @@
  * tree/element/collection.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/element/iter_owned.rs
+++ b/ftml/src/tree/element/iter_owned.rs
@@ -2,7 +2,7 @@
  * tree/element/iter_owned.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/element/iter_ref.rs
+++ b/ftml/src/tree/element/iter_ref.rs
@@ -2,7 +2,7 @@
  * tree/element/iter_ref.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/element/mod.rs
+++ b/ftml/src/tree/element/mod.rs
@@ -2,7 +2,7 @@
  * tree/element/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/element/object.rs
+++ b/ftml/src/tree/element/object.rs
@@ -2,7 +2,7 @@
  * tree/element/object.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/embed.rs
+++ b/ftml/src/tree/embed.rs
@@ -2,7 +2,7 @@
  * tree/embed.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/heading.rs
+++ b/ftml/src/tree/heading.rs
@@ -2,7 +2,7 @@
  * tree/heading.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/image.rs
+++ b/ftml/src/tree/image.rs
@@ -2,7 +2,7 @@
  * tree/image.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/link.rs
+++ b/ftml/src/tree/link.rs
@@ -2,7 +2,7 @@
  * tree/link.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/list.rs
+++ b/ftml/src/tree/list.rs
@@ -2,7 +2,7 @@
  * tree/list.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/mod.rs
+++ b/ftml/src/tree/mod.rs
@@ -2,7 +2,7 @@
  * tree/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/module.rs
+++ b/ftml/src/tree/module.rs
@@ -2,7 +2,7 @@
  * tree/module.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/partial.rs
+++ b/ftml/src/tree/partial.rs
@@ -2,7 +2,7 @@
  * tree/partial.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/ruby.rs
+++ b/ftml/src/tree/ruby.rs
@@ -2,7 +2,7 @@
  * tree/ruby.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/tab.rs
+++ b/ftml/src/tree/tab.rs
@@ -2,7 +2,7 @@
  * tree/tab.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/table.rs
+++ b/ftml/src/tree/table.rs
@@ -2,7 +2,7 @@
  * tree/table.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/tag.rs
+++ b/ftml/src/tree/tag.rs
@@ -2,7 +2,7 @@
  * tree/tag.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/tree/variables.rs
+++ b/ftml/src/tree/variables.rs
@@ -2,7 +2,7 @@
  * tree/variables.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/url.rs
+++ b/ftml/src/url.rs
@@ -2,7 +2,7 @@
  * url.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/utf16.rs
+++ b/ftml/src/utf16.rs
@@ -2,7 +2,7 @@
  * utf16.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/error.rs
+++ b/ftml/src/wasm/error.rs
@@ -2,7 +2,7 @@
  * wasm/error.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/macros.rs
+++ b/ftml/src/wasm/macros.rs
@@ -2,7 +2,7 @@
  * wasm/macros.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/misc.rs
+++ b/ftml/src/wasm/misc.rs
@@ -2,7 +2,7 @@
  * wasm/misc.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/mod.rs
+++ b/ftml/src/wasm/mod.rs
@@ -2,7 +2,7 @@
  * wasm/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/page_info.rs
+++ b/ftml/src/wasm/page_info.rs
@@ -2,7 +2,7 @@
  * wasm/page_info.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/parsing.rs
+++ b/ftml/src/wasm/parsing.rs
@@ -2,7 +2,7 @@
  * wasm/parsing.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/preproc.rs
+++ b/ftml/src/wasm/preproc.rs
@@ -2,7 +2,7 @@
  * wasm/preproc.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/render/html.rs
+++ b/ftml/src/wasm/render/html.rs
@@ -2,7 +2,7 @@
  * wasm/render/html.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/render/mod.rs
+++ b/ftml/src/wasm/render/mod.rs
@@ -2,7 +2,7 @@
  * wasm/render/mod.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/settings.rs
+++ b/ftml/src/wasm/settings.rs
@@ -2,7 +2,7 @@
  * wasm/settings.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/tokenizer.rs
+++ b/ftml/src/wasm/tokenizer.rs
@@ -2,7 +2,7 @@
  * wasm/tokenizer.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/ftml/src/wasm/utf16.rs
+++ b/ftml/src/wasm/utf16.rs
@@ -2,7 +2,7 @@
  * wasm/utf16.rs
  *
  * ftml - Library to parse Wikidot text
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/locales/validator/misc/header.txt
+++ b/locales/validator/misc/header.txt
@@ -2,7 +2,7 @@
  * (FILENAME)
  *
  * wikijump-locales-validator - Validate Wikijump's Fluent localization files
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/locales/validator/src/check.rs
+++ b/locales/validator/src/check.rs
@@ -2,7 +2,7 @@
  * check.rs
  *
  * wikijump-locales-validator - Validate Wikijump's Fluent localization files
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/locales/validator/src/main.rs
+++ b/locales/validator/src/main.rs
@@ -2,7 +2,7 @@
  * main.rs
  *
  * wikijump-locales-validator - Validate Wikijump's Fluent localization files
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/locales/validator/src/messages.rs
+++ b/locales/validator/src/messages.rs
@@ -2,7 +2,7 @@
  * messages.rs
  *
  * wikijump-locales-validator - Validate Wikijump's Fluent localization files
- * Copyright (C) 2019-2022 Wikijump Team
+ * Copyright (C) 2019-2023 Wikijump Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
Replace the instances of year 2022 with 2023 as appropriate.