### PR TITLE
Update wasm dependencies

### DIFF
--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "regex",
  "self_cell",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_repr",
  "str-macro",
@@ -1393,6 +1394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/ftml/Cargo.lock
+++ b/ftml/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -89,25 +89,26 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -216,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -226,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -250,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -296,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -308,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -323,15 +324,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -406,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "entities"
@@ -437,10 +438,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.8.0"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -565,15 +587,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -622,6 +644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,24 +664,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -668,9 +700,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
@@ -704,12 +736,18 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -738,9 +776,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -750,9 +788,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -779,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -789,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "outref"
@@ -852,15 +890,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1015,15 +1053,15 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1083,9 +1121,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1182,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -1192,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1235,28 +1273,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -1268,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1287,10 +1316,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
+name = "rustix"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -1306,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scopeguard"
@@ -1318,9 +1361,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "seahash"
@@ -1336,9 +1379,9 @@ checksum = "1ef965a420fe14fdac7dd018862966a4c14094f900e1650bbc71ddd7d580c8af"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -1406,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1455,16 +1504,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1478,18 +1526,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1518,15 +1566,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -1566,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -1655,9 +1703,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1667,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1682,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1692,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1705,15 +1753,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1779,43 +1827,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -44,6 +44,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
+serde-wasm-bindgen = "0.5"
 str-macro = "1"
 strum = "0.24"
 strum_macros = "0.24"

--- a/ftml/src/wasm/macros.rs
+++ b/ftml/src/wasm/macros.rs
@@ -18,11 +18,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+macro_rules! js_to_rust {
+    ($js:expr) => {{
+        use crate::wasm::error::error_to_js;
+        serde_wasm_bindgen::from_value($js).map_err(error_to_js)
+    }};
+}
+
 macro_rules! rust_to_js {
     ($object:expr) => {{
         use crate::wasm::error::error_to_js;
-
-        let js = JsValue::from_serde(&$object).map_err(error_to_js)?;
-        Ok(js.unchecked_into())
+        serde_wasm_bindgen::to_value(&$object).map_err(error_to_js)
     }};
 }

--- a/ftml/src/wasm/page_info.rs
+++ b/ftml/src/wasm/page_info.rs
@@ -44,10 +44,10 @@ export interface IPageInfo {
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "IPageInfo")]
+    #[wasm_bindgen]
     pub type IPageInfo;
 
-    #[wasm_bindgen(typescript_type = "string[]")]
+    #[wasm_bindgen]
     pub type ITags;
 }
 
@@ -73,7 +73,7 @@ impl PageInfo {
         }
     }
 
-    #[wasm_bindgen(constructor, typescript_type = "IPageInfo")]
+    #[wasm_bindgen(constructor)]
     pub fn new(object: IPageInfo) -> Result<PageInfo, JsValue> {
         let rust_page_info = object.into_serde().map_err(error_to_js)?;
 
@@ -84,42 +84,42 @@ impl PageInfo {
 
     // Getters
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn page(&self) -> String {
         self.inner.page.to_string()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn category(&self) -> Option<String> {
         self.inner.category.ref_map(ToString::to_string)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn site(&self) -> String {
         self.inner.site.to_string()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn title(&self) -> String {
         self.inner.title.to_string()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn alt_title(&self) -> Option<String> {
         self.inner.alt_title.ref_map(ToString::to_string)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn score(&self) -> f64 {
         self.inner.score.to_f64()
     }
 
-    #[wasm_bindgen(method, getter, typescript_type = "ITags")]
+    #[wasm_bindgen(getter)]
     pub fn tags(&self) -> Result<ITags, JsValue> {
         rust_to_js!(self.inner.tags)
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn language(&self) -> String {
         self.inner.language.to_string()
     }

--- a/ftml/src/wasm/page_info.rs
+++ b/ftml/src/wasm/page_info.rs
@@ -18,40 +18,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::error::error_to_js;
 use super::prelude::*;
 use crate::data::PageInfo as RustPageInfo;
 use ref_map::*;
 use std::sync::Arc;
-
-// Typescript declarations
-
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &str = r#"
-
-export interface IPageInfo {
-    page: string;
-    category: string | null;
-    site: string;
-    title: string;
-    alt_title: string | null;
-    score: number;
-    tags: string[];
-    language: string;
-}
-
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub type IPageInfo;
-
-    #[wasm_bindgen]
-    pub type ITags;
-}
-
-// Wrapper structure
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -74,11 +44,9 @@ impl PageInfo {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(object: IPageInfo) -> Result<PageInfo, JsValue> {
-        let rust_page_info = object.into_serde().map_err(error_to_js)?;
-
+    pub fn new(info: JsValue) -> Result<PageInfo, JsValue> {
         Ok(PageInfo {
-            inner: Arc::new(rust_page_info),
+            inner: Arc::new(js_to_rust!(info)?),
         })
     }
 
@@ -115,7 +83,7 @@ impl PageInfo {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn tags(&self) -> Result<ITags, JsValue> {
+    pub fn tags(&self) -> Result<JsValue, JsValue> {
         rust_to_js!(self.inner.tags)
     }
 

--- a/ftml/src/wasm/parsing.rs
+++ b/ftml/src/wasm/parsing.rs
@@ -28,45 +28,6 @@ use crate::utf16::Utf16IndexMap;
 use crate::Tokenization as RustTokenization;
 use std::sync::Arc;
 
-// Typescript declarations
-
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &str = r#"
-
-export interface IElement {
-    element: string;
-    data?: any;
-}
-
-export interface ISyntaxTree {
-    elements: IElement[];
-    table_of_contents: IElement[];
-    footnotes: IElement[][];
-}
-
-export interface IParseError {
-    token: string;
-    rule: string;
-    span: {
-        start: number;
-        end: number;
-    };
-    kind: string;
-}
-
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub type ISyntaxTree;
-
-    #[wasm_bindgen]
-    pub type IParseErrorArray;
-}
-
-// Wrapper structures
-
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct ParseOutcome {
@@ -92,7 +53,7 @@ impl ParseOutcome {
     }
 
     #[wasm_bindgen]
-    pub fn errors(&self) -> Result<IParseErrorArray, JsValue> {
+    pub fn errors(&self) -> Result<JsValue, JsValue> {
         rust_to_js!(self.inner.errors())
     }
 }
@@ -118,7 +79,7 @@ impl SyntaxTree {
     }
 
     #[wasm_bindgen]
-    pub fn data(&self) -> Result<ISyntaxTree, JsValue> {
+    pub fn data(&self) -> Result<JsValue, JsValue> {
         rust_to_js!(*self.inner)
     }
 }

--- a/ftml/src/wasm/parsing.rs
+++ b/ftml/src/wasm/parsing.rs
@@ -58,10 +58,10 @@ export interface IParseError {
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "ISyntaxTree")]
+    #[wasm_bindgen]
     pub type ISyntaxTree;
 
-    #[wasm_bindgen(typescript_type = "IParseError[]")]
+    #[wasm_bindgen]
     pub type IParseErrorArray;
 }
 
@@ -91,7 +91,7 @@ impl ParseOutcome {
         }
     }
 
-    #[wasm_bindgen(typescript_type = "IParseError")]
+    #[wasm_bindgen]
     pub fn errors(&self) -> Result<IParseErrorArray, JsValue> {
         rust_to_js!(self.inner.errors())
     }
@@ -117,7 +117,7 @@ impl SyntaxTree {
         }
     }
 
-    #[wasm_bindgen(typescript_type = "ISyntaxTree")]
+    #[wasm_bindgen]
     pub fn data(&self) -> Result<ISyntaxTree, JsValue> {
         rust_to_js!(*self.inner)
     }

--- a/ftml/src/wasm/render/html.rs
+++ b/ftml/src/wasm/render/html.rs
@@ -31,45 +31,6 @@ use crate::render::html::{HtmlOutput as RustHtmlOutput, HtmlRender};
 use crate::render::Render;
 use std::sync::Arc;
 
-// Typescript declarations
-
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &str = r#"
-
-export interface IHtmlOutput {
-    body: string;
-    style: string;
-    meta: IHtmlMeta[];
-}
-
-export interface IHtmlMeta {
-    tag_type: string;
-    name: string;
-    value: string;
-}
-
-export interface IBacklinks {
-    included_pages: string[];
-    internal_links: string[];
-    external_links: string[];
-}
-
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub type IStyleArray;
-
-    #[wasm_bindgen]
-    pub type IHtmlMetaArray;
-
-    #[wasm_bindgen]
-    pub type IBacklinks;
-}
-
-// Wrapper structures
-
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct HtmlOutput {
@@ -91,12 +52,12 @@ impl HtmlOutput {
     }
 
     #[wasm_bindgen]
-    pub fn html_meta(&self) -> Result<IHtmlMetaArray, JsValue> {
+    pub fn html_meta(&self) -> Result<JsValue, JsValue> {
         rust_to_js!(self.inner.meta)
     }
 
     #[wasm_bindgen]
-    pub fn backlinks(&self) -> Result<IBacklinks, JsValue> {
+    pub fn backlinks(&self) -> Result<JsValue, JsValue> {
         rust_to_js!(self.inner.backlinks)
     }
 }

--- a/ftml/src/wasm/render/html.rs
+++ b/ftml/src/wasm/render/html.rs
@@ -58,13 +58,13 @@ export interface IBacklinks {
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "string[]")]
+    #[wasm_bindgen]
     pub type IStyleArray;
 
-    #[wasm_bindgen(typescript_type = "IHtmlMeta[]")]
+    #[wasm_bindgen]
     pub type IHtmlMetaArray;
 
-    #[wasm_bindgen(typescript_type = "IBacklinks")]
+    #[wasm_bindgen]
     pub type IBacklinks;
 }
 
@@ -90,12 +90,12 @@ impl HtmlOutput {
         self.inner.body.clone()
     }
 
-    #[wasm_bindgen(typescript_type = "IHtmlMetaArray")]
+    #[wasm_bindgen]
     pub fn html_meta(&self) -> Result<IHtmlMetaArray, JsValue> {
         rust_to_js!(self.inner.meta)
     }
 
-    #[wasm_bindgen(typescript_type = "IBacklinks")]
+    #[wasm_bindgen]
     pub fn backlinks(&self) -> Result<IBacklinks, JsValue> {
         rust_to_js!(self.inner.backlinks)
     }

--- a/ftml/src/wasm/settings.rs
+++ b/ftml/src/wasm/settings.rs
@@ -48,7 +48,7 @@ export type WikitextMode =
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "IWikitextSettings")]
+    #[wasm_bindgen]
     pub type IWikitextSettings;
 }
 
@@ -74,7 +74,7 @@ impl WikitextSettings {
         }
     }
 
-    #[wasm_bindgen(constructor, typescript_type = "IWikitextSettings")]
+    #[wasm_bindgen(constructor)]
     pub fn new(object: IWikitextSettings) -> Result<WikitextSettings, JsValue> {
         let rust_wikitext_settings = object.into_serde().map_err(error_to_js)?;
 

--- a/ftml/src/wasm/settings.rs
+++ b/ftml/src/wasm/settings.rs
@@ -18,41 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use super::error::error_to_js;
 use super::prelude::*;
 use crate::settings::{
     WikitextMode as RustWikitextMode, WikitextSettings as RustWikitextSettings,
 };
 use std::sync::Arc;
-
-// Typescript declarations
-
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &str = r#"
-
-export interface IWikitextSettings {
-    mode: WikitextMode;
-    enable_page_syntax: boolean;
-    use_true_ids: boolean;
-    allow_local_paths: boolean;
-}
-
-export type WikitextMode =
-    | 'page'
-    | 'draft'
-    | 'forum-post'
-    | 'direct-message'
-    | 'list'
-
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub type IWikitextSettings;
-}
-
-// Wrapper structure
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -75,11 +45,9 @@ impl WikitextSettings {
     }
 
     #[wasm_bindgen(constructor)]
-    pub fn new(object: IWikitextSettings) -> Result<WikitextSettings, JsValue> {
-        let rust_wikitext_settings = object.into_serde().map_err(error_to_js)?;
-
+    pub fn new(settings: JsValue) -> Result<WikitextSettings, JsValue> {
         Ok(WikitextSettings {
-            inner: Arc::new(rust_wikitext_settings),
+            inner: Arc::new(js_to_rust!(settings)?),
         })
     }
 

--- a/ftml/src/wasm/tokenizer.rs
+++ b/ftml/src/wasm/tokenizer.rs
@@ -25,30 +25,6 @@ use crate::Tokenization as RustTokenization;
 use self_cell::self_cell;
 use std::sync::Arc;
 
-// Typescript declarations
-
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &str = r#"
-
-export interface IToken {
-    token: string;
-    slice: string;
-    span: {
-        start: number;
-        end: number;
-    };
-}
-
-"#;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub type ITokenArray;
-}
-
-// Wrapper structures
-
 self_cell!(
     struct TokenizationInner {
         owner: String,
@@ -86,7 +62,7 @@ impl Tokenization {
     }
 
     #[wasm_bindgen]
-    pub fn tokens(&self) -> Result<ITokenArray, JsValue> {
+    pub fn tokens(&self) -> Result<JsValue, JsValue> {
         self.inner
             .with_dependent(|_, inner| rust_to_js!(convert_tokens_utf16(inner)))
     }

--- a/ftml/src/wasm/tokenizer.rs
+++ b/ftml/src/wasm/tokenizer.rs
@@ -43,7 +43,7 @@ export interface IToken {
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(typescript_type = "IToken[]")]
+    #[wasm_bindgen]
     pub type ITokenArray;
 }
 
@@ -85,7 +85,7 @@ impl Tokenization {
         self.inner.borrow_owner().clone()
     }
 
-    #[wasm_bindgen(typescript_type = "ITokenArray")]
+    #[wasm_bindgen]
     pub fn tokens(&self) -> Result<ITokenArray, JsValue> {
         self.inner
             .with_dependent(|_, inner| rust_to_js!(convert_tokens_utf16(inner)))


### PR DESCRIPTION
After putting it off for a while, I've finally upgraded the wasm packages. This was annoying since they changed a fair bit of the internals, including changing how Typescript support works. We'll have to make sure this still works with our existing client code.

<details>
<summary>Generated ftml.d.ts file</summary>

It seems we don't need explicit type annotations, since they are now generated for us:

```typescript
/* tslint:disable */
/* eslint-disable */
/**
* @param {string} text
* @returns {Tokenization}
*/
export function tokenize(text: string): Tokenization;
/**
* @param {string} text
* @returns {string}
*/
export function preprocess(text: string): string;
/**
* @returns {string}
*/
export function version(): string;
/**
* @param {SyntaxTree} syntax_tree
* @param {PageInfo} page_info
* @param {WikitextSettings} settings
* @returns {string}
*/
export function render_text(syntax_tree: SyntaxTree, page_info: PageInfo, settings: WikitextSettings): string;
/**
* @param {Tokenization} tokens
* @param {PageInfo} page_info
* @param {WikitextSettings} settings
* @returns {ParseOutcome}
*/
export function parse(tokens: Tokenization, page_info: PageInfo, settings: WikitextSettings): ParseOutcome;
/**
* @param {SyntaxTree} syntax_tree
* @param {PageInfo} page_info
* @param {WikitextSettings} settings
* @returns {HtmlOutput}
*/
export function render_html(syntax_tree: SyntaxTree, page_info: PageInfo, settings: WikitextSettings): HtmlOutput;
/**
*/
export class HtmlOutput {
  free(): void;
/**
* @returns {HtmlOutput}
*/
  copy(): HtmlOutput;
/**
* @returns {string}
*/
  body(): string;
/**
* @returns {any}
*/
  html_meta(): any;
/**
* @returns {any}
*/
  backlinks(): any;
}
/**
*/
export class PageInfo {
  free(): void;
/**
* @returns {PageInfo}
*/
  copy(): PageInfo;
/**
* @param {any} info
*/
  constructor(info: any);
/**
*/
  readonly alt_title: string | undefined;
/**
*/
  readonly category: string | undefined;
/**
*/
  readonly language: string;
/**
*/
  readonly page: string;
/**
*/
  readonly score: number;
/**
*/
  readonly site: string;
/**
*/
  readonly tags: any;
/**
*/
  readonly title: string;
}
/**
*/
export class ParseOutcome {
  free(): void;
/**
* @returns {ParseOutcome}
*/
  copy(): ParseOutcome;
/**
* @returns {SyntaxTree}
*/
  syntax_tree(): SyntaxTree;
/**
* @returns {any}
*/
  errors(): any;
}
/**
*/
export class SyntaxTree {
  free(): void;
/**
* @returns {SyntaxTree}
*/
  copy(): SyntaxTree;
/**
* @returns {any}
*/
  data(): any;
}
/**
*/
export class Tokenization {
  free(): void;
/**
* @returns {Tokenization}
*/
  copy(): Tokenization;
/**
* @returns {string}
*/
  text(): string;
/**
* @returns {any}
*/
  tokens(): any;
}
/**
*/
export class Utf16IndexMap {
  free(): void;
/**
* @param {string} text
*/
  constructor(text: string);
/**
* @returns {Utf16IndexMap}
*/
  copy(): Utf16IndexMap;
/**
* @param {number} index
* @returns {number}
*/
  get_index(index: number): number;
}
/**
*/
export class WikitextSettings {
  free(): void;
/**
* @returns {WikitextSettings}
*/
  copy(): WikitextSettings;
/**
* @param {any} settings
*/
  constructor(settings: any);
/**
* @param {string} mode
* @returns {WikitextSettings}
*/
  static from_mode(mode: string): WikitextSettings;
}
```

</details>

Supersedes #1358, #1356