### PR TITLE
Avoid false positive lint failures (3) 

### DIFF
--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -156,4 +156,6 @@ jobs:
         run: cd ftml && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd ftml && cargo clippy --no-deps
+        run: cd ftml && cargo clippy --no-deps -- -A unused_imports
+
+        # See deepwell.yaml for explainer on unused_imports.

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -67,4 +67,4 @@ jobs:
       - name: Clippy
         run: cd ftml && cargo clippy --no-deps -- -A unused_imports
 
-        # See deepwell.yaml for explainer on unused_import.
+        # See deepwell.yaml for explainer on unused_imports.


### PR DESCRIPTION
Follow-up to #1678.

I thought ftml would be fine since it wasn't reporting issues, and didn't have the same kinds of imports we have in our other crates, but I was wrong. This should finally quiet our recent slate of unhelpful build failures.

Example failed build: https://github.com/scpwiki/wikijump/actions/runs/6713086734/job/18243975202