### PR TITLE
Add cdn.wikijump.com to default filter

### DIFF
--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -99,6 +99,13 @@
     },
     {
         "site": null,
+        "regex": "^cdn$",
+        "description": "Reserved name (cdn)",
+        "case_sensitive": false,
+        "user": true
+    },
+    {
+        "site": null,
         "regex": "^(ssl|tls)$",
         "description": "Reserved name (ssl / tls)",
         "case_sensitive": false,


### PR DESCRIPTION
Similar to other technical-related terms like "login" and "account", we should disallow `cdn.wikijump.com` from being a site slug.