### PR TITLE
[WJ-1118] Add case-sensitivity logic to filter regex.

### DIFF
--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -3,252 +3,294 @@
         "site": "www",
         "regex": "^alice$",
         "description": "Users named Alice cannot join (example)",
+        "case_sensitive": true,
         "user": true
     },
     {
         "site": "www",
         "regex": "^bob$",
         "description": "Users named Bob cannot join (example)",
+        "case_sensitive": true,
         "user": true
     },
     {
         "site": null,
         "regex": "^.*@example\\.com$",
         "description": "Cannot join using example.com emails (example)",
+        "case_sensitive": false,
         "email": true
     },
     {
         "site": null,
         "regex": "wikidot",
         "description": "Reserved name (wikidot)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "wikijump",
         "description": "Reserved name (wikijump)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^mail$",
         "description": "Reserved name (mail)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^dev(eloper)?$",
         "description": "Reserved name (dev / developer)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^blog$",
         "description": "Reserved name (blog)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^login$",
         "description": "Reserved name (login)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^logout$",
         "description": "Reserved name (logout)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^support$",
         "description": "Reserved name (support)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^help(desk)?$",
         "description": "Reserved name (help / helpdesk)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^pro(fessional)?$",
         "description": "Reserved name (pro / professional)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^web$",
         "description": "Reserved name (web)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(ssl|tls)$",
         "description": "Reserved name (ssl / tls)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^pay(ments?)?$",
         "description": "Reserved name (pay / payment / payments)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(wd|wj)?(up|down)load$",
         "description": "Reserved name (upload / download)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^secure$",
         "description": "Reserved name (secure)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^serv(ices?)?$",
         "description": "Reserved name (serv / service / services)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^static[0-9]*$",
         "description": "Reserved name (static with optional numbers)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^api$",
         "description": "Reserved name (api)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^guru$",
         "description": "Reserved name (guru)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^admin(ministrator)?",
         "description": "Reserved name (starts with admin / administrator)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^mod$",
         "description": "Reserved name (mod)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^moderator",
         "description": "Reserved name (starts with moderator)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^staff$",
         "description": "Reserved name (staff)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^module$",
         "description": "Reserved name (module)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^sys$",
         "description": "Reserved name (sys)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^system",
         "description": "Reserved name (starts with system)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^root$",
         "description": "Reserved name (root)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^sudo$",
         "description": "Reserved name (sudo)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^wheel$",
         "description": "Reserved name (wheel)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^anon(ymous)?$",
         "description": "Reserved name (anon / anonymous)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^guest",
         "description": "Reserved name (starts with guest)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^template$",
         "description": "Reserved name (template)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^template-$",
         "description": "Reserved name (starts with template-)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^example",
         "description": "Reserved name (starts with example)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^unknown$",
         "description": "Reserved name (unknown)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^null$",
         "description": "Reserved name (null)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^undefined$",
         "description": "Reserved name (undefined)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(img|image)$",
         "description": "Reserved name (img / image)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^scripts?$",
         "description": "Reserved name (script / scripts)",
+        "case_sensitive": false,
         "user": true
     },
 
@@ -256,104 +298,121 @@
         "site": null,
         "regex": "^warning$",
         "description": "Reserved name (warning)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^error$",
         "description": "Reserved name (error)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(ro)?bots?$",
         "description": "Reserved name (bot / bots / robot / robots)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(ftp|http|https)$",
         "description": "Reserved name (ftp / http / https)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^(stage|staging)$",
         "description": "Reserved name (stage / staging)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^prod(uction)?$",
         "description": "Reserved name (prod / production)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^official$",
         "description": "Reserved name (official)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^porn",
         "description": "Starts with 'porn'",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^spam",
         "description": "Starts with 'spam'",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^.$",
         "description": "Single-character usernames and slugs",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^[0-9]*www[0-9]*$",
         "description": "Looks like 'WWW'",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^xn-{1,}",
         "descriptoin": "Looks like/is punycode",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "@",
         "description": "Looks like an email (contains @)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^[0-9]+(\\.[0-9]+){2,}$",
         "description": "Looks like IPv4",
+        "case_sensitive": false,
         "user": true,
         "file": true
     },
     {
         "site": null,
-        "regex": "^:*[0-9a-fA-F]+(:[0-9a-fA-F]*)*$",
+        "regex": "^:*[0-9a-f]+(:[0-9a-f]*)*$",
         "description": "Looks like IPv6",
+        "case_sensitive": false,
         "user": true,
         "file": true
     },
     {
         "site": null,
-        "regex": "^[oO0]5\\-\\w+$",
+        "regex": "^[o0]5\\-\\w+$",
         "description": "Looks like an O5 designation (SCP Wiki related)",
+        "case_sensitive": false,
         "user": true
     },
     {
         "site": null,
         "regex": "^SCP\\-\\w+$",
         "description": "Looks like an SCP designation (SCP Wiki related)",
+        "case_sensitive": false,
         "user": true
     }
 ]

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -136,6 +136,7 @@ pub struct Page {
 pub struct Filter {
     pub regex: String,
     pub description: String,
+    pub case_sensitive: bool,
 
     #[serde(rename = "site")]
     pub site_slug: Option<String>,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -233,6 +233,7 @@ pub async fn seed(state: &ApiServerState) -> Result<()> {
                 affects_page: filter.page,
                 affects_file: filter.file,
                 affects_forum: filter.forum,
+                case_sensitive: filter.case_sensitive,
                 regex: filter.regex,
                 description: filter.description,
             },

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -118,7 +118,7 @@ impl FilterService {
                         model_regex.insert_str(0, "(?i)");
                     }
 
-                    model.regex = Set(model_regex)
+                    model.regex = Set(model_regex);
                 }
 
                 _ => {}

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -121,6 +121,7 @@ impl FilterService {
                     model.regex = Set(model_regex);
                 }
 
+                // If the regex is being changed but is case-sensitive, do not touch it.
                 _ => {}
             }
         };

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -109,7 +109,8 @@ impl FilterService {
 
                 // If the regex is not being changed, add/remove the flag from the database regex.
                 ProvidedValue::Unset => {
-                    let mut model_regex = model.get(filter::Column::Regex).as_ref().to_string();
+                    let mut model_regex =
+                        model.get(filter::Column::Regex).as_ref().to_string();
 
                     if case_sensitive {
                         model_regex = str!(model_regex.trim_start_matches("(?i)"));
@@ -331,7 +332,11 @@ impl FilterService {
                 Condition::all()
                     .add(filter::Column::SiteId.eq(site_id))
                     // Check for both case sensitive and insensitive variants
-                    .add(filter::Column::Regex.eq(regex).or(filter::Column::Regex.eq(format!("(?i){regex}"))))
+                    .add(
+                        filter::Column::Regex
+                            .eq(regex)
+                            .or(filter::Column::Regex.eq(format!("(?i){regex}"))),
+                    )
                     .add(filter::Column::DeletedAt.is_null()),
             )
             .one(txn)

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -107,14 +107,14 @@ impl FilterService {
                     regex.insert_str(0, "(?i)")
                 }
 
-                // If the regex is not being changed, add/remove the flag from the database regex.
+                // If the regex is not being changed, remove (and conditionally readd) the
+                // case-insensitivity flag from the database's regex.
                 ProvidedValue::Unset => {
-                    let mut model_regex =
-                        model.get(filter::Column::Regex).as_ref().to_string();
+                    let mut model_regex = str!(model.get(filter::Column::Regex).as_ref());
 
-                    if case_sensitive {
-                        model_regex = str!(model_regex.trim_start_matches("(?i)"));
-                    } else {
+                    model_regex = str!(model_regex.trim_start_matches("(?i)"));
+                        
+                    if !case_sensitive {
                         model_regex.insert_str(0, "(?i)");
                     }
 

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -107,6 +107,9 @@ impl FilterService {
                     regex.insert_str(0, "(?i)")
                 }
 
+                // If the regex is being changed but is case-sensitive, do not touch it.
+                ProvidedValue::Set(_) => {}
+
                 // If the regex is not being changed, remove (and conditionally readd) the
                 // case-insensitivity flag from the database's regex.
                 ProvidedValue::Unset => {
@@ -120,9 +123,6 @@ impl FilterService {
 
                     model.regex = Set(model_regex);
                 }
-
-                // If the regex is being changed but is case-sensitive, do not touch it.
-                _ => {}
             }
         };
 

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -113,7 +113,7 @@ impl FilterService {
                     let mut model_regex = str!(model.get(filter::Column::Regex).as_ref());
 
                     model_regex = str!(model_regex.trim_start_matches("(?i)"));
-                        
+
                     if !case_sensitive {
                         model_regex.insert_str(0, "(?i)");
                     }

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -155,7 +155,7 @@ pub struct CreateFilter {
     pub affects_page: bool,
     pub affects_file: bool,
     pub affects_forum: bool,
-    pub case_sensitive: bool, 
+    pub case_sensitive: bool,
     pub regex: String,
     pub description: String,
 }

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -155,6 +155,7 @@ pub struct CreateFilter {
     pub affects_page: bool,
     pub affects_file: bool,
     pub affects_forum: bool,
+    pub case_sensitive: bool, 
     pub regex: String,
     pub description: String,
 }
@@ -167,6 +168,7 @@ pub struct UpdateFilter {
     pub affects_page: ProvidedValue<bool>,
     pub affects_file: ProvidedValue<bool>,
     pub affects_forum: ProvidedValue<bool>,
+    pub case_sensitive: ProvidedValue<bool>,
     pub regex: ProvidedValue<String>,
     pub description: ProvidedValue<String>,
 }


### PR DESCRIPTION
This PR adds logic for specifying case-sensitivity for filters. This is performed by adding the `(?i)` flag to the beginning of the case-insensitive regex in the database, which specifies everything else in the regex is case-insensitive (or until it reaches a `(?-i)` flag). See [WJ-1118](https://scuttle.atlassian.net/browse/WJ-1118) for additional details.

[WJ-1118]: https://scuttle.atlassian.net/browse/WJ-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ