### PR TITLE
Update contributor names / mapping

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+# See https://git-scm.com/docs/gitmailmap
+
+Emmie Maeda <emmie.maeda@gmail.com> <ammon.i.smith@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,7 @@
 # See https://git-scm.com/docs/gitmailmap
 
 Emmie Maeda <emmie.maeda@gmail.com> <ammon.i.smith@gmail.com>
+
+Daniel Tharp <github@nags.me> pxdnbluesoul <github@nags.me>
+Daniel Tharp <github@nags.me> bluesoul <github@nags.me>
+Daniel Tharp <github@nags.me> bluesoul <atlassian@nags.me>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ or reaching out to a member individually:
 
 | GitHub                                         | Wikidot                                                                | Discord           | Email                     |
 |------------------------------------------------|------------------------------------------------------------------------|-------------------|---------------------------|
-| [@emmiegit](https://github.com/emmiegit)       | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | ammon.i.smith@gmail.com   |
+| [@emmiegit](https://github.com/emmiegit)       | [aismallard](https://www.wikidot.com/account/messages#/new/4598089)    | `aismallard#0002` | emmie.maeda@gmail.com   |
 | [@stormbreath](https://github.com/stormbreath) | [stormbreath](https://www.wikidot.com/account/messages#/new/3075960)   |                   |                           |
 | [@rossjrw](https://github.com/rossjrw)         | [Croquembouche](https://www.wikidot.com/account/messages#/new/2893766) |                   | ross@rossjrw.com          |
 | [@danieltharp](https://github.com/danieltharp) | [pxdnbluesoul](https://www.wikidot.com/account/messages#/new/1414125)  |                   | daniel.tharp@gmail.com    |

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
 version = "2022.12.11"
-authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
+authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 
 [dependencies]

--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["parser-implementations"]
 exclude = [".gitignore", ".editorconfig"]
 
 version = "1.21.0"
-authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
+authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 
 [lib]

--- a/locales/validator/Cargo.toml
+++ b/locales/validator/Cargo.toml
@@ -9,7 +9,7 @@ categories = []
 exclude = [".gitignore"]
 
 version = "0.1.0"
-authors = ["Ammon Smith <ammon.i.smith@gmail.com>"]
+authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 rust-version = "1.56.0"
 


### PR DESCRIPTION
This adds a [`.mailmap` file](https://git-scm.com/docs/gitmailmap) which is useful for mapping the various listed names/emails of contributors. (Particularly that of bluesoul, who has a couple name/email combinations.) I also update my name listed in the `Cargo.toml` files and `SECURITY.md`.