### PR TITLE
Avoid false positive lint failures (2)

### DIFF
--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -65,4 +65,6 @@ jobs:
         run: cd ftml && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd ftml && cargo clippy --no-deps
+        run: cd ftml && cargo clippy --no-deps -- -A unused_imports
+
+        # See deepwell.yaml for explainer on unused_import.


### PR DESCRIPTION
Follow-up to #1651

Despite the `--no-deps`, our locale workflow is picking up errors not from its own code being linted but because clippy is annoying about deepwell's use of star imports in prelude and the like.