### PR TITLE
Bump deepwell version

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2023.4.19"
+version = "2023.4.26"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2023.4.19"
+version = "2023.4.26"
 authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 


### PR DESCRIPTION
Because the filters epic ([WJ-1112](https://scuttle.atlassian.net/browse/WJ-1112)) has been finished / merged in, this is a good time to bump the deepwell version.

[WJ-1112]: https://scuttle.atlassian.net/browse/WJ-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ