### PR TITLE
Add specific category support to missing special pages

### DIFF
--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -66,10 +66,13 @@ impl SpecialPageService {
                     // If not in _default, add category-specific template
                     // to check first, if it exists.
                     (None, slug) => {
-                        let mut slugs = vec![cow!(slug)];
+                        let mut slugs = Vec::with_capacity(2);
+                        slugs.push(cow!(slug));
+
                         if let Some(ref category) = page_info.category {
                             slugs.insert(0, Cow::Owned(format!("{category}:{slug}")));
                         }
+
                         slugs
                     }
                 };

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -52,6 +52,9 @@ impl SpecialPageService {
         let config = ctx.config();
         let (slug, key) = match sp_page_type {
             SpecialPageType::Template => (cow!(config.special_page_template), ""),
+            SpecialPageType::Private => {
+                (cow!(config.special_page_private), "wiki-page-private")
+            }
             SpecialPageType::Missing => {
                 let slug = match split_category(&config.special_page_missing) {
                     // Has category explicitly, only use this exact slug.
@@ -65,9 +68,6 @@ impl SpecialPageService {
                 };
 
                 (slug, "wiki-page-missing")
-            }
-            SpecialPageType::Private => {
-                (cow!(config.special_page_private), "wiki-page-private")
             }
         };
 

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -50,19 +50,19 @@ impl SpecialPageService {
         // If empty, then pull a constant string (not in the localization files).
         let config = ctx.config();
         let (slug, key) = match sp_page_type {
-            SpecialPageType::Template => (&config.special_page_template, ""),
+            SpecialPageType::Template => (cow!(config.special_page_template), ""),
             SpecialPageType::Missing => {
-                (&config.special_page_missing, "wiki-page-missing")
+                (cow!(config.special_page_missing), "wiki-page-missing")
             }
             SpecialPageType::Private => {
-                (&config.special_page_private, "wiki-page-private")
+                (cow!(config.special_page_private), "wiki-page-private")
             }
         };
 
         let wikitext = match PageService::get_optional(
             ctx,
             site.site_id,
-            Reference::Slug(cow!(slug)),
+            Reference::Slug(slug),
         )
         .await?
         {

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -59,20 +59,22 @@ impl SpecialPageService {
                 (vec![cow!(config.special_page_private)], "wiki-page-private")
             }
             SpecialPageType::Missing => {
-                let slug = match split_category(&config.special_page_missing) {
+                let slugs = match split_category(&config.special_page_missing) {
                     // Has category explicitly, only use this exact slug.
                     (Some(_), slug) => vec![cow!(slug)],
 
-                    // Draw from the same category.
-                    (None, slug) => match page_info.category {
-                        Some(ref category) => {
-                            vec![Cow::Owned(format!("{category}:{slug}")), cow!(slug)]
+                    // If not in _default, add category-specific template
+                    // to check first, if it exists.
+                    (None, slug) => {
+                        let mut slugs = vec![cow!(slug)];
+                        if let Some(ref category) = page_info.category {
+                            slugs.insert(0, Cow::Owned(format!("{category}:{slug}")));
                         }
-                        None => vec![cow!(slug)],
-                    },
+                        slugs
+                    }
                 };
 
-                (slug, "wiki-page-missing")
+                (slugs, "wiki-page-missing")
             }
         };
         debug_assert!(


### PR DESCRIPTION
When you visit a page that doesn't exist, it pulls the message to display from `_404`. But to be more specific, it first checks the _current category's_ `_404` page, then if that doesn't exist it goes to the site-wide one.

I implement this by changing the single slug to check into a list, and then the first one to exist is used. Then if all are missing, it uses the localization fallback (this has been split into a helper method). For missing pages, I have a little routine that adds the category-specific slug if contextually relevant.

Missing page, category-specific `_404`:
![image](https://github.com/scpwiki/wikijump/assets/8848022/e1a9804e-4ace-49cf-9a3b-86fa4098902a)

Missing page, no category-specific `_404`:
![image](https://github.com/scpwiki/wikijump/assets/8848022/c0d779c2-ef9e-4cf0-9b7d-074d549feb03)
