### PR TITLE
Update minio container health check system

### DIFF
--- a/install/local/dev/docker-compose.yaml
+++ b/install/local/dev/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - "INITIAL_BUCKETS=deepwell-files"
       - "DATA_DIR=/data"  # You can add a volume for /data if you wish
     healthcheck:
-      test: ["CMD", "curl", "-If", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "/healthcheck.sh"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/install/local/dev/minio/Dockerfile
+++ b/install/local/dev/minio/Dockerfile
@@ -2,6 +2,6 @@ FROM quay.io/minio/mc:latest AS mc
 FROM quay.io/minio/minio:latest AS minio
 
 COPY --from=mc /usr/bin/mc /usr/local/bin/mc
-COPY ./docker-entrypoint.sh /
+COPY ./docker-entrypoint.sh ./healthcheck.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/install/local/dev/minio/docker-entrypoint.sh
+++ b/install/local/dev/minio/docker-entrypoint.sh
@@ -18,7 +18,7 @@ readonly mc_region="${MINIO_REGION_NAME:-us-east-1}"
 # Helper functions
 
 function wait_for_server() {
-	until curl -If "http://localhost:$api_port/minio/health/live"; do
+	until /healthcheck.sh "$api_port"; do
 		sleep 1
 		echo "Waiting..."
 	done

--- a/install/local/dev/minio/healthcheck.sh
+++ b/install/local/dev/minio/healthcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+port_number="${1:-9000}"  # pass in or default
+timeout 5s bash -c ":> /dev/tcp/127.0.0.1/$port_number"


### PR DESCRIPTION
As noted in https://github.com/minio/minio/issues/18373, `curl` is no longer shipped in the `minio` container, which means our existing health check system is now broken. Using a recommendation in the linked issue, we can update the health check, and place that into a separate script for future update convenience.