### PR TITLE
[WJ-968] Add text prune job

### DIFF
--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -147,6 +147,21 @@ delay-ms = 5
 # It is merely for clearing the database of already-expired tokens.
 prune-session-secs = 600  # 5 minutes
 
+# The period, in seconds, to prune all unused text rows.
+#
+# The text table deduplicates identical text objects, and
+# their hashes are instead what is referenced from page revisions
+# etc.
+#
+# While revisions are only appended to and not deleted, it is
+# however possible for text rows to become orphaned and unused.
+# For instance, this can occur when previewing or rerendering pages.
+#
+# This job runs periodically to delete unused text rows from the database
+# to avoid clutter. However because this does not occur regularly, and
+# the cleanup query is slow, the job should be run infrequently.
+prune-text-secs = 86400  # 1 day
+
 
 [domain]
 

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -105,6 +105,7 @@ struct Mfa {
 struct Job {
     delay_ms: u64,
     prune_session_secs: u64,
+    prune_text_secs: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -200,6 +201,7 @@ impl ConfigFile {
                 Job {
                     delay_ms: job_delay_ms,
                     prune_session_secs,
+                    prune_text_secs,
                 },
             locale: Locale {
                 path: localization_path,
@@ -257,6 +259,7 @@ impl ConfigFile {
             totp_time_skew: time_skew,
             job_delay: StdDuration::from_millis(job_delay_ms),
             job_prune_session_period: StdDuration::from_secs(prune_session_secs),
+            job_prune_text_period: StdDuration::from_secs(prune_text_secs),
             render_timeout: StdDuration::from_millis(render_timeout_ms),
             default_name_changes: i16::from(default_name_changes),
             max_name_changes: i16::from(max_name_changes),

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -101,6 +101,9 @@ pub struct Config {
     /// How often to run the "prune expired sessions" recurring job.
     pub job_prune_session_period: StdDuration,
 
+    /// How often to run the "prune unused text" recurring job.
+    pub job_prune_text_period: StdDuration,
+
     /// Maximum run time for a render request.
     pub render_timeout: StdDuration,
 

--- a/deepwell/src/services/job/service.rs
+++ b/deepwell/src/services/job/service.rs
@@ -20,7 +20,7 @@
 
 use super::prelude::*;
 use crate::api::ApiServerState;
-use crate::services::{PageRevisionService, SessionService};
+use crate::services::{PageRevisionService, SessionService, TextService};
 use async_std::task;
 use crossfire::mpsc;
 use sea_orm::TransactionTrait;
@@ -128,6 +128,9 @@ impl JobRunner {
             }
             Job::PruneSessions => {
                 SessionService::prune(ctx).await?;
+            }
+            Job::PruneText => {
+                TextService::prune(ctx).await?;
             }
         }
 

--- a/deepwell/src/services/job/service.rs
+++ b/deepwell/src/services/job/service.rs
@@ -81,7 +81,7 @@ impl JobRunner {
     pub fn spawn(state: &ApiServerState) {
         // Copy configuration fields
         let session_prune_delay = state.config.job_prune_session_period;
-        let text_prune_delay = todo!(); // state.config.job_prune_text_period;
+        let text_prune_delay = state.config.job_prune_text_period;
 
         // Main runner
         let state = Arc::clone(state);

--- a/deepwell/src/services/job/structs.rs
+++ b/deepwell/src/services/job/structs.rs
@@ -22,4 +22,5 @@
 pub enum Job {
     RerenderPageId { site_id: i64, page_id: i64 },
     PruneSessions,
+    PruneText,
 }

--- a/deepwell/src/services/text.rs
+++ b/deepwell/src/services/text.rs
@@ -111,6 +111,9 @@ impl TextService {
             };
         }
 
+        // All foreign keys of text.hash should have conditions here.
+        // These foreign key constraints prevent us from deleting anything
+        // actually used.
         let txn = ctx.transaction();
         let DeleteResult { rows_affected, .. } = Text::delete_many()
             .filter(

--- a/install/files/local/deepwell.toml
+++ b/install/files/local/deepwell.toml
@@ -33,6 +33,7 @@ files = "wjfiles.localhost"
 [job]
 delay-ms = 5
 prune-session-secs = 600  # 5 minutes
+prune-text-secs = 86400  # 1 day
 
 [locale]
 path = "/opt/locales"


### PR DESCRIPTION
As noted in [WJ-968](https://scuttle.atlassian.net/browse/WJ-968), it's possible (but uncommon) for orphan text rows to exist in the `text` table. This adds a job to call `TextService::prune()`, and implements that method (previously stubbed). This job is run on the cadence specified in the configuration file.

This was tested by running a local DEEPWELL instance, it immediately ran the text prune job, which succeeded.

[WJ-968]: https://scuttle.atlassian.net/browse/WJ-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ