### PR TITLE
[WJ-1149] Change text hash to use KangarooTwelve

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1091,6 +1091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1312,7 @@ dependencies = [
  "subtle",
  "thiserror",
  "tide",
+ "tiny-keccak",
  "toml 0.7.3",
  "typenum",
  "unic-langid",
@@ -4214,6 +4221,15 @@ dependencies = [
  "quote",
  "standback",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -50,6 +50,7 @@ strum_macros = "0.24"
 subtle = "2.4"
 thiserror = "1"
 tide = "0.16"
+tiny-keccak = { version = "2", features = ["k12"] }
 toml = { version = "0.7", features = ["parse"] }
 typenum = "1"
 unic-langid = "0.9"

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -174,13 +174,17 @@ CREATE TYPE page_revision_change AS ENUM (
     'tags'
 );
 
--- No unique constraint because that creates a separate index,
--- which will impact performance. Instead we add a CHECK constraint.
+-- No unique constraint for 'contents' because that would create
+-- create a separate index, which will impact performance.
+--
+-- If the KangarooTwelve hash algorithm was available in pgcrypto
+-- we'd check directly (hash = digest(contents, 'kangarootwelve')),
+-- but since we can't we'll just verify the hash length.
 CREATE TABLE text (
     hash BYTEA PRIMARY KEY,
     contents TEXT COMPRESSION pglz NOT NULL,
 
-    CHECK (hash = digest(contents, 'sha512'))
+    CHECK (length(hash) = 16)  -- KangarooTwelve hash size, 128 bits
 );
 
 -- Main revision table

--- a/deepwell/src/hash/blob.rs
+++ b/deepwell/src/hash/blob.rs
@@ -1,0 +1,66 @@
+/*
+ * hash/blo.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2023 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use arraystring::ArrayString;
+use sha2::{Digest, Sha512};
+use typenum::U128;
+
+/// The expected length of a blob hash digest.
+///
+/// This is the output length for SHA-512 in bytes.
+pub const BLOB_HASH_LENGTH: usize = 64;
+
+/// The array type for a blob hash digest.
+pub type BlobHash = [u8; 64];
+
+/// The stack string type for a hex representation of a blob hash.
+///
+/// Because it is hexadecimal, it must be double the size of the
+/// actual byte buffer it represents.
+pub type BlobHexHash = ArrayString<U128>;
+
+/// Produces a byte array containing the SHA-512 hash for the given data.
+pub fn sha512_hash(data: &[u8]) -> BlobHash {
+    // Perform hash
+    let mut hasher = Sha512::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+
+    // Copy data into regular Rust array
+    let mut bytes = [0; 64];
+    bytes.copy_from_slice(&result);
+    bytes
+}
+
+/// Converts the given SHA-512 hash into a hex array string.
+pub fn blob_hash_to_hex(hash: &[u8]) -> BlobHexHash {
+    debug_assert_eq!(
+        hash.len(),
+        BLOB_HASH_LENGTH,
+        "SHA-512 hash buffer of incorrect length",
+    );
+
+    let mut hex_bytes = [0; 128];
+
+    hex::encode_to_slice(hash, &mut hex_bytes)
+        .expect("Encoding hash to hex slice failed");
+
+    ArrayString::from_utf8(hex_bytes).expect("Encoded hash was not UTF-8")
+}

--- a/deepwell/src/hash/mod.rs
+++ b/deepwell/src/hash/mod.rs
@@ -1,0 +1,25 @@
+/*
+ * hash/mod.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2023 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+mod blob;
+mod text;
+
+pub use self::blob::*;
+pub use self::text::*;

--- a/deepwell/src/hash/text.rs
+++ b/deepwell/src/hash/text.rs
@@ -1,5 +1,5 @@
 /*
- * hash.rs
+ * hash/text.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2023 Wikijump Team
@@ -19,45 +19,41 @@
  */
 
 use arraystring::ArrayString;
-use sha2::{Digest, Sha512};
-use typenum::U128;
+use tiny_keccak::{Hasher, KangarooTwelve};
+use typenum::U32;
 
-/// The expected length of a hash digest.
+/// The expected length of a text hash digest.
 ///
-/// This is the output length for SHA-512 in bytes.
-pub const HASH_LENGTH: usize = 64;
+/// This is the standard output length for KangarooTwelve in bytes.
+pub const TEXT_HASH_LENGTH: usize = 16;
 
-/// The array type for a hash digest.
-pub type Hash = [u8; 64];
+/// The array type for a text hash digest;
+pub type TextHash = [u8; 16];
 
-/// The stack string type for a hex representation of a hash.
+/// The stack string type for a hex representation of a text hash.
 ///
 /// Because it is hexadecimal, it must be double the size of the
 /// actual byte buffer it represents.
-pub type HexHash = ArrayString<U128>;
+pub type TextHexHash = ArrayString<U32>;
 
-/// Produces a byte array containing the SHA-512 for the given data.
-pub fn sha512_hash(data: &[u8]) -> Hash {
-    // Perform hash
-    let mut hasher = Sha512::new();
+/// Produces a byte array containing the KangaroTwelve hash for the given data.
+pub fn k12_hash(data: &[u8]) -> TextHash {
+    let mut bytes = [0; 16];
+    let mut hasher = KangarooTwelve::new(data);
     hasher.update(data);
-    let result = hasher.finalize();
-
-    // Copy data into regular Rust array
-    let mut bytes = [0; 64];
-    bytes.copy_from_slice(&result);
+    hasher.finalize(&mut bytes);
     bytes
 }
 
 /// Converts the given SHA-512 hash into a hex array string.
-pub fn hash_to_hex(hash: &[u8]) -> HexHash {
+pub fn text_hash_to_hex(hash: &[u8]) -> TextHexHash {
     debug_assert_eq!(
         hash.len(),
-        HASH_LENGTH,
-        "SHA-512 hash buffer of incorrect length",
+        TEXT_HASH_LENGTH,
+        "KangaroTwelve hash buffer of incorrect length",
     );
 
-    let mut hex_bytes = [0; 128];
+    let mut hex_bytes = [0; 32];
 
     hex::encode_to_slice(hash, &mut hex_bytes)
         .expect("Encoding hash to hex slice failed");

--- a/deepwell/src/hash/text.rs
+++ b/deepwell/src/hash/text.rs
@@ -18,9 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use arraystring::ArrayString;
 use tiny_keccak::{Hasher, KangarooTwelve};
-use typenum::U32;
 
 /// The expected length of a text hash digest.
 ///
@@ -30,12 +28,6 @@ pub const TEXT_HASH_LENGTH: usize = 16;
 /// The array type for a text hash digest;
 pub type TextHash = [u8; 16];
 
-/// The stack string type for a hex representation of a text hash.
-///
-/// Because it is hexadecimal, it must be double the size of the
-/// actual byte buffer it represents.
-pub type TextHexHash = ArrayString<U32>;
-
 /// Produces a byte array containing the KangaroTwelve hash for the given data.
 pub fn k12_hash(data: &[u8]) -> TextHash {
     let mut bytes = [0; 16];
@@ -43,20 +35,4 @@ pub fn k12_hash(data: &[u8]) -> TextHash {
     hasher.update(data);
     hasher.finalize(&mut bytes);
     bytes
-}
-
-/// Converts the given SHA-512 hash into a hex array string.
-pub fn text_hash_to_hex(hash: &[u8]) -> TextHexHash {
-    debug_assert_eq!(
-        hash.len(),
-        TEXT_HASH_LENGTH,
-        "KangaroTwelve hash buffer of incorrect length",
-    );
-
-    let mut hex_bytes = [0; 32];
-
-    hex::encode_to_slice(hash, &mut hex_bytes)
-        .expect("Encoding hash to hex slice failed");
-
-    ArrayString::from_utf8(hex_bytes).expect("Encoded hash was not UTF-8")
 }

--- a/deepwell/src/methods/text.rs
+++ b/deepwell/src/methods/text.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::hash::Hash;
+use crate::hash::TextHash;
 
 pub async fn text_put(mut req: ApiRequest) -> ApiResponse {
     let txn = req.database().begin().await?;
@@ -49,11 +49,11 @@ pub async fn text_get(req: ApiRequest) -> ApiResponse {
     Ok(body.into())
 }
 
-fn read_hash(req: &ApiRequest) -> Result<Hash, TideError> {
+fn read_hash(req: &ApiRequest) -> Result<TextHash, TideError> {
     let hash_hex = req.param("hash")?;
     tide::log::debug!("Text hash: {hash_hex}");
 
-    let mut hash = [0; 64];
+    let mut hash = [0; 16];
 
     hex::decode_to_slice(hash_hex, &mut hash)
         .map_err(|error| TideError::new(StatusCode::UnprocessableEntity, error))?;

--- a/deepwell/src/services/blob/mod.rs
+++ b/deepwell/src/services/blob/mod.rs
@@ -28,7 +28,7 @@ mod prelude {
     pub use super::super::prelude::*;
     pub use super::mime_type;
     pub use super::structs::*;
-    pub use crate::hash::{hash_to_hex, sha512_hash, Hash};
+    pub use crate::hash::{blob_hash_to_hex, sha512_hash, BlobHash};
 }
 
 mod mime;

--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -40,7 +40,7 @@ impl BlobService {
 
         let bucket = ctx.s3_bucket();
         let hash = sha512_hash(data);
-        let hex_hash = hash_to_hex(&hash);
+        let hex_hash = blob_hash_to_hex(&hash);
 
         // Convert size to correct integer type
         let size: i64 = data.len().try_into().expect("Buffer size exceeds i64");
@@ -92,7 +92,7 @@ impl BlobService {
         hash: &[u8],
     ) -> Result<Option<Vec<u8>>> {
         let bucket = ctx.s3_bucket();
-        let hex_hash = hash_to_hex(hash);
+        let hex_hash = blob_hash_to_hex(hash);
         let response = bucket.get_object(&hex_hash).await?;
 
         match response.status_code() {
@@ -111,7 +111,7 @@ impl BlobService {
         ctx: &ServiceContext<'_>,
         hash: &[u8],
     ) -> Result<Option<BlobMetadata>> {
-        let hex_hash = hash_to_hex(hash);
+        let hex_hash = blob_hash_to_hex(hash);
 
         match Self::head(ctx, &hex_hash).await? {
             None => Ok(None),
@@ -145,7 +145,7 @@ impl BlobService {
     }
 
     pub async fn exists(ctx: &ServiceContext<'_>, hash: &[u8]) -> Result<bool> {
-        let hex_hash = hash_to_hex(hash);
+        let hex_hash = blob_hash_to_hex(hash);
         let result = Self::head(ctx, &hex_hash).await?;
         Ok(result.is_some())
     }
@@ -185,7 +185,7 @@ impl BlobService {
 
     pub async fn hard_delete(ctx: &ServiceContext<'_>, hash: &[u8]) -> Result<()> {
         let bucket = ctx.s3_bucket();
-        let hex_hash = hash_to_hex(hash);
+        let hex_hash = blob_hash_to_hex(hash);
 
         let response = bucket.delete_object(&hex_hash).await?;
         match response.status_code() {

--- a/deepwell/src/services/blob/structs.rs
+++ b/deepwell/src/services/blob/structs.rs
@@ -23,7 +23,7 @@ use crate::utils::DateTimeWithTimeZone;
 
 #[derive(Debug)]
 pub struct CreateBlobOutput {
-    pub hash: Hash,
+    pub hash: BlobHash,
     pub mime: String,
     pub size: i64,
     pub created: bool,

--- a/deepwell/src/services/file_revision/mod.rs
+++ b/deepwell/src/services/file_revision/mod.rs
@@ -21,7 +21,7 @@
 mod prelude {
     pub use super::super::prelude::*;
     pub use super::structs::*;
-    pub use crate::hash::Hash;
+    pub use crate::hash::BlobHash;
     pub use crate::models::sea_orm_active_enums::FileRevisionType;
 }
 

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -42,7 +42,7 @@ pub struct CreateFileRevisionBody {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct FileBlob {
-    pub s3_hash: Hash,
+    pub s3_hash: BlobHash,
     pub size_hint: i64,
     pub mime_hint: String,
 }
@@ -61,7 +61,7 @@ pub struct CreateFirstFileRevision {
     pub file_id: i64,
     pub user_id: i64,
     pub name: String,
-    pub s3_hash: Hash,
+    pub s3_hash: BlobHash,
     pub size_hint: i64,
     pub mime_hint: String,
     pub licensing: serde_json::Value,

--- a/deepwell/src/services/render/structs.rs
+++ b/deepwell/src/services/render/structs.rs
@@ -19,12 +19,12 @@
  */
 
 use super::prelude::*;
-use crate::hash::Hash;
+use crate::hash::TextHash;
 
 #[derive(Debug)]
 pub struct RenderOutput {
     pub html_output: HtmlOutput,
     pub errors: Vec<ParseError>,
-    pub compiled_hash: Hash,
+    pub compiled_hash: TextHash,
     pub compiled_generator: String,
 }

--- a/deepwell/src/services/text.rs
+++ b/deepwell/src/services/text.rs
@@ -25,7 +25,7 @@
 //! identified by its hash.
 
 use super::prelude::*;
-use crate::hash::{sha512_hash, Hash, HASH_LENGTH};
+use crate::hash::{k12_hash, TextHash, TEXT_HASH_LENGTH};
 use crate::models::text::{self, Entity as Text};
 
 #[derive(Debug)]
@@ -36,7 +36,7 @@ impl TextService {
         ctx: &ServiceContext<'_>,
         hash: &[u8],
     ) -> Result<Option<String>> {
-        assert_eq!(hash.len(), HASH_LENGTH);
+        assert_eq!(hash.len(), TEXT_HASH_LENGTH);
 
         let txn = ctx.transaction();
         let contents = Text::find()
@@ -80,9 +80,9 @@ impl TextService {
     }
 
     /// Creates a text entry with this data, if it does not already exist.
-    pub async fn create(ctx: &ServiceContext<'_>, contents: String) -> Result<Hash> {
+    pub async fn create(ctx: &ServiceContext<'_>, contents: String) -> Result<TextHash> {
         let txn = ctx.transaction();
-        let hash = sha512_hash(contents.as_bytes());
+        let hash = k12_hash(contents.as_bytes());
 
         if !Self::exists(ctx, &hash).await? {
             let model = text::ActiveModel {


### PR DESCRIPTION
This a shorter hash that uses Keccak as its core, and is better suited to serve as the text hash due to its smaller size. Files remain on SHA-512 since they are larger blobs, and less likely to be smaller than the hash itself.

See [WJ-1149](https://scuttle.atlassian.net/browse/WJ-1149) for more rationale information.

[WJ-1149]: https://scuttle.atlassian.net/browse/WJ-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ