### PR TITLE
[WJ-1122] Add minimum byte length for user names/slugs.

### DIFF
--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -197,3 +197,6 @@ max-name-changes = 3
 #
 # Set to 0 to disable.
 refill-name-change-days = 90
+
+# The minimum length for a user's name in bytes.
+min-byte-length = 3

--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -199,4 +199,13 @@ max-name-changes = 3
 refill-name-change-days = 90
 
 # The minimum length for a user's name in bytes.
+# A user who attempts to register must have a slug which is at least this long.
+#
+#  The intent is to prevent the proliferation of very short, unidentifiable usernames
+# such as single Latin letters (e.g. "N"). However, we check *bytes* specifically to
+# avoid Anglo-centricism, as many full names in other languages fit within two letters
+# (consider CJK for instance). Single characters outside of the main ASCII block
+# usually take up two or three bytes themselves, making it a non-issue for those languages. 
+#
+# See WJ-1122.
 min-byte-length = 3

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -132,6 +132,7 @@ struct User {
     default_name_changes: u8,
     max_name_changes: u8,
     refill_name_change_days: u64,
+    minimum_name_bytes: u8,
 }
 
 impl ConfigFile {
@@ -210,6 +211,7 @@ impl ConfigFile {
                     default_name_changes,
                     max_name_changes,
                     refill_name_change_days,
+                    minimum_name_bytes,
                 },
         } = self;
 
@@ -263,6 +265,7 @@ impl ConfigFile {
             refill_name_change: StdDuration::from_secs(
                 refill_name_change_days * 24 * 60 * 60,
             ),
+            minimum_name_bytes: i16::from(minimum_name_bytes),
         }
     }
 }

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -132,7 +132,7 @@ struct User {
     default_name_changes: u8,
     max_name_changes: u8,
     refill_name_change_days: u64,
-    minimum_name_bytes: u8,
+    minimum_name_bytes: usize,
 }
 
 impl ConfigFile {
@@ -265,7 +265,7 @@ impl ConfigFile {
             refill_name_change: StdDuration::from_secs(
                 refill_name_change_days * 24 * 60 * 60,
             ),
-            minimum_name_bytes: i16::from(minimum_name_bytes),
+            minimum_name_bytes,
         }
     }
 }

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -114,7 +114,7 @@ pub struct Config {
     pub refill_name_change: StdDuration,
 
     /// Minimum length of bytes in a username.
-    pub minimum_name_bytes: i16,
+    pub minimum_name_bytes: usize,
 }
 
 impl Config {

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -112,6 +112,9 @@ pub struct Config {
 
     /// How long until a user gets another name change token.
     pub refill_name_change: StdDuration,
+
+    /// Minimum length of bytes in a username.
+    pub minimum_name_bytes: i16,
 }
 
 impl Config {

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -76,6 +76,9 @@ impl AliasService {
         // Then we check that the new slug doesn't already exist.
         // This also checks aliases, though we also verify down below that
         // it actually finds conflicts properly.
+        //
+        // If the alias is for a user, also ensures that it is over
+        // the minimum name length.
         match alias_type {
             AliasType::Site => {
                 if !SiteService::exists(ctx, Reference::Id(target_id)).await? {
@@ -111,6 +114,11 @@ impl AliasService {
                     );
 
                     return Err(Error::Conflict);
+                }
+
+                if slug.bytes().len() < ctx.config().minimum_name_bytes {
+                    tide::log::error!("User's name does not contain enough bytes.");
+                    return Err(Error::BadRequest);
                 }
             }
         }

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -77,7 +77,7 @@ impl AliasService {
         // This also checks aliases, though we also verify down below that
         // it actually finds conflicts properly.
         //
-        // If the alias is for a user, also ensures that it is over
+        // If the alias is for a user, also ensures that it is at least
         // the minimum name length.
         match alias_type {
             AliasType::Site => {

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -117,7 +117,12 @@ impl AliasService {
                 }
 
                 if slug.bytes().len() < ctx.config().minimum_name_bytes {
-                    tide::log::error!("User's name does not contain enough bytes.");
+                    tide::log::error!(
+                        "User's name is not long enough ({} < {})",
+                        slug.bytes().len(),
+                        ctx.config().minimum_name_bytes,
+                    );
+                    
                     return Err(Error::BadRequest);
                 }
             }

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -78,7 +78,7 @@ impl AliasService {
         // it actually finds conflicts properly.
         //
         // If the alias is for a user, also ensures that it is at least
-        // the minimum name length.
+        // the minimum name length in bytes.
         match alias_type {
             AliasType::Site => {
                 if !SiteService::exists(ctx, Reference::Id(target_id)).await? {
@@ -116,13 +116,13 @@ impl AliasService {
                     return Err(Error::Conflict);
                 }
 
-                if slug.bytes().len() < ctx.config().minimum_name_bytes {
+                if slug.len() < ctx.config().minimum_name_bytes {
                     tide::log::error!(
                         "User's name is not long enough ({} < {})",
-                        slug.bytes().len(),
+                        slug.len(),
                         ctx.config().minimum_name_bytes,
                     );
-                    
+
                     return Err(Error::BadRequest);
                 }
             }

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -59,13 +59,13 @@ impl UserService {
         tide::log::info!("Attempting to create user '{}' ('{}')", name, slug);
 
         // Check if username contains the minimum amount of required bytes.
-        if name.bytes().len() < ctx.config().minimum_name_bytes {
+        if name.len() < ctx.config().minimum_name_bytes {
             tide::log::error!(
                 "User's name is not long enough ({} < {})",
-                slug.bytes().len(),
+                slug.len(),
                 ctx.config().minimum_name_bytes,
             );
-            
+
             return Err(Error::BadRequest);
         }
 
@@ -451,10 +451,10 @@ impl UserService {
 
         // Check if the new name has the minimum required amount of bytes.
 
-        if new_name.bytes().len() < ctx.config().minimum_name_bytes {
+        if new_name.len() < ctx.config().minimum_name_bytes {
             tide::log::error!(
                 "User's name is not long enough ({} < {})",
-                new_name.bytes().len(),
+                new_name.len(),
                 ctx.config().minimum_name_bytes,
             );
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -60,7 +60,12 @@ impl UserService {
 
         // Check if username contains the minimum amount of required bytes.
         if name.bytes().len() < ctx.config().minimum_name_bytes {
-            tide::log::error!("User's name does not contain enough bytes.");
+            tide::log::error!(
+                "User's name is not long enough ({} < {})",
+                slug.bytes().len(),
+                ctx.config().minimum_name_bytes,
+            );
+            
             return Err(Error::BadRequest);
         }
 
@@ -447,7 +452,12 @@ impl UserService {
         // Check if the new name has the minimum required amount of bytes.
 
         if new_name.bytes().len() < ctx.config().minimum_name_bytes {
-            tide::log::error!("User's name does not contain enough bytes.");
+            tide::log::error!(
+                "User's name is not long enough ({} < {})",
+                new_name.bytes().len(),
+                ctx.config().minimum_name_bytes,
+            );
+
             return Err(Error::BadRequest);
         }
 


### PR DESCRIPTION
This PR adds a config option for the minimum bytes a user's name/slug must be, and adds checks for if this condition is not satisfied. See [WJ-1122](https://scuttle.atlassian.net/browse/WJ-1122).

Please be aware I am very sleep deprived, so I may have missed something important. Thorough review would be appreciated (there are only a few lines).

[WJ-1122]: https://scuttle.atlassian.net/browse/WJ-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ