### PR TITLE
Remove deprecated dependencies of ftml

### DIFF
--- a/ftml/Cargo.toml
+++ b/ftml/Cargo.toml
@@ -28,9 +28,9 @@ cfg-if = "1"
 enum-map = "2"
 entities = "1"
 latex2mathml = { version = "0.2", optional = true }
-lazy_static = "1"
 log = "0.4"
 maplit = "1"
+once_cell = "1.17.1"
 parcel_css = { version = "1.0.0-alpha.32", optional = true }
 parcel_selectors = "=0.24.7"  # this is *not* a required dependency,
                               # but we are pinning it since 0.24.8 does
@@ -50,7 +50,6 @@ strum_macros = "0.24"
 time = { version = "0.3", features = ["formatting", "macros", "parsing", "serde"], default-features = false }
 tinyvec = "1"
 unicase = "2"
-void = "1"
 wikidot-normalize = "0.11"
 
 [build-dependencies]

--- a/ftml/src/includes/includer/debug.rs
+++ b/ftml/src/includes/includer/debug.rs
@@ -20,20 +20,20 @@
 
 use super::prelude::*;
 use crate::tree::VariableMap;
+use std::convert::Infallible;
 use std::fmt::{self, Display};
-use void::Void;
 
 #[derive(Debug)]
 pub struct DebugIncluder;
 
 impl<'t> Includer<'t> for DebugIncluder {
-    type Error = Void;
+    type Error = Infallible;
 
     #[inline]
     fn include_pages(
         &mut self,
         includes: &[IncludeRef<'t>],
-    ) -> Result<Vec<FetchedPage<'t>>, Void> {
+    ) -> Result<Vec<FetchedPage<'t>>, Infallible> {
         let mut first = true;
         let mut pages = Vec::new();
 
@@ -66,7 +66,10 @@ impl<'t> Includer<'t> for DebugIncluder {
     }
 
     #[inline]
-    fn no_such_include(&mut self, page_ref: &PageRef<'t>) -> Result<Cow<'t, str>, Void> {
+    fn no_such_include(
+        &mut self,
+        page_ref: &PageRef<'t>,
+    ) -> Result<Cow<'t, str>, Infallible> {
         Ok(Cow::Owned(format!("<MISSING-PAGE {page_ref}>")))
     }
 }

--- a/ftml/src/includes/includer/null.rs
+++ b/ftml/src/includes/includer/null.rs
@@ -19,24 +19,27 @@
  */
 
 use super::prelude::*;
-use void::Void;
+use std::convert::Infallible;
 
 #[derive(Debug)]
 pub struct NullIncluder;
 
 impl<'t> Includer<'t> for NullIncluder {
-    type Error = Void;
+    type Error = Infallible;
 
     #[inline]
     fn include_pages(
         &mut self,
         _includes: &[IncludeRef<'t>],
-    ) -> Result<Vec<FetchedPage<'t>>, Void> {
+    ) -> Result<Vec<FetchedPage<'t>>, Infallible> {
         Ok(Vec::new())
     }
 
     #[inline]
-    fn no_such_include(&mut self, _page_ref: &PageRef<'t>) -> Result<Cow<'t, str>, Void> {
+    fn no_such_include(
+        &mut self,
+        _page_ref: &PageRef<'t>,
+    ) -> Result<Cow<'t, str>, Infallible> {
         Ok(Cow::Borrowed(""))
     }
 }

--- a/ftml/src/includes/mod.rs
+++ b/ftml/src/includes/mod.rs
@@ -38,20 +38,19 @@ use self::parse::parse_include_block;
 use crate::data::PageRef;
 use crate::settings::WikitextSettings;
 use crate::tree::VariableMap;
+use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
 
-lazy_static! {
-    static ref INCLUDE_REGEX: Regex = {
-        RegexBuilder::new(r"^\[\[\s*include-messy\s+")
-            .case_insensitive(true)
-            .multi_line(true)
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap()
-    };
-    static ref VARIABLE_REGEX: Regex =
-        Regex::new(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}").unwrap();
-}
+static INCLUDE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new(r"^\[\[\s*include-messy\s+")
+        .case_insensitive(true)
+        .multi_line(true)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap()
+});
+static VARIABLE_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\{\$(?P<name>[a-zA-Z0-9_\-]+)\}").unwrap());
 
 pub fn include<'t, I, E, F>(
     input: &'t str,

--- a/ftml/src/info.rs
+++ b/ftml/src/info.rs
@@ -29,33 +29,34 @@ pub use self::build::{
     RUSTC_VERSION, TARGET,
 };
 
-lazy_static! {
-    static ref VERSION_INFO: String = {
-        let mut version = format!("v{PKG_VERSION}");
+use once_cell::sync::Lazy;
 
-        if let Some(commit_hash) = *GIT_COMMIT_HASH_SHORT {
-            str_write!(&mut version, " [{commit_hash}]");
-        }
+static VERSION_INFO: Lazy<String> = Lazy::new(|| {
+    let mut version = format!("v{PKG_VERSION}");
 
-        version
-    };
-    pub static ref VERSION: String = format!("{PKG_NAME} {}", *VERSION_INFO);
-    pub static ref FULL_VERSION: String = {
-        let mut version = format!("{}\n\nCompiled:\n", *VERSION_INFO);
+    if let Some(commit_hash) = *GIT_COMMIT_HASH_SHORT {
+        str_write!(&mut version, " [{commit_hash}]");
+    }
 
-        str_writeln!(&mut version, "* across {NUM_JOBS} threads");
-        str_writeln!(&mut version, "* by {RUSTC_VERSION}");
-        str_writeln!(&mut version, "* for {TARGET}");
-        str_writeln!(&mut version, "* on {BUILT_TIME_UTC}");
+    version
+});
+pub static VERSION: Lazy<String> = Lazy::new(|| format!("{PKG_NAME} {}", *VERSION_INFO));
+pub static FULL_VERSION: Lazy<String> = Lazy::new(|| {
+    let mut version = format!("{}\n\nCompiled:\n", *VERSION_INFO);
 
-        version
-    };
-    pub static ref VERSION_WITH_NAME: String = format!("{PKG_NAME} {}", *VERSION);
-    pub static ref FULL_VERSION_WITH_NAME: String =
-        format!("{PKG_NAME} {}", *FULL_VERSION);
-    pub static ref GIT_COMMIT_HASH_SHORT: Option<&'static str> =
-        GIT_COMMIT_HASH.map(|s| &s[..8]);
-}
+    str_writeln!(&mut version, "* across {NUM_JOBS} threads");
+    str_writeln!(&mut version, "* by {RUSTC_VERSION}");
+    str_writeln!(&mut version, "* for {TARGET}");
+    str_writeln!(&mut version, "* on {BUILT_TIME_UTC}");
+
+    version
+});
+pub static VERSION_WITH_NAME: Lazy<String> =
+    Lazy::new(|| format!("{PKG_NAME} {}", *VERSION));
+pub static FULL_VERSION_WITH_NAME: Lazy<String> =
+    Lazy::new(|| format!("{PKG_NAME} {}", *FULL_VERSION));
+pub static GIT_COMMIT_HASH_SHORT: Lazy<Option<&'static str>> =
+    Lazy::new(|| GIT_COMMIT_HASH.map(|s| &s[..8]));
 
 #[test]
 fn info() {

--- a/ftml/src/lib.rs
+++ b/ftml/src/lib.rs
@@ -85,9 +85,6 @@ extern crate cfg_if;
 extern crate enum_map;
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate log;
 
 #[macro_use]

--- a/ftml/src/parsing/rule/impls/block/blocks/char.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/char.rs
@@ -20,24 +20,23 @@
 
 use super::prelude::*;
 use entities::ENTITIES;
+use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::char;
 use std::collections::HashMap;
 
-lazy_static! {
-    static ref ENTITY_MAPPING: HashMap<&'static str, &'static str> = {
-        let mut mapping = HashMap::new();
+static ENTITY_MAPPING: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    let mut mapping = HashMap::new();
 
-        for entity in &ENTITIES {
-            let key = strip_entity(entity.entity);
-            let value = entity.characters;
+    for entity in &ENTITIES {
+        let key = strip_entity(entity.entity);
+        let value = entity.characters;
 
-            mapping.insert(key, value);
-        }
+        mapping.insert(key, value);
+    }
 
-        mapping
-    };
-}
+    mapping
+});
 
 pub const BLOCK_CHAR: BlockRule = BlockRule {
     name: "block-char",

--- a/ftml/src/parsing/rule/impls/block/blocks/date.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/date.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::tree::DateItem;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use time::format_description::well_known::{Iso8601, Rfc2822, Rfc3339};
 use time::{Date, OffsetDateTime, PrimitiveDateTime, UtcOffset};
@@ -146,10 +147,8 @@ fn parse_date(value: &str) -> Result<DateItem, DateParseError> {
 
 /// Parse the timezone based on the specifier string.
 fn parse_timezone(value: &str) -> Result<UtcOffset, DateParseError> {
-    lazy_static! {
-        static ref TIMEZONE_REGEX: Regex =
-            Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap();
-    }
+    static TIMEZONE_REGEX: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"^(\+|-)?([0-9]{1,2}):?([0-9]{2})?$").unwrap());
 
     info!("Parsing possible timezone value '{value}'");
 

--- a/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/module/mapping.rs
@@ -19,6 +19,7 @@
  */
 
 use super::{modules::*, ModuleRule};
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use unicase::UniCase;
 
@@ -33,9 +34,8 @@ pub const MODULE_RULES: [ModuleRule; 6] = [
 
 pub type ModuleRuleMap = HashMap<UniCase<&'static str>, &'static ModuleRule>;
 
-lazy_static! {
-    pub static ref MODULE_RULE_MAP: ModuleRuleMap = build_module_rule_map(&MODULE_RULES);
-}
+pub static MODULE_RULE_MAP: Lazy<ModuleRuleMap> =
+    Lazy::new(|| build_module_rule_map(&MODULE_RULES));
 
 #[inline]
 pub fn get_module_rule_with_name(name: &str) -> Option<&'static ModuleRule> {

--- a/ftml/src/parsing/rule/impls/block/blocks/table.rs
+++ b/ftml/src/parsing/rule/impls/block/blocks/table.rs
@@ -257,18 +257,14 @@ fn parse_cell<'r, 't>(
     errors: Vec<ParseError>,
     header: bool,
 ) -> ParseResult<'r, 't, Elements<'t>> {
-    lazy_static! {
-        static ref ONE: NonZeroU32 = NonZeroU32::new(1).unwrap();
-    }
-
     // Remove leading and trailing whitespace
     strip_whitespace(&mut elements);
 
     // Extract column-span if specified via attributes.
     // If not specified, then the default.
     let column_span = match attributes.remove("colspan") {
-        Some(value) => value.parse().unwrap_or(*ONE),
-        None => *ONE,
+        Some(value) => value.parse().unwrap_or(NonZeroU32::new(1).unwrap()),
+        None => NonZeroU32::new(1).unwrap(),
     };
 
     let element = Element::Partial(PartialElement::TableCell(TableCell {

--- a/ftml/src/parsing/rule/impls/block/mapping.rs
+++ b/ftml/src/parsing/rule/impls/block/mapping.rs
@@ -19,6 +19,7 @@
  */
 
 use super::{blocks::*, BlockRule};
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use unicase::UniCase;
 
@@ -87,9 +88,8 @@ pub const BLOCK_RULES: [BlockRule; 60] = [
 
 pub type BlockRuleMap = HashMap<UniCase<&'static str>, &'static BlockRule>;
 
-lazy_static! {
-    pub static ref BLOCK_RULE_MAP: BlockRuleMap = build_block_rule_map(&BLOCK_RULES);
-}
+pub static BLOCK_RULE_MAP: Lazy<BlockRuleMap> =
+    Lazy::new(|| build_block_rule_map(&BLOCK_RULES));
 
 #[inline]
 pub fn get_block_rule_with_name(name: &str) -> Option<&'static BlockRule> {

--- a/ftml/src/parsing/rule/impls/block/parser.rs
+++ b/ftml/src/parsing/rule/impls/block/parser.rs
@@ -28,11 +28,10 @@ use crate::parsing::{
     ParseResult, Parser, Token,
 };
 use crate::tree::Element;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
-lazy_static! {
-    static ref ARGUMENT_KEY: Regex = Regex::new(r"[A-Za-z0-9_\-]+").unwrap();
-}
+static ARGUMENT_KEY: Lazy<Regex> = Lazy::new(|| Regex::new(r"[A-Za-z0-9_\-]+").unwrap());
 
 impl<'r, 't> Parser<'r, 't>
 where

--- a/ftml/src/parsing/rule/impls/color.rs
+++ b/ftml/src/parsing/rule/impls/color.rs
@@ -19,13 +19,12 @@
  */
 
 use super::prelude::*;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
 
-lazy_static! {
-    static ref HEX_COLOR: Regex =
-        Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap();
-}
+static HEX_COLOR: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$").unwrap());
 
 pub const RULE_COLOR: Rule = Rule {
     name: "color",

--- a/ftml/src/parsing/rule/impls/variable.rs
+++ b/ftml/src/parsing/rule/impls/variable.rs
@@ -19,11 +19,10 @@
  */
 
 use super::prelude::*;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
-lazy_static! {
-    static ref VARIABLE_REGEX: Regex = Regex::new(r"\{\$(.+)\}").unwrap();
-}
+static VARIABLE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\{\$(.+)\}").unwrap());
 
 pub const RULE_VARIABLE: Rule = Rule {
     name: "variable",

--- a/ftml/src/parsing/rule/mapping.rs
+++ b/ftml/src/parsing/rule/mapping.rs
@@ -21,97 +21,96 @@
 use super::{impls::*, Rule};
 use crate::parsing::token::{ExtractedToken, Token};
 use enum_map::EnumMap;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    /// Mapping of all tokens to the rules they possibly correspond with.
-    ///
-    /// This is the first tokens that could consistute the given rule,
-    /// in order of precedence.
-    ///
-    /// An empty list means that this is a special token that shouldn't be used
-    /// in this manner. It will of course fall back to interpreting this token
-    /// as text, but will also produce an error for the user.
-    pub static ref RULE_MAP: EnumMap<Token, Vec<Rule>> = {
-        enum_map! {
-            // Symbols
-            Token::LeftBracket => vec![RULE_LINK_SINGLE, RULE_TEXT],
-            Token::LeftBracketAnchor => vec![RULE_LINK_ANCHOR],
-            Token::LeftBracketStar => vec![RULE_LINK_SINGLE_NEW_TAB],
-            Token::RightBracket => vec![RULE_TEXT],
-            Token::LeftBlock => vec![RULE_BLOCK],
-            Token::LeftBlockEnd => vec![],
-            Token::LeftBlockAnchor => vec![RULE_ANCHOR],
-            Token::LeftBlockStar => vec![RULE_BLOCK_STAR],
-            Token::RightBlock => vec![],
-            Token::LeftParentheses => vec![RULE_BIBCITE, RULE_TEXT],
-            Token::RightParentheses => vec![RULE_BIBCITE, RULE_TEXT],
-            Token::LeftMath => vec![RULE_MATH],
-            Token::RightMath => vec![],
-            Token::DoubleDash => vec![RULE_STRIKETHROUGH, RULE_DASH],
-            Token::TripleDash => vec![RULE_HORIZONTAL_RULE],
-            Token::LeftDoubleAngle => vec![RULE_DOUBLE_ANGLE],
-            Token::ClearFloatBoth => vec![RULE_CLEAR_FLOAT],
-            Token::ClearFloatLeft => vec![RULE_CLEAR_FLOAT],
-            Token::ClearFloatRight => vec![RULE_CLEAR_FLOAT],
-            Token::Pipe => vec![RULE_TEXT],
-            Token::Equals => vec![RULE_CENTER, RULE_TEXT],
-            Token::Colon => vec![RULE_DEFINITION_LIST, RULE_TEXT],
-            Token::Underscore => vec![RULE_UNDERSCORE_LINE_BREAK, RULE_TEXT],
-            Token::Quote => vec![RULE_BLOCKQUOTE, RULE_DOUBLE_ANGLE, RULE_TEXT],
-            Token::Heading => vec![RULE_HEADER, RULE_TEXT],
-            Token::Whitespace => vec![RULE_UNDERSCORE_LINE_BREAK, RULE_LIST, RULE_TEXT],
+/// Mapping of all tokens to the rules they possibly correspond with.
+///
+/// This is the first tokens that could consistute the given rule,
+/// in order of precedence.
+///
+/// An empty list means that this is a special token that shouldn't be used
+/// in this manner. It will of course fall back to interpreting this token
+/// as text, but will also produce an error for the user.
+pub static RULE_MAP: Lazy<EnumMap<Token, Vec<Rule>>> = Lazy::new(|| {
+    enum_map! {
+        // Symbols
+        Token::LeftBracket => vec![RULE_LINK_SINGLE, RULE_TEXT],
+        Token::LeftBracketAnchor => vec![RULE_LINK_ANCHOR],
+        Token::LeftBracketStar => vec![RULE_LINK_SINGLE_NEW_TAB],
+        Token::RightBracket => vec![RULE_TEXT],
+        Token::LeftBlock => vec![RULE_BLOCK],
+        Token::LeftBlockEnd => vec![],
+        Token::LeftBlockAnchor => vec![RULE_ANCHOR],
+        Token::LeftBlockStar => vec![RULE_BLOCK_STAR],
+        Token::RightBlock => vec![],
+        Token::LeftParentheses => vec![RULE_BIBCITE, RULE_TEXT],
+        Token::RightParentheses => vec![RULE_BIBCITE, RULE_TEXT],
+        Token::LeftMath => vec![RULE_MATH],
+        Token::RightMath => vec![],
+        Token::DoubleDash => vec![RULE_STRIKETHROUGH, RULE_DASH],
+        Token::TripleDash => vec![RULE_HORIZONTAL_RULE],
+        Token::LeftDoubleAngle => vec![RULE_DOUBLE_ANGLE],
+        Token::ClearFloatBoth => vec![RULE_CLEAR_FLOAT],
+        Token::ClearFloatLeft => vec![RULE_CLEAR_FLOAT],
+        Token::ClearFloatRight => vec![RULE_CLEAR_FLOAT],
+        Token::Pipe => vec![RULE_TEXT],
+        Token::Equals => vec![RULE_CENTER, RULE_TEXT],
+        Token::Colon => vec![RULE_DEFINITION_LIST, RULE_TEXT],
+        Token::Underscore => vec![RULE_UNDERSCORE_LINE_BREAK, RULE_TEXT],
+        Token::Quote => vec![RULE_BLOCKQUOTE, RULE_DOUBLE_ANGLE, RULE_TEXT],
+        Token::Heading => vec![RULE_HEADER, RULE_TEXT],
+        Token::Whitespace => vec![RULE_UNDERSCORE_LINE_BREAK, RULE_LIST, RULE_TEXT],
 
-            // Formatting
-            Token::Bold => vec![RULE_BOLD],
-            Token::Italics => vec![RULE_ITALICS],
-            Token::Underline => vec![RULE_UNDERLINE],
-            Token::Superscript => vec![RULE_SUPERSCRIPT],
-            Token::Subscript => vec![RULE_SUBSCRIPT],
-            Token::LeftMonospace => vec![RULE_MONOSPACE],
-            Token::RightMonospace => vec![],
-            Token::Color => vec![RULE_COLOR],
-            Token::Raw => vec![RULE_RAW],
-            Token::LeftRaw => vec![RULE_RAW],
-            Token::RightRaw => vec![],
+        // Formatting
+        Token::Bold => vec![RULE_BOLD],
+        Token::Italics => vec![RULE_ITALICS],
+        Token::Underline => vec![RULE_UNDERLINE],
+        Token::Superscript => vec![RULE_SUPERSCRIPT],
+        Token::Subscript => vec![RULE_SUBSCRIPT],
+        Token::LeftMonospace => vec![RULE_MONOSPACE],
+        Token::RightMonospace => vec![],
+        Token::Color => vec![RULE_COLOR],
+        Token::Raw => vec![RULE_RAW],
+        Token::LeftRaw => vec![RULE_RAW],
+        Token::RightRaw => vec![],
 
-            // Lists
-            Token::BulletItem => vec![RULE_LIST, RULE_TEXT],
-            Token::NumberedItem => vec![RULE_LIST, RULE_TEXT],
+        // Lists
+        Token::BulletItem => vec![RULE_LIST, RULE_TEXT],
+        Token::NumberedItem => vec![RULE_LIST, RULE_TEXT],
 
-            // Links
-            Token::LeftLink => vec![RULE_LINK_TRIPLE],
-            Token::LeftLinkStar => vec![RULE_LINK_TRIPLE_NEW_TAB],
-            Token::RightLink => vec![],
+        // Links
+        Token::LeftLink => vec![RULE_LINK_TRIPLE],
+        Token::LeftLinkStar => vec![RULE_LINK_TRIPLE_NEW_TAB],
+        Token::RightLink => vec![],
 
-            // Tables
-            Token::TableColumn => vec![RULE_TABLE],
-            Token::TableColumnLeft => vec![RULE_TABLE],
-            Token::TableColumnRight => vec![RULE_TABLE],
-            Token::TableColumnCenter => vec![RULE_TABLE],
-            Token::TableColumnTitle => vec![RULE_TABLE],
+        // Tables
+        Token::TableColumn => vec![RULE_TABLE],
+        Token::TableColumnLeft => vec![RULE_TABLE],
+        Token::TableColumnRight => vec![RULE_TABLE],
+        Token::TableColumnCenter => vec![RULE_TABLE],
+        Token::TableColumnTitle => vec![RULE_TABLE],
 
-            // Text components
-            Token::Identifier => vec![RULE_TEXT],
-            Token::Email => vec![RULE_EMAIL],
-            Token::Url => vec![RULE_URL],
-            Token::Variable => vec![RULE_VARIABLE, RULE_TEXT],
-            Token::String => vec![RULE_TEXT],
+        // Text components
+        Token::Identifier => vec![RULE_TEXT],
+        Token::Email => vec![RULE_EMAIL],
+        Token::Url => vec![RULE_URL],
+        Token::Variable => vec![RULE_VARIABLE, RULE_TEXT],
+        Token::String => vec![RULE_TEXT],
 
-            // Input boundaries
-            Token::LineBreak => vec![RULE_BLOCK_SKIP_NEWLINE, RULE_DEFINITION_LIST_SKIP_NEWLINE, RULE_LINE_BREAK],
-            Token::ParagraphBreak => vec![RULE_LINE_BREAK_PARAGRAPH],
-            Token::InputStart => vec![RULE_NULL],
-            Token::InputEnd => vec![RULE_NULL],
+        // Input boundaries
+        Token::LineBreak => vec![RULE_BLOCK_SKIP_NEWLINE, RULE_DEFINITION_LIST_SKIP_NEWLINE, RULE_LINE_BREAK],
+        Token::ParagraphBreak => vec![RULE_LINE_BREAK_PARAGRAPH],
+        Token::InputStart => vec![RULE_NULL],
+        Token::InputEnd => vec![RULE_NULL],
 
-            // Miscellaneous
-            Token::LeftComment => vec![RULE_COMMENT],
-            Token::RightComment => vec![],
+        // Miscellaneous
+        Token::LeftComment => vec![RULE_COMMENT],
+        Token::RightComment => vec![],
 
-            // Fallback
-            Token::Other => vec![RULE_TEXT],
-        }
-    };
-}
+        // Fallback
+        Token::Other => vec![RULE_TEXT],
+    }
+});
 
 #[inline]
 pub fn get_rules_for_token(current: &ExtractedToken) -> &'static [Rule] {

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -32,38 +32,37 @@
 //! it was moved to the parser to prevent typography from converting
 //! the `--` in `[!--` and `--]` into em dashes.
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 
-lazy_static! {
-    // ‘ - LEFT SINGLE QUOTATION MARK
-    // ’ - RIGHT SINGLE QUOTATION MARK
-    static ref SINGLE_QUOTES: Replacer = Replacer::RegexSurround {
-        regex: Regex::new(r"`(.*?)'").unwrap(),
-        begin: "\u{2018}",
-        end: "\u{2019}",
-    };
+// ‘ - LEFT SINGLE QUOTATION MARK
+// ’ - RIGHT SINGLE QUOTATION MARK
+static SINGLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
+    regex: Regex::new(r"`(.*?)'").unwrap(),
+    begin: "\u{2018}",
+    end: "\u{2019}",
+});
 
-    // “ - LEFT DOUBLE QUOTATION MARK
-    // ” - RIGHT DOUBLE QUOTATION MARK
-    static ref DOUBLE_QUOTES: Replacer = Replacer::RegexSurround {
-        regex: Regex::new(r"``(.*?)''").unwrap(),
-        begin: "\u{201c}",
-        end: "\u{201d}",
-    };
+// “ - LEFT DOUBLE QUOTATION MARK
+// ” - RIGHT DOUBLE QUOTATION MARK
+static DOUBLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
+    regex: Regex::new(r"``(.*?)''").unwrap(),
+    begin: "\u{201c}",
+    end: "\u{201d}",
+});
 
-    // „ - DOUBLE LOW-9 QUOTATION MARK
-    static ref LOW_DOUBLE_QUOTES: Replacer = Replacer::RegexSurround {
-        regex: Regex::new(r",,(.*?)''").unwrap(),
-        begin: "\u{201e}",
-        end: "\u{201d}",
-    };
+// „ - DOUBLE LOW-9 QUOTATION MARK
+static LOW_DOUBLE_QUOTES: Lazy<Replacer> = Lazy::new(|| Replacer::RegexSurround {
+    regex: Regex::new(r",,(.*?)''").unwrap(),
+    begin: "\u{201e}",
+    end: "\u{201d}",
+});
 
-    // … - HORIZONTAL ELLIPSIS
-    static ref ELLIPSIS: Replacer = Replacer::RegexReplace {
-        regex: Regex::new(r"(?:\.\.\.|\. \. \.)").unwrap(),
-        replacement: "\u{2026}",
-    };
-}
+// … - HORIZONTAL ELLIPSIS
+static ELLIPSIS: Lazy<Replacer> = Lazy::new(|| Replacer::RegexReplace {
+    regex: Regex::new(r"(?:\.\.\.|\. \. \.)").unwrap(),
+    replacement: "\u{2026}",
+});
 
 /// Helper struct to easily perform string replacements.
 #[derive(Debug)]

--- a/ftml/src/preproc/whitespace.rs
+++ b/ftml/src/preproc/whitespace.rs
@@ -27,24 +27,23 @@
 //! * Convert null characters to regular spaces
 //! * Compress groups of 3+ newlines into 2 newlines
 
+use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
 
-lazy_static! {
-    static ref LEADING_NONSTANDARD_WHITESPACE: Regex = {
-        RegexBuilder::new("^[\u{00a0}\u{2007}]+")
-            .multi_line(true)
-            .build()
-            .unwrap()
-    };
-    static ref WHITESPACE_ONLY_LINE: Regex = {
-        RegexBuilder::new(r"^\s+$")
-            .multi_line(true)
-            .build()
-            .unwrap()
-    };
-    static ref LEADING_NEWLINES: Regex = Regex::new(r"^\n+").unwrap();
-    static ref TRAILING_NEWLINES: Regex = Regex::new(r"\n+$").unwrap();
-}
+static LEADING_NONSTANDARD_WHITESPACE: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new("^[\u{00a0}\u{2007}]+")
+        .multi_line(true)
+        .build()
+        .unwrap()
+});
+static WHITESPACE_ONLY_LINE: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new(r"^\s+$")
+        .multi_line(true)
+        .build()
+        .unwrap()
+});
+static LEADING_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\n+").unwrap());
+static TRAILING_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new(r"\n+$").unwrap());
 
 pub fn substitute(text: &mut String) {
     // Replace DOS and Mac newlines

--- a/ftml/src/settings/interwiki.rs
+++ b/ftml/src/settings/interwiki.rs
@@ -18,30 +18,25 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-lazy_static! {
-    pub static ref EMPTY_INTERWIKI: InterwikiSettings = {
-        InterwikiSettings {
-            prefixes: hashmap! {},
-        }
-    };
-    pub static ref DEFAULT_INTERWIKI: InterwikiSettings = {
-        InterwikiSettings {
-            prefixes: hashmap! {
-                cow!("wikipedia") => cow!("https://wikipedia.org/wiki/$$"),
-                cow!("wp") => cow!("https://wikipedia.org/wiki/$$"),
-                cow!("commons") => cow!("https://commons.wikimedia.org/wiki/$$"),
-                cow!("google") => cow!("https://google.com/search?q=$$"),
-                cow!("duckduckgo") => cow!("https://duckduckgo.com/?q=$$"),
-                cow!("ddg") => cow!("https://duckduckgo.com/?q=$$"),
-                cow!("dictionary") => cow!("https://dictionary.com/browse/$$"),
-                cow!("thesaurus") => cow!("https://thesaurus.com/browse/$$"),
-            },
-        }
-    };
-}
+pub static EMPTY_INTERWIKI: Lazy<InterwikiSettings> = Lazy::new(|| InterwikiSettings {
+    prefixes: hashmap! {},
+});
+pub static DEFAULT_INTERWIKI: Lazy<InterwikiSettings> = Lazy::new(|| InterwikiSettings {
+    prefixes: hashmap! {
+        cow!("wikipedia") => cow!("https://wikipedia.org/wiki/$$"),
+        cow!("wp") => cow!("https://wikipedia.org/wiki/$$"),
+        cow!("commons") => cow!("https://commons.wikimedia.org/wiki/$$"),
+        cow!("google") => cow!("https://google.com/search?q=$$"),
+        cow!("duckduckgo") => cow!("https://duckduckgo.com/?q=$$"),
+        cow!("ddg") => cow!("https://duckduckgo.com/?q=$$"),
+        cow!("dictionary") => cow!("https://dictionary.com/browse/$$"),
+        cow!("thesaurus") => cow!("https://thesaurus.com/browse/$$"),
+    },
+});
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct InterwikiSettings {

--- a/ftml/src/test/ast.rs
+++ b/ftml/src/test/ast.rs
@@ -30,12 +30,12 @@ use crate::render::html::HtmlRender;
 use crate::render::Render;
 use crate::settings::{WikitextMode, WikitextSettings};
 use crate::tree::SyntaxTree;
+use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process;
-use void::ResultVoidExt;
 
 /// Temporary measure to not run certain tests.
 ///
@@ -50,13 +50,11 @@ const SKIP_TESTS: &[&str] = &[];
 /// tests to check if certain functionality is working as expected.
 const ONLY_TESTS: &[&str] = &[];
 
-lazy_static! {
-    static ref TEST_DIRECTORY: PathBuf = {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("test");
-        path
-    };
-}
+static TEST_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("test");
+    path
+});
 
 macro_rules! cow {
     ($text:expr) => {
@@ -215,7 +213,7 @@ impl Test<'_> {
 
         let (mut text, _pages) =
             crate::include(&self.input, &settings, TestIncluder, || unreachable!())
-                .void_unwrap();
+                .unwrap_or_else(|x| match x {});
 
         crate::preprocess(&mut text);
         let tokens = crate::tokenize(&text);

--- a/ftml/src/test/includer.rs
+++ b/ftml/src/test/includer.rs
@@ -21,7 +21,7 @@
 use crate::data::PageRef;
 use crate::includes::{FetchedPage, IncludeRef, Includer};
 use std::borrow::Cow;
-use void::Void;
+use std::convert::Infallible;
 
 const FRUIT_PAGE_SOURCE: &str = "
 * Apple
@@ -50,13 +50,13 @@ const COMPONENT_FRUIT_PAGE_SOURCE: &str = "
 pub struct TestIncluder;
 
 impl<'t> Includer<'t> for TestIncluder {
-    type Error = Void;
+    type Error = Infallible;
 
     #[inline]
     fn include_pages(
         &mut self,
         includes: &[IncludeRef<'t>],
-    ) -> Result<Vec<FetchedPage<'t>>, Void> {
+    ) -> Result<Vec<FetchedPage<'t>>, Infallible> {
         let mut pages = Vec::new();
 
         for include in includes {
@@ -70,7 +70,10 @@ impl<'t> Includer<'t> for TestIncluder {
     }
 
     #[inline]
-    fn no_such_include(&mut self, page_ref: &PageRef<'t>) -> Result<Cow<'t, str>, Void> {
+    fn no_such_include(
+        &mut self,
+        page_ref: &PageRef<'t>,
+    ) -> Result<Cow<'t, str>, Infallible> {
         Ok(Cow::Owned(format!(
             "[[div class=\"wj-error\"]]\nNo such page '{page_ref}'\n[[/div]]",
         )))

--- a/ftml/src/test/prop.rs
+++ b/ftml/src/test/prop.rs
@@ -27,6 +27,7 @@ use crate::tree::{
     ContainerType, Element, FloatAlignment, Heading, HeadingLevel, ImageSource,
     LinkLabel, LinkLocation, LinkType, ListItem, ListType, Module, SyntaxTree,
 };
+use once_cell::sync::Lazy;
 use proptest::option;
 use proptest::prelude::*;
 use std::borrow::Cow;
@@ -34,10 +35,8 @@ use std::num::NonZeroU32;
 
 // Constants
 
-lazy_static! {
-    static ref SAFE_ATTRIBUTES_VEC: Vec<&'static str> =
-        SAFE_ATTRIBUTES.iter().map(|s| s.as_ref()).collect();
-}
+static SAFE_ATTRIBUTES_VEC: Lazy<Vec<&'static str>> =
+    Lazy::new(|| SAFE_ATTRIBUTES.iter().map(|s| s.as_ref()).collect());
 
 const SIMPLE_EMAIL_REGEX: &str = r"\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*";
 const SIMPLE_URL_REGEX: &str = r"https?://([-.]\w)+";

--- a/ftml/src/tree/align.rs
+++ b/ftml/src/tree/align.rs
@@ -73,10 +73,10 @@ pub struct FloatAlignment {
 
 impl FloatAlignment {
     pub fn parse(name: &str) -> Option<Self> {
-        lazy_static! {
-            static ref IMAGE_ALIGNMENT_REGEX: Regex =
-                Regex::new(r"^[fF]?([<=>])").unwrap();
-        }
+        use once_cell::sync::Lazy;
+
+        static IMAGE_ALIGNMENT_REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"^[fF]?([<=>])").unwrap());
 
         IMAGE_ALIGNMENT_REGEX
             .find(name)

--- a/ftml/src/tree/attribute/safe.rs
+++ b/ftml/src/tree/attribute/safe.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashSet;
 use unicase::UniCase;
@@ -36,157 +37,152 @@ macro_rules! hashset_unicase {
     };
 }
 
-lazy_static! {
-    /// List of safe attributes. All others will be filtered out.
-    ///
-    /// See https://scuttle.atlassian.net/wiki/spaces/WD/pages/1030782977/Allowed+Attributes+in+Wikitext
-    pub static ref SAFE_ATTRIBUTES: HashSet<UniCase<&'static str>> = {
-        hashset_unicase![
-            "accept",
-            "align",
-            "alt",
-            "autocapitalize",
-            "autoplay",
-            "background",
-            "bgcolor",
-            "border",
-            "buffered",
-            "checked",
-            "cite",
-            "class",
-            "cols",
-            "colspan",
-            "contenteditable",
-            "controls",
-            "coords",
-            "datetime",
-            "decoding",
-            "default",
-            "dir",
-            "dirname",
-            "disabled",
-            "download",
-            "draggable",
-            "for",
-            "form",
-            "headers",
-            "height",
-            "hidden",
-            "high",
-            "href",
-            "hreflang",
-            "id",
-            "inputmode",
-            "ismap",
-            "itemprop",
-            "kind",
-            "label",
-            "lang",
-            "list",
-            "loop",
-            "low",
-            "max",
-            "maxlength",
-            "min",
-            "minlength",
-            "multiple",
-            "muted",
-            "name",
-            "optimum",
-            "pattern",
-            "placeholder",
-            "poster",
-            "preload",
-            "readonly",
-            "required",
-            "reversed",
-            "role",
-            "rows",
-            "rowspan",
-            "scope",
-            "selected",
-            "shape",
-            "size",
-            "sizes",
-            "span",
-            "spellcheck",
-            "src",
-            "srclang",
-            "srcset",
-            "start",
-            "step",
-            "style",
-            "tabindex",
-            "target",
-            "title",
-            "translate",
-            "type",
-            "usemap",
-            "value",
-            "width",
-            "wrap",
-        ]
-    };
+/// List of safe attributes. All others will be filtered out.
+///
+/// See https://scuttle.atlassian.net/wiki/spaces/WD/pages/1030782977/Allowed+Attributes+in+Wikitext
+pub static SAFE_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(|| {
+    hashset_unicase![
+        "accept",
+        "align",
+        "alt",
+        "autocapitalize",
+        "autoplay",
+        "background",
+        "bgcolor",
+        "border",
+        "buffered",
+        "checked",
+        "cite",
+        "class",
+        "cols",
+        "colspan",
+        "contenteditable",
+        "controls",
+        "coords",
+        "datetime",
+        "decoding",
+        "default",
+        "dir",
+        "dirname",
+        "disabled",
+        "download",
+        "draggable",
+        "for",
+        "form",
+        "headers",
+        "height",
+        "hidden",
+        "high",
+        "href",
+        "hreflang",
+        "id",
+        "inputmode",
+        "ismap",
+        "itemprop",
+        "kind",
+        "label",
+        "lang",
+        "list",
+        "loop",
+        "low",
+        "max",
+        "maxlength",
+        "min",
+        "minlength",
+        "multiple",
+        "muted",
+        "name",
+        "optimum",
+        "pattern",
+        "placeholder",
+        "poster",
+        "preload",
+        "readonly",
+        "required",
+        "reversed",
+        "role",
+        "rows",
+        "rowspan",
+        "scope",
+        "selected",
+        "shape",
+        "size",
+        "sizes",
+        "span",
+        "spellcheck",
+        "src",
+        "srclang",
+        "srcset",
+        "start",
+        "step",
+        "style",
+        "tabindex",
+        "target",
+        "title",
+        "translate",
+        "type",
+        "usemap",
+        "value",
+        "width",
+        "wrap",
+    ]
+});
 
-    /// List of all HTML5 attributes with special boolean behavior.
-    ///
-    /// That is, you set them to "true" by having the attribute present without
-    /// a value, and "false" by excluding them.
-    ///
-    /// A notable example is "checked" for `<input>`:
-    /// * `<input type="checkbox" checked>` means the checkbox starts checked
-    /// * `<input type="checkbox">` means it starts unchecked
-    ///
-    /// This list includes all such attributes, even if they are not part of
-    /// `SAFE_ATTRIBUTES`.
-    pub static ref BOOLEAN_ATTRIBUTES: HashSet<UniCase<&'static str>> = {
-        hashset_unicase![
-            "allowfullscreen",
-            "allowpaymentrequest",
-            "async",
-            "autofocus",
-            "autoplay",
-            "checked",
-            "controls",
-            "default",
-            "disabled",
-            "formnovalidate",
-            "hidden",
-            "ismap",
-            "itemscope",
-            "loop",
-            "multiple",
-            "muted",
-            "nomodule",
-            "novalidate",
-            "open",
-            "playsinline",
-            "readonly",
-            "required",
-            "reversed",
-            "selected",
-            "truespeed",
-        ]
-    };
+/// List of all HTML5 attributes with special boolean behavior.
+///
+/// That is, you set them to "true" by having the attribute present without
+/// a value, and "false" by excluding them.
+///
+/// A notable example is "checked" for `<input>`:
+/// * `<input type="checkbox" checked>` means the checkbox starts checked
+/// * `<input type="checkbox">` means it starts unchecked
+///
+/// This list includes all such attributes, even if they are not part of
+/// `SAFE_ATTRIBUTES`.
+pub static BOOLEAN_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> = Lazy::new(|| {
+    hashset_unicase![
+        "allowfullscreen",
+        "allowpaymentrequest",
+        "async",
+        "autofocus",
+        "autoplay",
+        "checked",
+        "controls",
+        "default",
+        "disabled",
+        "formnovalidate",
+        "hidden",
+        "ismap",
+        "itemscope",
+        "loop",
+        "multiple",
+        "muted",
+        "nomodule",
+        "novalidate",
+        "open",
+        "playsinline",
+        "readonly",
+        "required",
+        "reversed",
+        "selected",
+        "truespeed",
+    ]
+});
 
-    /// List of HTML attributes which need to be checked for XSS.
-    ///
-    /// For instance, you could have `href="javascript:doSomething()"`,
-    /// which would escape normal sandboxing and run trusted javascript
-    /// from untrusted user data.
-    ///
-    /// ## See also
-    /// * `detect_dangerous_schemes()`
-    /// * `normalize_href()`
-    pub static ref URL_ATTRIBUTES: HashSet<UniCase<&'static str>> = {
-        hashset_unicase![
-            "href",
-            "src",
-        ]
-    };
+/// List of HTML attributes which need to be checked for XSS.
+///
+/// For instance, you could have `href="javascript:doSomething()"`,
+/// which would escape normal sandboxing and run trusted javascript
+/// from untrusted user data.
+///
+/// ## See also
+/// * `detect_dangerous_schemes()`
+/// * `normalize_href()`
+pub static URL_ATTRIBUTES: Lazy<HashSet<UniCase<&'static str>>> =
+    Lazy::new(|| hashset_unicase!["href", "src",]);
 
-    static ref ATTRIBUTE_SUFFIX_SAFE: Regex = Regex::new(r"[a-zA-z0-9\-]+").unwrap();
-}
+static ATTRIBUTE_SUFFIX_SAFE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[a-zA-z0-9\-]+").unwrap());
 
 pub const SAFE_ATTRIBUTE_PREFIXES: [&str; 2] = ["aria-", "data-"];
 


### PR DESCRIPTION
- `lazy_static` has generally fallen out of favor due to `once_cell`, which will be soon incorporated into the standard library.
- `void` is no longer maintained by its original author and has been replaced by `std::convert::Infallible`.