### PR TITLE
[WJ-1137] Add punycode-like names to default filter

### DIFF
--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -20,7 +20,7 @@ level = "info"
 # The IP and port to bind to when the server starts.
 address = "[::]:2747"
 
-# The path to write the pid file
+# The path to write the pid file.
 # If excluded or empty, then no pid file is written.
 pid-file = ""
 

--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -320,6 +320,12 @@
     },
     {
         "site": null,
+        "regex": "^xn-{1,}",
+        "descriptoin": "Looks like/is punycode",
+        "user": true
+    },
+    {
+        "site": null,
         "regex": "@",
         "description": "Looks like an email (contains @)",
         "user": true


### PR DESCRIPTION
In HTTP, [punycode](https://en.wikipedia.org/wiki/Punycode) domains begin with `xn--`. We shouldn't allow this as it could be used for confusability attacks (making something that looks like `scp-wiki` but in Cryllic). This adds it to the default filter set.