### PR TITLE
Remove nightly from Rust lint checks

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -112,6 +112,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -129,7 +129,7 @@ jobs:
         run: cd deepwell && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd deepwell && cargo clippy --no-deps -- -A unused_imports
+        run: cd deepwell && cargo clippy --no-deps
 
         # clippy is over aggressive with "unused import" warnings, reporting it for
         # prelude modules and common export patterns, which is noisy and unhelpful.

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -130,9 +130,3 @@ jobs:
 
       - name: Clippy
         run: cd deepwell && cargo clippy --no-deps
-
-        # clippy is over aggressive with "unused import" warnings, reporting it for
-        # prelude modules and common export patterns, which is noisy and unhelpful.
-        #
-        # Since regular (i.e. actual) unused imports will fail the normal build, we
-        # can just suppress all unused import warnings in Clippy.

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -112,7 +112,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -157,5 +157,3 @@ jobs:
 
       - name: Clippy
         run: cd ftml && cargo clippy --no-deps
-
-        # See deepwell.yaml for explainer on unused_imports.

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -156,6 +156,6 @@ jobs:
         run: cd ftml && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd ftml && cargo clippy --no-deps -- -A unused_imports
+        run: cd ftml && cargo clippy --no-deps
 
         # See deepwell.yaml for explainer on unused_imports.

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -139,6 +139,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -139,7 +139,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -48,7 +48,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -66,5 +66,3 @@ jobs:
 
       - name: Clippy
         run: cd ftml && cargo clippy --no-deps
-
-        # See deepwell.yaml for explainer on unused_imports.

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -65,6 +65,6 @@ jobs:
         run: cd ftml && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd ftml && cargo clippy --no-deps -- -A unused_imports
+        run: cd ftml && cargo clippy --no-deps
 
         # See deepwell.yaml for explainer on unused_imports.

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -48,6 +48,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
The regression with some builds, as well as issues we've had such as the aggressive unused imports lint resulted from _nightly_ clippy. This also resulted in nightly builds, which is why we've had strange build regressions. Since clippy has been landed in stable for some time, we can just switch to that.

We could also merge the rustfmt and clippy steps into the main build group, but I'm not doing that for two reasons:
1. Having a separate group is helpful for seeing at a glance what kind of build failures you have. If there's only one, you can't tell if the failure is "code isn't formatted" vs "it won't compile".
2. There is the question of whether format checks should be before or after compilation. If they're before, then something like a missing comma can mean your build doesn't even try to compile, if it's after, then you might have to wait for the entire compilation to finish before seeing said comma is missing and you have to push a fix.