### PR TITLE
Update rust to 1.73.0

### DIFF
--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -52,7 +52,7 @@ The routes are defined in `api/`, with their implementations in `methods/`, and 
 
 ### Compilation
 
-This executable targets the latest stable Rust. At time of writing, that is `1.72.0`.
+This executable targets the latest stable Rust. At time of writing, that is `1.73.0`.
 
 At present the crate has one feature:
 * `notify` &mdash; Enables a feature to track the locale directory and configuration file, reloading the server if they are modified. This should be used in local builds only, not in production.

--- a/ftml/README.md
+++ b/ftml/README.md
@@ -30,7 +30,7 @@ Available under the terms of the GNU Affero General Public License. See [LICENSE
 
 ### Compilation
 
-This library targets the latest stable Rust. At time of writing, that is `1.72.0`.
+This library targets the latest stable Rust. At time of writing, that is `1.73.0`.
 
 ```sh
 $ cargo build --release


### PR DESCRIPTION
Rust has released the [1.73.0](https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html) update. One important change of note is that this [fixes](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-173) the [`needless_pass_by_ref_mut`](https://github.com/rust-lang/rust-clippy/pull/10900) lint which had a false positive in ftml causing builds to fail for some time. 