### PR TITLE
Add special page for banned users

### DIFF
--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -224,6 +224,13 @@ missing = "_404"
 # Fallback string is localized as "wiki-page-private"
 private = "_public"
 
+# When a user is banned from the site.
+# This is only shown if the site disallows banned users from
+# being able to see pages.
+#
+# Fallback string is localized as "wiki-page-banned"
+banned = "_ban"
+
 
 [user]
 

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -135,6 +135,7 @@ struct SpecialPages {
     template: String,
     missing: String,
     private: String,
+    banned: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -224,6 +225,7 @@ impl ConfigFile {
                     template: special_page_template,
                     missing: special_page_missing,
                     private: special_page_private,
+                    banned: special_page_banned,
                 },
             user:
                 User {
@@ -286,6 +288,7 @@ impl ConfigFile {
             special_page_template,
             special_page_missing,
             special_page_private,
+            special_page_banned,
             default_name_changes: i16::from(default_name_changes),
             maximum_name_changes: i16::from(maximum_name_changes),
             refill_name_change: StdDuration::from_secs(

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -129,6 +129,9 @@ pub struct Config {
     /// Page slug for pages you don't have permission to see. Default: `_public`
     pub special_page_private: String,
 
+    /// Page slug for when the user is banned, and the site disallows banned viewing. Default: `_ban`
+    pub special_page_banned: String,
+
     /// Default name changes per user.
     pub default_name_changes: i16,
 

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -57,6 +57,9 @@ impl SpecialPageService {
             SpecialPageType::Private => {
                 (&config.special_page_private, "wiki-page-private")
             }
+            SpecialPageType::Banned => {
+                (&config.special_page_banned, "wiki-page-banned")
+            }
         };
 
         let wikitext = match PageService::get_optional(

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -57,9 +57,7 @@ impl SpecialPageService {
             SpecialPageType::Private => {
                 (&config.special_page_private, "wiki-page-private")
             }
-            SpecialPageType::Banned => {
-                (&config.special_page_banned, "wiki-page-banned")
-            }
+            SpecialPageType::Banned => (&config.special_page_banned, "wiki-page-banned"),
         };
 
         let wikitext = match PageService::get_optional(

--- a/deepwell/src/services/special_page/structs.rs
+++ b/deepwell/src/services/special_page/structs.rs
@@ -26,6 +26,7 @@ pub enum SpecialPageType {
     Template,
     Missing,
     Private,
+    Banned,
 }
 
 #[derive(Serialize, Debug)]

--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -29,6 +29,13 @@ use crate::models::user::Model as UserModel;
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct UserPermissions;
 
+impl UserPermissions {
+    pub fn is_banned(self) -> bool {
+        // TODO value from struct
+        false
+    }
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetPageView {
@@ -77,6 +84,7 @@ pub enum GetPageViewOutput {
         options: PageOptions,
         redirect_page: Option<String>,
         compiled_html: String,
+        banned: bool,
     },
 
     #[serde(rename_all = "camelCase")]

--- a/install/files/local/deepwell.toml
+++ b/install/files/local/deepwell.toml
@@ -46,6 +46,7 @@ special-prefix = "_"
 template = "_template"
 missing = "_404"
 private = "_public"
+banned = "_ban"
 
 [user]
 default-name-changes = 2

--- a/locales/fluent/wiki-page/en.ftl
+++ b/locales/fluent/wiki-page/en.ftl
@@ -20,6 +20,10 @@ wiki-page-private = + Private content
 
     This area of the website is private and you don't have access to it. If you believe you need access to this area please contact the web site administrators.
 
+wiki-page-banned = + You have been banned
+
+    You are currently banned from this site, and the site settings do not allow banned users to view pages.
+
 wiki-page-site-slug = <h1>No { -service-name } site exists with this address.</h1>
     <p>
       <a href="https://{ $slug }.{ $domain }/">{ $slug }.{ $domain }</a> does not exist.


### PR DESCRIPTION
Currently if you are banned from a Wikidot site, you are shown a generic, un-customizable page permissions error. This is poor UX, as EN at least doesn't mind banned users _reading_ the site (since it's public anyways), and the error message suggests it's an issue on _our_ end and not _their_ end, resulting in unnecessary inquiries.

We won't be carrying this behavior over, but we can add a site setting to, if the site staff decide to, disallow banned users from having read access. In this case, we should provide a special message for banned users, and allow it to be customized.

This is done by adding a `_ban` special page which is like `_public` but displays for banned users, specifically where site settings also disallow them from reading the site. If they are banned but have read-only access, this error is _not_ displayed.