### PR TITLE
[WJ-1177] Add DEEPWELL configuration validation to CI

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -8,6 +8,11 @@ on:
       - 'deepwell/src/**'
       - '.github/workflows/deepwell.yaml'
       - '.gihub/codecov.yml'
+      - 'deepwell/config.example.toml'
+      - 'install/files/local/deepwell.toml'
+      # TODO: add install/files/dev/deepwell.toml
+      #       and install/files/prod/deepwell.toml
+      #       both here and below
   push:
     branches:
       - develop
@@ -42,6 +47,11 @@ jobs:
 
       - name: Build
         run: cd deepwell && cargo build
+
+      - name: Check Configuration
+        run: cd deepwell && cargo run -- config.example.toml ../install/files/local/deepwell.toml
+        env:
+          DEEPWELL_SPECIAL_ACTION: validate-config
 
       - name: Test
         run: cd deepwell && cargo test --all-features -- --nocapture --test-threads 1

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -7,7 +7,7 @@ on:
       - 'deepwell/Cargo.lock'
       - 'deepwell/src/**'
       - '.github/workflows/deepwell.yaml'
-      - '.gihub/codecov.yml'
+      - '.github/codecov.yml'
       - 'deepwell/config.example.toml'
       - 'install/files/local/deepwell.toml'
       # TODO: add install/files/dev/deepwell.toml

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -174,5 +174,21 @@ pub fn parse_args() -> Config {
         config.seeder_path = value;
     }
 
+    // Process special action, if any
+    if let Some(value) = matches.remove_one::<String>("special-action") {
+        match value.as_str() {
+            "config" => {
+                println!("Special action: Validate configuration only");
+
+                // The validation was performed earlier, so we simply exit at this stage
+                process::exit(0);
+            }
+            _ => {
+                eprintln!("Invalid special action: {value}");
+                process::exit(1);
+            }
+        }
+    }
+
     config
 }

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -105,13 +105,6 @@ pub fn parse_args() -> Config {
                 .help("The path to read translation files from."),
         )
         .arg(
-            Arg::new("special-action")
-                .short('x')
-                .long("special")
-                .action(ArgAction::Set)
-                .help("Run this special action instead of starting the daemon."),
-        )
-        .arg(
             Arg::new("config-file")
                 .value_parser(value_parser!(PathBuf))
                 .action(ArgAction::Set)
@@ -172,22 +165,6 @@ pub fn parse_args() -> Config {
 
     if let Some(value) = matches.remove_one::<PathBuf>("seeder-path") {
         config.seeder_path = value;
-    }
-
-    // Process special action, if any
-    if let Some(value) = matches.remove_one::<String>("special-action") {
-        match value.as_str() {
-            "config" => {
-                println!("Special action: Validate configuration only");
-
-                // The validation was performed earlier, so we simply exit at this stage
-                process::exit(0);
-            }
-            _ => {
-                eprintln!("Invalid special action: {value}");
-                process::exit(1);
-            }
-        }
     }
 
     config

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -105,6 +105,13 @@ pub fn parse_args() -> Config {
                 .help("The path to read translation files from."),
         )
         .arg(
+            Arg::new("special-action")
+                .short('x')
+                .long("special")
+                .action(ArgAction::Set)
+                .help("Run this special action instead of starting the daemon."),
+        )
+        .arg(
             Arg::new("config-file")
                 .value_parser(value_parser!(PathBuf))
                 .action(ArgAction::Set)

--- a/deepwell/src/config/mod.rs
+++ b/deepwell/src/config/mod.rs
@@ -36,8 +36,8 @@ pub struct SetupConfig {
 
 impl SetupConfig {
     pub fn load() -> Self {
-        let secrets = Secrets::load();
         let config = parse_args();
+        let secrets = Secrets::load();
 
         SetupConfig { secrets, config }
     }

--- a/deepwell/src/config/mod.rs
+++ b/deepwell/src/config/mod.rs
@@ -28,7 +28,7 @@ pub use self::object::Config;
 pub use self::secrets::Secrets;
 
 use self::args::parse_args;
-use self::special_action::SpecialAction;
+use self::special_action::run_special_action;
 
 #[derive(Debug, Clone)]
 pub struct SetupConfig {
@@ -38,8 +38,7 @@ pub struct SetupConfig {
 
 impl SetupConfig {
     pub fn load() -> Self {
-        SpecialAction::run(); // if set, run the action then quit
-
+        run_special_action();
         let secrets = Secrets::load();
         let config = parse_args();
 

--- a/deepwell/src/config/special_action.rs
+++ b/deepwell/src/config/special_action.rs
@@ -67,5 +67,6 @@ fn validate_config() -> i32 {
         }
     }
 
+    println!("All passed files checked, exiting");
     return_code
 }

--- a/deepwell/src/config/special_action.rs
+++ b/deepwell/src/config/special_action.rs
@@ -31,10 +31,7 @@ use std::{env, process};
 pub fn run_special_action() {
     // Get action name, if specified.
     // Otherwise return and perform normal execution.
-    let action_name = match env::var("DEEPWELL_SPECIAL_ACTION") {
-        Ok(value) => value,
-        Err(_) => return,
-    };
+    let Ok(action_name) = env::var("DEEPWELL_SPECIAL_ACTION") else { return };
 
     // Run appropriate special action.
     let return_code = match action_name.as_str() {

--- a/deepwell/src/config/special_action.rs
+++ b/deepwell/src/config/special_action.rs
@@ -1,5 +1,5 @@
 /*
- * config/mod.rs
+ * config/special_action.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2023 Wikijump Team
@@ -18,31 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-mod args;
-mod file;
-mod object;
-mod secrets;
-mod special_action;
+#[derive(Debug)]
+pub enum SpecialAction {}
 
-pub use self::object::Config;
-pub use self::secrets::Secrets;
-
-use self::args::parse_args;
-use self::special_action::SpecialAction;
-
-#[derive(Debug, Clone)]
-pub struct SetupConfig {
-    pub secrets: Secrets,
-    pub config: Config,
-}
-
-impl SetupConfig {
-    pub fn load() -> Self {
-        SpecialAction::run(); // if set, run the action then quit
-
-        let secrets = Secrets::load();
-        let config = parse_args();
-
-        SetupConfig { secrets, config }
-    }
+impl SpecialAction {
+    pub fn run() {}
 }


### PR DESCRIPTION
To avoid issues where typos or not-yet-updated documentation (i.e. `config.example.toml`) cause runtime issues with using such a configuration file in a deployment, here we add a CI step to validate configuration files before merge.

This is implemented by adding a concept of "special action" to deepwell, set via env variable, which can specify the executable to perform a special task instead of running a server. In this case, we have it coherency check all the configuration files passed in on the command line.