### PR TITLE
Bump deepwell version

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2023.5.14"
+version = "2023.10.6"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2023.5.14"
+version = "2023.10.6"
 authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
 edition = "2021" # this is *not* the same as the current year
 


### PR DESCRIPTION
It's been a while since the last version bump, and since we merged #1641, it seems like a good time to increase the version number.