### PR TITLE
Add serde rename to model script

### DIFF
--- a/deepwell/scripts/generate-models.sh
+++ b/deepwell/scripts/generate-models.sh
@@ -13,5 +13,6 @@ sea-orm-cli generate entity \
 	--date-time-crate time \
 	--with-copy-enums \
 	--with-serde both \
+	--model-extra-attributes 'serde(rename_all = "camelCase")' \
 	--database-url postgres://wikijump:wikijump@localhost/wikijump \
 	--output-dir src/models

--- a/deepwell/src/models/alias.rs
+++ b/deepwell/src/models/alias.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "alias")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub alias_id: i64,

--- a/deepwell/src/models/file.rs
+++ b/deepwell/src/models/file.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "file")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub file_id: i64,

--- a/deepwell/src/models/file_revision.rs
+++ b/deepwell/src/models/file_revision.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "file_revision")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub revision_id: i64,

--- a/deepwell/src/models/filter.rs
+++ b/deepwell/src/models/filter.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "filter")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub filter_id: i64,

--- a/deepwell/src/models/page.rs
+++ b/deepwell/src/models/page.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub page_id: i64,

--- a/deepwell/src/models/page_attribution.rs
+++ b/deepwell/src/models/page_attribution.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_attribution")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub page_id: i64,

--- a/deepwell/src/models/page_category.rs
+++ b/deepwell/src/models/page_category.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_category")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub category_id: i64,

--- a/deepwell/src/models/page_connection.rs
+++ b/deepwell/src/models/page_connection.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_connection")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub from_page_id: i64,

--- a/deepwell/src/models/page_connection_missing.rs
+++ b/deepwell/src/models/page_connection_missing.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_connection_missing")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub from_page_id: i64,

--- a/deepwell/src/models/page_link.rs
+++ b/deepwell/src/models/page_link.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_link")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub page_id: i64,

--- a/deepwell/src/models/page_lock.rs
+++ b/deepwell/src/models/page_lock.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_lock")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub page_lock_id: i64,

--- a/deepwell/src/models/page_parent.rs
+++ b/deepwell/src/models/page_parent.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_parent")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub parent_page_id: i64,

--- a/deepwell/src/models/page_revision.rs
+++ b/deepwell/src/models/page_revision.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_revision")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub revision_id: i64,

--- a/deepwell/src/models/page_vote.rs
+++ b/deepwell/src/models/page_vote.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "page_vote")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub page_vote_id: i64,

--- a/deepwell/src/models/session.rs
+++ b/deepwell/src/models/session.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "session")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
     pub session_token: String,

--- a/deepwell/src/models/site.rs
+++ b/deepwell/src/models/site.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "site")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub site_id: i64,

--- a/deepwell/src/models/site_domain.rs
+++ b/deepwell/src/models/site_domain.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "site_domain")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false, column_type = "Text")]
     pub domain: String,

--- a/deepwell/src/models/site_member.rs
+++ b/deepwell/src/models/site_member.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "site_member")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub membership_id: i64,

--- a/deepwell/src/models/text.rs
+++ b/deepwell/src/models/text.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "text")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(
         primary_key,

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "user")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key)]
     pub user_id: i64,

--- a/deepwell/src/models/user_bot_owner.rs
+++ b/deepwell/src/models/user_bot_owner.rs
@@ -4,8 +4,8 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[sea_orm(table_name = "user_bot_owner")]
+#[serde(rename_all = "camelCase")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub bot_user_id: i64,


### PR DESCRIPTION
This is a follow-up to #1631 which adds an option to the `generate-models.sh` script to add the `#[serde(rename_all = "camelCase")]` automatically. (The ones for the enums still have to be added manually though.)