### PR TITLE
[WJ-1208] Fix long job delay error

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "rsmq_async"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0cbaea882b64cfb32a7f60e48bb038aebb7f24ecddc919d86bd85ce697d108"
+checksum = "b43e36b87051ada4f8b82bad3f00ee7d8b1d38ab44b0e2fa6cd22b7d46ccff77"
 dependencies = [
  "async-trait",
  "bb8",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -48,7 +48,7 @@ redis = { version = "0.23", features = ["aio", "connection-manager", "keep-alive
 ref-map = "0.1"
 regex = "1"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
-rsmq_async = "6"
+rsmq_async = "7"
 rust-s3 = { version = "0.32", features = ["with-async-std"], default-features = false }
 sea-orm = { version = "0.12", features = ["sqlx-postgres", "runtime-async-std-rustls", "postgres-array", "macros", "with-json", "with-time"], default-features = false }
 sea-query = "0.30"


### PR DESCRIPTION
This updates the `rsmq_async` crate to version 7, which fixes an issue present in prior versions which prevented us from queuing jobs which ran once a day.

See https://github.com/DavidBM/rsmq-async-rs/issues/17