### PR TITLE
Return null for frontend when translation missing

### DIFF
--- a/deepwell/src/endpoints/locale.rs
+++ b/deepwell/src/endpoints/locale.rs
@@ -37,7 +37,7 @@ pub struct TranslateInput {
     messages: HashMap<String, MessageArguments<'static>>,
 }
 
-type TranslateOutput = HashMap<String, String>;
+type TranslateOutput = HashMap<String, Option<String>>;
 
 pub async fn locale_info(
     _ctx: &ServiceContext<'_>,
@@ -91,9 +91,9 @@ pub async fn translate_strings(
         let arguments = arguments_raw.into_fluent_args();
         let translation =
             ctx.localization()
-                .translate(&locales, &message_key, &arguments)?;
+                .translate_option(&locales, &message_key, &arguments)?;
 
-        output.insert(message_key, translation.to_string());
+        output.insert(message_key, translation.map(|t| t.to_string()));
     }
 
     Ok(output)

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -249,6 +249,32 @@ impl Localizations {
         // Done
         Ok(output)
     }
+
+    /// A variant of `translate()` which returns `Option`.
+    ///
+    /// This way, if a translation cannot be found, instead of returning
+    /// an error, it instead returns `Ok(None)`.
+    pub fn translate_option<'a, L, I>(
+        &'a self,
+        locales: I,
+        key: &str,
+        args: &'a FluentArgs<'a>,
+    ) -> Result<Option<Cow<'a, str>>, ServiceError>
+    where
+        L: AsRef<LanguageIdentifier> + Display + 'a,
+        I: IntoIterator<Item = L>,
+    {
+        match self.translate(locales, key, args) {
+            Ok(translation) => Ok(Some(translation)),
+            Err(
+                ServiceError::LocaleMissing
+                | ServiceError::LocaleMessageMissing
+                | ServiceError::LocaleMessageValueMissing
+                | ServiceError::LocaleMessageAttributeMissing,
+            ) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 impl Debug for Localizations {


### PR DESCRIPTION
For the frontend, we want to return `null` for any message keys whose translations could not be found, rather than returning a request-level error. We do this by adding a new method which captures that variety of error and returns `Option<_>` accordingly.