### PR TITLE
Add checks to disallow empty slugs

### DIFF
--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -615,6 +615,11 @@ impl PageService {
     ) -> Result<()> {
         let txn = ctx.transaction();
 
+        if slug.is_empty() {
+            tide::log::error!("Cannot create page with empty slug");
+            return Err(Error::BadRequest);
+        }
+
         let result = Page::find()
             .filter(
                 Condition::all()

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -257,6 +257,11 @@ impl SiteService {
     ) -> Result<()> {
         let txn = ctx.transaction();
 
+        if slug.is_empty() {
+            tide::log::error!("Cannot create site with empty slug");
+            return Err(Error::BadRequest);
+        }
+
         let result = Site::find()
             .filter(
                 Condition::all()

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -58,6 +58,12 @@ impl UserService {
 
         tide::log::info!("Attempting to create user '{}' ('{}')", name, slug);
 
+        // Empty slug check
+        if slug.is_empty() {
+            tide::log::error!("Cannot create user with empty slug");
+            return Err(Error::BadRequest);
+        }
+
         // Check if username contains the minimum amount of required bytes.
         if name.len() < ctx.config().minimum_name_bytes {
             tide::log::error!(
@@ -66,12 +72,6 @@ impl UserService {
                 ctx.config().minimum_name_bytes,
             );
 
-            return Err(Error::BadRequest);
-        }
-
-        // Empty slug check
-        if slug.is_empty() {
-            tide::log::error!("Cannot create user with empty slug");
             return Err(Error::BadRequest);
         }
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -69,6 +69,12 @@ impl UserService {
             return Err(Error::BadRequest);
         }
 
+        // Empty slug check
+        if slug.is_empty() {
+            tide::log::error!("Cannot create user with empty slug");
+            return Err(Error::BadRequest);
+        }
+
         // Perform filter validation
         if !bypass_filter {
             try_join!(
@@ -410,6 +416,12 @@ impl UserService {
 
         let new_slug = get_regular_slug(&new_name);
         let old_slug = &user.slug;
+
+        // Empty slug check
+        if new_slug.is_empty() {
+            tide::log::error!("Cannot create user with empty slug");
+            return Err(Error::BadRequest);
+        }
 
         // Perform filter validation
         if !bypass_filter {


### PR DESCRIPTION
Turns out that you were allowed to make users/sites/pages with an empty slug, since it was technically already normalized. Oops!

Tested with local deployment.