### PR TITLE
Update rust dependencies (2)

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bce8d450891e3b36f85a2230cec441fddd60e0c455b61b15bb3ffba955ca85"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1518,7 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.22.0"
+version = "1.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551c4e44a6d3e0bf1dad446a4d11c58da9514e2f287bf1428bbcc65e4f7eba9"
 dependencies = [
  "built",
  "cfg-if 1.0.0",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -64,7 +64,7 @@ wikidot-path = "0.4"
 #            https://github.com/tkaitchuck/aHash/issues/95
 
 [build-dependencies]
-built = { version = "0.6", features = ["chrono", "git2"] }
+built = { version = "0.6", features = ["git2"] }
 
 # Performance options
 


### PR DESCRIPTION
Well it turns out more than one sub-dependency still uses chrono, so that sucks. But we can still update ftml as bumped last PR.