### PR TITLE
[WJ-1180] Fix loading page data in +error.svelte

### DIFF
--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -1,6 +1,6 @@
 import { pageView } from "$lib/server/deepwell/views.ts"
 import type { Optional } from "$lib/types.ts"
-import { redirect } from "@sveltejs/kit"
+import { error, redirect } from "@sveltejs/kit"
 
 // TODO form single deepwell request that does all the relevant prep stuff here
 
@@ -51,8 +51,7 @@ export async function loadPage(
   }
 
   if (errorStatus !== null) {
-    // TODO fix +error.svelte?
-    // throw error(errorStatus, viewData)
+    throw error(errorStatus, viewData)
   }
 
   // TODO remove checkRedirect when errorStatus is fixed

--- a/framerail/src/routes/+error.svelte
+++ b/framerail/src/routes/+error.svelte
@@ -4,24 +4,21 @@
 
 <h1>UNTRANSLATED:Svelte Error</h1>
 
-<!-- What's going on here? Every guide says the error() call
-data appears in "page", but it's empty. I can't render an error
-page without contextual information. -->
-<textarea class="debug">{JSON.stringify(page)}</textarea>
+<p><textarea class="debug">{JSON.stringify($page)}</textarea></p>
 
 <!--
 Use svelte-switch-case package with {#switch data.view}
 as soon as we can figure out prettier support for it.
 -->
-{#if page.error.view === "pageMissing"}
+{#if $page.error.view === "pageMissing"}
   UNTRANSLATED:Page not found
-  {@html page.error.compiledHtml}
-{:else if page.error.view === "pagePermissions"}
+  {@html $page.error.compiledHtml}
+{:else if $page.error.view === "pagePermissions"}
   UNTRANSLATED:Lacks permissions for page
-  {@html page.error.compiledHtml}
-{:else if page.error.view === "siteMissing"}
+  {@html $page.error.compiledHtml}
+{:else if $page.error.view === "siteMissing"}
   UNTRANSLATED:No such site
-  {@html page.error.html}
+  {@html $page.error.html}
 {:else}
   UNTRANSLATED:Fallback error, something really went wrong
 {/if}

--- a/framerail/src/routes/+page.svelte
+++ b/framerail/src/routes/+page.svelte
@@ -10,17 +10,6 @@
 
 {@html data.compiledHtml}
 
-{#if data.view === "pageMissing"}
-  UNTRANSLATED:TODO fix error page
-  {@html data.compiledHtml}
-{:else if data.view === "pagePermissions"}
-  UNTRANSLATED:TODO fix error page
-  {@html data.compiledHtml}
-{:else if data.view === "siteMissing"}
-  UNTRANSLATED:TODO fix error page
-  {@html data.html}
-{/if}
-
 <style global lang="scss">
   @keyframes spin {
     from {


### PR DESCRIPTION
Turns out you need to do `$page` for loading values from store.