### PR TITLE
[WJ-1136] Add "unknown user"

### DIFF
--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -10,6 +10,7 @@
         "real_name": "Administrator",
         "gender": null,
         "birthday": null,
+        "location": null,
         "biography": "Root platform administrator for this Wikijump instance",
         "user_page": null,
         "aliases": [
@@ -30,6 +31,7 @@
         "real_name": "Wikijump",
         "gender": null,
         "birthday": "2019-01-18",
+        "location": "Here",
         "biography": "Wikijump system user",
         "user_page": "https://wikijump.org/",
         "aliases": [
@@ -50,6 +52,7 @@
         "real_name": "Anonymous User",
         "gender": null,
         "birthday": null,
+        "location": "Everywhere and nowhere",
         "biography": "Wikijump anonymous user",
         "user_page": null,
         "aliases": [
@@ -71,6 +74,7 @@
         "real_name": "Unknown User",
         "gender": null,
         "birthday": null,
+        "location": "Unknown",
         "biography": "Wikijump unknown user",
         "user_page": null,
         "aliases": [

--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -91,7 +91,7 @@
         "gender": null,
         "birthday": null,
         "biography": "Example user for documentation purposes",
-        "user_page": null,
+        "user_page": "https://example.com/",
         "aliases": [
             "example",
             "example-user",

--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -56,11 +56,31 @@
             "anon",
             "nobody",
             "null",
+            "void",
             "undefined"
         ]
     },
     {
         "id": 4,
+        "type": "system",
+        "name": "Unknown",
+        "slug": "unknown",
+        "email": "unknown@wikijump",
+        "password": null,
+        "locale": "en",
+        "real_name": "Unknown User",
+        "gender": null,
+        "birthday": null,
+        "biography": "Wikijump unknown user",
+        "user_page": null,
+        "aliases": [
+            "unknown-user",
+            "unknown-author",
+            "mystery"
+        ]
+    },
+    {
+        "id": 5,
         "type": "system",
         "name": "User",
         "slug": "user",
@@ -74,7 +94,11 @@
         "user_page": null,
         "aliases": [
             "example",
-            "sample"
+            "example-user",
+            "sample",
+            "sample-user",
+            "demo",
+            "demo-user"
         ]
     }
 ]

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -95,6 +95,7 @@ pub struct User {
     pub real_name: Option<String>,
     pub gender: Option<String>,
     pub birthday: Option<NaiveDate>,
+    pub location: Option<String>,
     pub biography: Option<String>,
     pub user_page: Option<String>,
     pub aliases: Vec<String>,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -93,6 +93,7 @@ pub async fn seed(state: &ApiServerState) -> Result<()> {
                 real_name: ProvidedValue::Set(user.real_name),
                 gender: ProvidedValue::Set(user.gender),
                 birthday: ProvidedValue::Set(user.birthday),
+                location: ProvidedValue::Set(user.location),
                 biography: ProvidedValue::Set(user.biography),
                 user_page: ProvidedValue::Set(user.user_page),
                 ..Default::default()

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -284,6 +284,10 @@ impl UserService {
             model.birthday = Set(birthday);
         }
 
+        if let ProvidedValue::Set(location) = input.location {
+            model.location = Set(location);
+        }
+
         if let ProvidedValue::Set(biography) = input.biography {
             model.biography = Set(biography);
         }


### PR DESCRIPTION
Instead of using "anonymous" for this purpose, per [WJ-1136](https://scuttle.atlassian.net/browse/WJ-1136) this adds an "unknown user" sentinel which specifically represents users whose true identity are not known or represented, rather than being intentionally concealed.

Thankfully because of our new seeder infrastructure, making this change was very simple.

I also noticed that the `location` field had been inadvertantly excluded. I have added it, along with starter seed values, and the relevant code changes to also insert that data.

[WJ-1136]: https://scuttle.atlassian.net/browse/WJ-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ