### PR TITLE
[WJ-1186] Multiple translation requests per call

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -132,7 +132,7 @@ fn build_routes(mut app: ApiServer) -> ApiServer {
 
     // Localization
     app.at("/locale/:locale").get(locale_get);
-    app.at("/message/:locale/:message_key").put(message_put);
+    app.at("/message/:locale/translate").put(translate_put);
 
     // Routes for web server
     app.at("/view/page").put(view_page);

--- a/deepwell/src/endpoints/locale.rs
+++ b/deepwell/src/endpoints/locale.rs
@@ -64,7 +64,10 @@ pub async fn translate_put(mut req: ApiRequest) -> ApiResponse {
     let mut output: TranslateOutput = HashMap::new();
 
     for (message_key, arguments_raw) in input {
-        tide::log::debug!("Formatting message key {message_key}");
+        tide::log::info!(
+            "Formatting message key {message_key} ({} arguments)",
+            arguments_raw.len(),
+        );
 
         let arguments = arguments_raw.into_fluent_args();
         match localizations.translate(&locale, &message_key, &arguments) {

--- a/deepwell/src/endpoints/locale.rs
+++ b/deepwell/src/endpoints/locale.rs
@@ -21,6 +21,7 @@
 use super::prelude::*;
 use crate::locales::MessageArguments;
 use ref_map::*;
+use std::collections::HashMap;
 use unic_langid::LanguageIdentifier;
 
 #[derive(Serialize, Debug)]
@@ -30,6 +31,9 @@ struct LocaleOutput<'a> {
     region: Option<&'a str>,
     variants: Vec<String>,
 }
+
+type TranslateInput<'a> = HashMap<String, MessageArguments<'a>>;
+type TranslateOutput = HashMap<String, String>;
 
 pub async fn locale_get(req: ApiRequest) -> ApiResponse {
     let locale_str = req.param("locale")?;
@@ -47,22 +51,29 @@ pub async fn locale_get(req: ApiRequest) -> ApiResponse {
     Ok(body.into())
 }
 
-pub async fn message_put(mut req: ApiRequest) -> ApiResponse {
-    let input: MessageArguments = req.body_json().await?;
+pub async fn translate_put(mut req: ApiRequest) -> ApiResponse {
+    let input: TranslateInput = req.body_json().await?;
     let locale_str = req.param("locale")?;
-    let message_key = req.param("message_key")?;
-    tide::log::info!("Formatting message key {message_key} in locale {locale_str}");
+    let localizations = &req.state().localizations;
+    tide::log::info!(
+        "Translating {} message keys in locale {locale_str}",
+        input.len(),
+    );
 
     let locale = LanguageIdentifier::from_bytes(locale_str.as_bytes())?;
-    let arguments = input.into_fluent_args();
+    let mut output: TranslateOutput = HashMap::new();
 
-    let result = req
-        .state()
-        .localizations
-        .translate(&locale, message_key, &arguments);
+    for (message_key, arguments_raw) in input {
+        tide::log::debug!("Formatting message key {message_key}");
 
-    match result {
-        Ok(message) => Ok(message.as_ref().into()),
-        Err(error) => Err(ServiceError::from(error).into_tide_error()),
+        let arguments = arguments_raw.into_fluent_args();
+        match localizations.translate(&locale, &message_key, &arguments) {
+            Ok(translation) => output.insert(message_key, translation.to_string()),
+            Err(error) => return Err(ServiceError::from(error).into_tide_error()),
+        };
     }
+
+    let body = Body::from_json(&output)?;
+    let response = Response::builder(StatusCode::Ok).body(body).into();
+    Ok(response)
 }

--- a/deepwell/src/locales/arguments.rs
+++ b/deepwell/src/locales/arguments.rs
@@ -38,6 +38,11 @@ impl<'a> MessageArguments<'a> {
 
         args
     }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
This replaces the `PUT /message/:locale/:message_key` call (which translates one message key) with `PUT /message/:locale/translate` (which translates many).

The request body is the following:
```json
{
    "message-key-1": {
        "variable-1": 100,
        "variable-2": "foo"
    },
    "message-key-2": {}
}
```

This will return a JSON object where each key corresponds to the translated message:
```json
{
    "message-key-1": "100 new foo objects have been successfully initialized.",
    "message-key-2": "Create new page"
}
```