### PR TITLE
[WJ-1187] Automatic reload on configuration change

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -45,8 +45,11 @@ jobs:
       - name: System Dependencies
         run: sudo apt update && sudo apt install libmagic-dev
 
-      - name: Build
-        run: cd deepwell && cargo build
+      - name: Build (local)
+        run: cd deepwell && cargo build --features local
+
+      - name: Build (deploy)
+        run: cd deepwell && cargo build --features deploy
 
       - name: Check Configuration
         run: cd deepwell && cargo run -- config.example.toml ../install/files/local/deepwell.toml

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "arraystring",
  "async-std",
  "built",
+ "cfg-if 1.0.0",
  "clap",
  "color-backtrace",
  "crossfire",

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "hostname",
  "intl-memoizer",
  "lazy_static",
+ "notify-debouncer-mini",
  "otp",
  "rand 0.8.5",
  "ref-map",
@@ -1550,6 +1551,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2147,6 +2169,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2299,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2477,6 +2539,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2569,36 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
 ]
 
 [[package]]
@@ -3552,6 +3656,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -5033,6 +5146,16 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
  "hostname",
  "intl-memoizer",
  "lazy_static",
- "notify-debouncer-mini",
+ "notify",
  "otp",
  "rand 0.8.5",
  "ref-map",
@@ -2589,17 +2589,6 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys",
-]
-
-[[package]]
-name = "notify-debouncer-mini"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
-dependencies = [
- "crossbeam-channel",
- "log",
- "notify",
 ]
 
 [[package]]

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -12,6 +12,11 @@ version = "2023.5.14"
 authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 
+[features]
+local = ["notify"]
+deploy = []
+notify = ["notify-debouncer-mini"]
+
 [dependencies]
 anyhow = "1"
 arraystring = "0.3"
@@ -32,6 +37,7 @@ hex = "0.4"
 hostname = "0.3"
 intl-memoizer = "0.5"
 lazy_static = "1"
+notify-debouncer-mini = { version = "0.4", optional = true }
 otp = { git = "https://github.com/TimDumol/rust-otp" }
 rand = "0.8"
 ref-map = "0.1"

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1"
 arraystring = "0.3"
 argon2 = "0.5"
 async-std = { version = "1", features = ["attributes"] }
+cfg-if = "1"
 clap = "4"
 color-backtrace = "0.6"
 crossfire = "1.0"

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -13,9 +13,9 @@ authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 
 [features]
-local = ["notify"]
+local = ["watch"]
 deploy = []
-notify = ["notify-debouncer-mini"]
+watch = ["notify"]
 
 [dependencies]
 anyhow = "1"
@@ -38,7 +38,7 @@ hex = "0.4"
 hostname = "0.3"
 intl-memoizer = "0.5"
 lazy_static = "1"
-notify-debouncer-mini = { version = "0.4", optional = true }
+notify = { version = "6", optional = true }
 otp = { git = "https://github.com/TimDumol/rust-otp" }
 rand = "0.8"
 ref-map = "0.1"

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -58,6 +58,12 @@ This executable targets the latest stable Rust. At time of writing, that is `1.7
 $ cargo build --release
 ```
 
+There are two features supported by DEEPWELL, along with what they add:
+
+* `local` &mdash; Intended for local development, where frequent compilation is likely.
+ * Tracks the locale directory and configuration file, reloading them if they are modified.
+* `deploy` &mdash; Intended for "deployed" environments, i.e. `dev` and `prod`.
+
 ### Testing
 
 Tests have not yet been implemented, but when they are, run:

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -80,7 +80,7 @@ $ cargo build --features <deploy|local> -- [-q] [-p <port>] <config-file>
 
 There are a number of arguments beyond the ones shown. Run with `--help` for all relevant information.
 
-This runs a local instance of DEEPWELL with the given configuration file. When debugging (i.e. on `--features local` only), you can also pass in `-w` or `--watch-config` to have the process to restart automatically when the configuration file or any localization files change.
+This runs a local instance of DEEPWELL with the given configuration file. When debugging (i.e. on `--features local` only), you can also pass in `-w` or `--watch-files` to have the process to restart automatically when the configuration file or any localization files change.
 
 ### Testing
 

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -54,15 +54,23 @@ The routes are defined in `api/`, with their implementations in `methods/`, and 
 
 This executable targets the latest stable Rust. At time of writing, that is `1.72.0`.
 
-```sh
-$ cargo build --release
-```
-
 There are two features supported by DEEPWELL, along with what they add:
 
 * `local` &mdash; Intended for local development, where frequent compilation is likely.
  * Tracks the locale directory and configuration file, reloading them if they are modified.
 * `deploy` &mdash; Intended for "deployed" environments, i.e. `dev` and `prod`.
+
+Thus for a _release build_ (being deployed somewhere) you would want to run:
+
+```sh
+$ cargo build --release --features deploy
+```
+
+And for a _local build_ you would want:
+
+```sh
+$ cargo build --features local
+```
 
 ### Testing
 

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -36,7 +36,7 @@ $ scripts/generate-models.sh
 The primary organization of the crate is as follows:
 
 * `api/` &mdash; Web server definition, such as its routes and related structures.
-  * Each API is namespaced based on its version. The primary version of interest is the "internal" API, which is consumed by PHP and not meant for outside consumption due to it providing unguarded access.
+  * Exposes the internal API for use by Framerail.
 * `endpoints/` &mdash; Implementations for individual endpoints described above.
 * `services/` &mdash; "Services", or logical encapsulations of different concepts or operations.
   * For instance, the `ParentService` allows retrieving and storing data related to parent-child page relationships. You can think of it as "wrapping" the `page_parent` table.

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -72,6 +72,16 @@ And for a _local build_ you would want:
 $ cargo build --features local
 ```
 
+### Execution
+
+```sh
+$ cargo build --features <deploy|local> -- [-q] [-p <port>] <config-file>
+```
+
+There are a number of arguments beyond the ones shown. Run with `--help` for all relevant information.
+
+This runs a local instance of DEEPWELL with the given configuration file. When debugging (i.e. on `--features local` only), you can also pass in `-w` or `--watch-config` to have the process to restart automatically when the configuration file or any localization files change.
+
 ### Testing
 
 Tests have not yet been implemented, but when they are, run:

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -82,6 +82,8 @@ There are a number of arguments beyond the ones shown. Run with `--help` for all
 
 This runs a local instance of DEEPWELL with the given configuration file. When debugging (i.e. on `--features local` only), you can also pass in `-w` or `--watch-files` to have the process to restart automatically when the configuration file or any localization files change.
 
+This does not seem to work with Docker, so you should instead manually stop the `api` container and run it locally with the flag. That will properly watch changes and restart itself.
+
 ### Testing
 
 Tests have not yet been implemented, but when they are, run:

--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -63,7 +63,7 @@ authentication-fail-delay-ms = 100
 [security.session]
 
 # All session tokens are prefixed with this string.
-# It makes a session token immediately reecognizable
+# It makes a session token immediately recognizable
 # as it is otherwise a long random string.
 token-prefix = "wj:"
 
@@ -246,7 +246,7 @@ maximum-name-changes = 3
 # The minimum length for a user's name in bytes.
 # A user who attempts to register must have a slug which is at least this long.
 #
-#  The intent is to prevent the proliferation of very short, unidentifiable usernames
+# The intent is to prevent the proliferation of very short, unidentifiable usernames
 # such as single Latin letters (e.g. "N"). However, we check *bytes* specifically to
 # avoid Anglo-centricism, as many full names in other languages fit within two letters
 # (consider CJK for instance). Single characters outside of the main ASCII block

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -126,6 +126,7 @@ fn build_routes(mut app: ApiServer) -> ApiServer {
     app.at("/version/full").get(full_version);
     app.at("/hostname").get(hostname);
     app.at("/config").get(config_dump);
+    app.at("/config/path").get(config_path);
     app.at("/normalize/:input").all(normalize_method);
     app.at("/teapot")
         .all(|_| async { error_response(StatusCode::ImATeapot, "🫖") });

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -73,9 +73,7 @@ pub fn parse_args() -> Config {
             Arg::new("watch-config")
                 .short('w')
                 .long("watch")
-                .value_name("BOOLEAN")
-                .value_parser(BoolishValueParser::new())
-                .action(ArgAction::Set)
+                .action(ArgAction::SetTrue)
                 .help("Whether to auto-restart when configuration or localization files change."),
         )
         .arg(
@@ -160,8 +158,8 @@ pub fn parse_args() -> Config {
         config.address.set_port(value);
     }
 
-    if let Some(value) = matches.remove_one::<bool>("watch-config") {
-        config.watch_files = value;
+    if matches.remove_one::<bool>("watch-config") == Some(true) {
+        config.watch_files = true;
     }
 
     if let Some(value) = matches.remove_one::<bool>("run-migrations") {

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -70,6 +70,15 @@ pub fn parse_args() -> Config {
                 .help("What port to listen on."),
         )
         .arg(
+            Arg::new("watch-config")
+                .short('w')
+                .long("watch")
+                .value_name("BOOLEAN")
+                .value_parser(BoolishValueParser::new())
+                .action(ArgAction::Set)
+                .help("Whether to auto-restart when configuration or localization files change."),
+        )
+        .arg(
             Arg::new("run-migrations")
                 .short('M')
                 .long("migrate")
@@ -149,6 +158,10 @@ pub fn parse_args() -> Config {
 
     if let Some(value) = matches.remove_one::<u16>("port") {
         config.address.set_port(value);
+    }
+
+    if let Some(value) = matches.remove_one::<bool>("watch-config") {
+        config.watch_files = value;
     }
 
     if let Some(value) = matches.remove_one::<bool>("run-migrations") {

--- a/deepwell/src/config/args.rs
+++ b/deepwell/src/config/args.rs
@@ -119,7 +119,7 @@ pub fn parse_args() -> Config {
         .remove_one::<PathBuf>("config-file")
         .expect("Required argument not provided");
 
-    let mut config = match Config::load(&config_path) {
+    let mut config = match Config::load(config_path) {
         Ok(config) => config,
         Err(error) => {
             eprintln!("Unable to load configuration from file: {error}");

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -157,7 +157,7 @@ impl ConfigFile {
     }
 
     /// Deconstruct the `ConfigFile` and flatten it as a `Config` object.
-    pub fn into_config(self, raw_toml: String) -> Config {
+    pub fn into_config(self, raw_toml: String, raw_toml_path: PathBuf) -> Config {
         macro_rules! time_duration {
             // Convert a stdlib duration into a 'time' crate duration
             ($method:ident, $value:expr $(,)?) => {{
@@ -251,6 +251,7 @@ impl ConfigFile {
 
         Config {
             raw_toml,
+            raw_toml_path,
             logger,
             logger_level,
             address,

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -22,7 +22,7 @@ use super::file::ConfigFile;
 use anyhow::Result;
 use std::env;
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration as StdDuration;
 use tide::log::LevelFilter;
 use time::Duration as TimeDuration;
@@ -35,6 +35,9 @@ use time::Duration as TimeDuration;
 pub struct Config {
     /// The raw TOML data that was read on server load.
     pub raw_toml: String,
+
+    /// The path where the above raw TOML data was read from.
+    pub raw_toml_path: PathBuf,
 
     /// Whether the logger should be enabled or not.
     /// Also enables colorful backtraces.
@@ -147,9 +150,9 @@ pub struct Config {
 
 impl Config {
     #[inline]
-    pub fn load(path: &Path) -> Result<Self> {
-        let (config_file, raw_toml) = ConfigFile::load(path)?;
-        let config = ConfigFile::into_config(config_file, raw_toml);
+    pub fn load(path: PathBuf) -> Result<Self> {
+        let (config_file, raw_toml) = ConfigFile::load(&path)?;
+        let config = ConfigFile::into_config(config_file, raw_toml, path);
         Ok(config)
     }
 

--- a/deepwell/src/config/special_action.rs
+++ b/deepwell/src/config/special_action.rs
@@ -56,7 +56,7 @@ fn validate_config() -> i32 {
         let path = PathBuf::from(value);
         print!("Checking {}... ", path.display());
 
-        match Config::load(&path) {
+        match Config::load(path) {
             Ok(_) => println!("success"),
             Err(error) => {
                 println!("error");

--- a/deepwell/src/endpoints/misc.rs
+++ b/deepwell/src/endpoints/misc.rs
@@ -62,6 +62,13 @@ pub async fn config_dump(req: ApiRequest) -> ApiResponse {
     Ok(body.into())
 }
 
+pub async fn config_path(req: ApiRequest) -> ApiResponse {
+    tide::log::info!("Dumping DEEPWELL configuration path for debugging");
+    let toml_path = &req.state().config.raw_toml_path;
+    let body = Body::from_string(toml_path.display().to_string());
+    Ok(body.into())
+}
+
 pub async fn normalize_method(req: ApiRequest) -> ApiResponse {
     let input = req.param("input")?;
     tide::log::info!("Running normalize as utility web method: {input}");

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -39,6 +39,9 @@ extern crate str_macro;
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "notify")]
+mod restart;
+
 mod api;
 mod config;
 mod constants;
@@ -52,6 +55,9 @@ mod services;
 mod utils;
 mod web;
 
+#[cfg(feature = "notify")]
+use self::restart::setup_autorestart;
+
 use self::config::SetupConfig;
 use anyhow::Result;
 use std::fs::File;
@@ -62,6 +68,10 @@ use std::process;
 async fn main() -> Result<()> {
     // Load the configuration so we can set up
     let SetupConfig { secrets, config } = SetupConfig::load();
+
+    // Set up restart-on-config change (if feature enabled)
+    #[cfg(feature = "notify")]
+    setup_autorestart(&config)?;
 
     // Copy fields we need
     let socket_address = config.address;

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -69,10 +69,6 @@ async fn main() -> Result<()> {
     // Load the configuration so we can set up
     let SetupConfig { secrets, config } = SetupConfig::load();
 
-    // Set up restart-on-config change (if feature enabled)
-    #[cfg(feature = "notify")]
-    setup_autorestart(&config)?;
-
     // Copy fields we need
     let socket_address = config.address;
     let run_migrations = config.run_migrations;
@@ -106,6 +102,10 @@ async fn main() -> Result<()> {
 
     // Set up server state
     let app_state = api::build_server_state(config, secrets).await?;
+
+    // Set up restart-on-config change (if feature enabled)
+    #[cfg(feature = "notify")]
+    setup_autorestart(&app_state)?;
 
     // Run seeder, if enabled
     if run_seeder {

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -106,10 +106,11 @@ async fn main() -> Result<()> {
     let app_state = api::build_server_state(config, secrets).await?;
 
     // Set up restart-on-config change (if feature enabled)
+    let watcher;
     if watch_files {
         cfg_if! {
             if #[cfg(feature = "notify")] {
-                setup_autorestart(&app_state)?;
+                watcher = setup_autorestart(&app_state)?;
             } else {
                 tide::log::error!("The --watch-files option requires the 'notify' feature");
                 process::exit(1);

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -97,7 +97,9 @@ async fn main() -> Result<()> {
     }
 
     // Set up restart-on-config change (if feature enabled)
+    #[cfg(feature = "watch")]
     let _watcher;
+
     if config.watch_files {
         cfg_if! {
             if #[cfg(feature = "watch")] {

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -39,7 +39,7 @@ extern crate str_macro;
 #[macro_use]
 mod macros;
 
-#[cfg(feature = "notify")]
+#[cfg(feature = "watch")]
 mod watch;
 
 mod api;
@@ -100,10 +100,10 @@ async fn main() -> Result<()> {
     let _watcher;
     if config.watch_files {
         cfg_if! {
-            if #[cfg(feature = "notify")] {
+            if #[cfg(feature = "watch")] {
                 _watcher = setup_autorestart(&config)?;
             } else {
-                tide::log::error!("The --watch-files option requires the 'notify' feature");
+                tide::log::error!("The --watch-files option requires the 'watch' feature");
                 process::exit(1);
             }
         }

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -40,7 +40,7 @@ extern crate str_macro;
 mod macros;
 
 #[cfg(feature = "notify")]
-mod restart;
+mod watch;
 
 mod api;
 mod config;
@@ -56,7 +56,7 @@ mod utils;
 mod web;
 
 #[cfg(feature = "notify")]
-use self::restart::setup_autorestart;
+use self::watch::setup_autorestart;
 
 use self::config::SetupConfig;
 use anyhow::Result;

--- a/deepwell/src/restart.rs
+++ b/deepwell/src/restart.rs
@@ -107,6 +107,11 @@ fn event_is_applicable(
 fn restart_self() -> Void {
     tide::log::info!("Restarting server");
 
-    // TODO
-    todo!()
+    let executable = env::current_exe().expect("Unable to get current executable");
+    let arguments = env::args_os().collect::<Vec<_>>();
+
+    let mut command = Command::new(executable);
+    command.args(arguments);
+    let error = command.exec();
+    panic!("Unable to exec(): {error}");
 }

--- a/deepwell/src/restart.rs
+++ b/deepwell/src/restart.rs
@@ -1,0 +1,40 @@
+/*
+ * restart.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2023 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Automatically restart server when configuration changes are detected.
+//!
+//! This is gated behind the `notify` feature, and will restart the entire
+//! process when changes to the localization files or the server configuration
+//! file are detected.
+//!
+//! For localization at least, in principle this could load the files in-place,
+//! but the server start-up is fast enough, and the borrow checker changes needed
+//! would be much more intrusive.
+//!
+//! This feature is intended for _local development only_, please do not use in production!
+//!
+//! This feature assumes you are running on a UNIX-like system.
+
+use crate::config::Config;
+use notify_debouncer_mini::{new_debouncer, notify::*, DebounceEventResult};
+
+pub fn setup_autorestart(config: &Config) -> Result<()> {
+    todo!()
+}

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -1,5 +1,5 @@
 /*
- * restart.rs
+ * watch.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2023 Wikijump Team

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -39,12 +39,12 @@ use notify::{
     Config as WatcherConfig, Event, EventKind, RecommendedWatcher, RecursiveMode,
     Result as WatcherResult, Watcher,
 };
+use std::convert::Infallible;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 use std::{env, fs};
-use void::Void;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -140,7 +140,7 @@ fn path_is_applicable(watched_paths: &WatchedPaths, path: &Path) -> bool {
     false
 }
 
-fn restart_self() -> Void {
+fn restart_self() -> Infallible {
     tide::log::info!("Restarting server");
 
     let executable = env::current_exe().expect("Unable to get current executable");

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -49,6 +49,7 @@ use void::Void;
 const DEBOUNCE_DURATION: Duration = Duration::from_secs(1);
 
 pub fn setup_autorestart(state: &ApiServerState) -> Result<Debouncer<impl Watcher>> {
+    tide::log::info!("Starting watcher for auto-restart on file change");
     let raw_toml_path = &state.config.raw_toml_path;
     let localization_path = &state.config.localization_path;
     let state = Arc::clone(&state);
@@ -75,10 +76,12 @@ pub fn setup_autorestart(state: &ApiServerState) -> Result<Debouncer<impl Watche
 
     // Add autowatch to configuration file.
     let watcher = debouncer.watcher();
+    tide::log::debug!("Adding regular watch to {}", raw_toml_path.display());
     watcher.watch(raw_toml_path, RecursiveMode::NonRecursive)?;
 
     // Add autowatch to localization directory.
     // Recursive because it is nested.
+    tide::log::debug!("Adding recursive watch to {}", localization_path.display());
     watcher.watch(localization_path, RecursiveMode::Recursive)?;
 
     // Return. Once out of scope, the watcher stops working.

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -130,11 +130,8 @@ fn event_is_applicable(
 fn restart_self() -> Void {
     tide::log::info!("Restarting server");
 
-    let (executable, arguments) = {
-        let mut arguments = env::args_os().collect::<Vec<_>>();
-        let executable = arguments.remove(0);
-        (executable, arguments)
-    };
+    let executable = env::current_exe().expect("Unable to get current executable");
+    let arguments = env::args_os().skip(1).collect::<Vec<_>>();
 
     tide::log::info!(
         "Replacing process with exec: {} {:?}",

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -37,7 +37,7 @@
 use crate::config::Config;
 use anyhow::Result;
 use notify::{
-    Config as WatcherConfig, Event, EventKind, PollWatcher, RecursiveMode,
+    Config as WatcherConfig, Event, EventKind, RecommendedWatcher, RecursiveMode,
     Result as WatcherResult, Watcher,
 };
 use std::os::unix::process::CommandExt;
@@ -55,14 +55,14 @@ struct WatchedPaths {
     localization_path: PathBuf,
 }
 
-pub fn setup_autorestart(config: &Config) -> Result<PollWatcher> {
+pub fn setup_autorestart(config: &Config) -> Result<RecommendedWatcher> {
     tide::log::info!("Starting watcher for auto-restart on file change");
     let watched_paths = WatchedPaths {
         config_path: fs::canonicalize(&config.raw_toml_path)?,
         localization_path: fs::canonicalize(&config.localization_path)?,
     };
 
-    let mut watcher = PollWatcher::new(
+    let mut watcher = RecommendedWatcher::new(
         move |result: WatcherResult<Event>| match result {
             Err(error) => {
                 tide::log::error!("Unable to receive filesystem events: {error}");

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -37,7 +37,9 @@
 use crate::config::Config;
 use anyhow::Result;
 use notify_debouncer_mini::{
-    new_debouncer, notify::*, DebounceEventResult, DebouncedEvent, Debouncer,
+    new_debouncer,
+    notify::{RecursiveMode, Watcher},
+    DebounceEventResult, DebouncedEvent, Debouncer,
 };
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -32,7 +32,6 @@
 //! Note the [security implications of `current_exe()`](https://doc.rust-lang.org/std/env/fn.current_exe.html#security).
 //!
 //! This feature assumes you are running on a UNIX-like system.
-//! Linux's inotify is _not_ used because of its incompatibility with Docker mounts.
 
 use crate::config::Config;
 use anyhow::Result;

--- a/install/aws/dev/docker/api/Dockerfile
+++ b/install/aws/dev/docker/api/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /src/deepwell
 RUN cargo vendor
 
 # Build deepwell server
-RUN cargo build --release
+RUN cargo build --release --features deploy
 
 #
 # Final image

--- a/install/aws/prod/docker/api/Dockerfile
+++ b/install/aws/prod/docker/api/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /src/deepwell
 RUN cargo vendor
 
 # Build deepwell server
-RUN cargo build --release
+RUN cargo build --release --features deploy
 
 #
 # Final image

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -18,6 +18,8 @@ RUN cargo install cargo-watch
 # Install development configuration file
 COPY install/files/local/deepwell.toml /etc/deepwell.toml
 
+# /opt/locales is provided via docker-compose.dev.yaml
+
 # Copy source
 # Don't build until container execution (see cargo-watch)
 RUN mkdir /src

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -24,4 +24,4 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run -- /etc/deepwell.toml"]
+CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- /etc/deepwell.toml"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -24,4 +24,4 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- /etc/deepwell.toml"]
+CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- --watch-files /etc/deepwell.toml"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-CMD ["/usr/local/cargo/bin/cargo", "watch", "--why", "-x", "run --features local -- --watch-files /etc/deepwell.toml"]
+CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- /etc/deepwell.toml"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- --watch-files /etc/deepwell.toml"]
+CMD ["/usr/local/cargo/bin/cargo", "watch", "--why", "-x", "run --features local -- --watch-files /etc/deepwell.toml"]


### PR DESCRIPTION
`cargo watch` will rebuild `deepwell` when any watched files change. However this can take a bit even if no source files have changed, as it rebuilds the binary. I have implemented a feature, `-w` or `--watch-files`, which will restart the process (via self-`exec`) if the configuration TOML file or anything under `locales` changes. This option is CLI-only, and is not found in the configuration files. It only applies to a `local` feature flagged build only.

However, I cannot get this to work with Docker. None of the events are coming through like with a local instance.

For now, I have re-enabled the `cargo watch` approach for deploy, and changed to use the `RecommendedWatcher` (inotify on linux). (If you want to try to get this to work on Docker, keep in mind `PollWatcher` must be used, and you need to disable the `-w [path]` flags in `cargo watch`.) This works fine, but is slower. To use `-w` you can manually stop the container and then run deepwell locally on your host machine. This will restart on file change nearly instanteously, it's quite nice.