### PR TITLE
Remove local / deploy features from deepwell

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -45,11 +45,11 @@ jobs:
       - name: System Dependencies
         run: sudo apt update && sudo apt install libmagic-dev
 
-      - name: Build (local)
-        run: cd deepwell && cargo build --features local
+      - name: Build (no features)
+        run: cd deepwell && cargo build --no-default-features
 
-      - name: Build (deploy)
-        run: cd deepwell && cargo build --features deploy
+      - name: Build (all features)
+        run: cd deepwell && cargo build --all-features
 
       - name: Check Configuration
         run: cd deepwell && cargo run -- config.example.toml ../install/files/local/deepwell.toml

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -13,8 +13,6 @@ authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 
 [features]
-local = ["watch"]
-deploy = []
 watch = ["notify"]
 
 [dependencies]

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -54,22 +54,11 @@ The routes are defined in `api/`, with their implementations in `methods/`, and 
 
 This executable targets the latest stable Rust. At time of writing, that is `1.72.0`.
 
-There are two features supported by DEEPWELL, along with what they add:
-
-* `local` &mdash; Intended for local development, where frequent compilation is likely.
- * Tracks the locale directory and configuration file, reloading them if they are modified.
-* `deploy` &mdash; Intended for "deployed" environments, i.e. `dev` and `prod`.
-
-Thus for a _release build_ (being deployed somewhere) you would want to run:
+At present the crate has one feature:
+* `notify` &mdash; Enables a feature to track the locale directory and configuration file, reloading the server if they are modified. This should be used in local builds only, not in production.
 
 ```sh
-$ cargo build --release --features deploy
-```
-
-And for a _local build_ you would want:
-
-```sh
-$ cargo build --features local
+$ cargo build [--features ...] [--release]
 ```
 
 ### Execution

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -46,6 +46,9 @@ use std::process::Command;
 use std::time::Duration;
 use std::{env, fs};
 
+#[cfg(not(debug))]
+compile_error!("The 'watch' feature should not be used in production!");
+
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -46,9 +46,6 @@ use std::process::Command;
 use std::time::Duration;
 use std::{env, fs};
 
-#[cfg(not(debug))]
-compile_error!("The 'watch' feature should not be used in production!");
-
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]

--- a/install/aws/dev/docker/api/Dockerfile
+++ b/install/aws/dev/docker/api/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /src/deepwell
 RUN cargo vendor
 
 # Build deepwell server
-RUN cargo build --release --features deploy
+RUN cargo build --release
 
 #
 # Final image

--- a/install/aws/prod/docker/api/Dockerfile
+++ b/install/aws/prod/docker/api/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /src/deepwell
 RUN cargo vendor
 
 # Build deepwell server
-RUN cargo build --release --features deploy
+RUN cargo build --release
 
 #
 # Final image

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run --features local -- /etc/deepwell.toml"]
+CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run -- /etc/deepwell.toml"]


### PR DESCRIPTION
Presently there is just the one feature, `watch`, and the `local` / `deploy` psuedo-features are not helpful. Removing for now, if we need them in the future we can add it then.