### PR TITLE
Fix locale for guest with no Accept-Language header

### DIFF
--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -25,7 +25,12 @@ export async function loadPage(
 
   // Request data from backend
   // Includes fallback locale in case there is no Accept-Language header
-  const response = await pageView(domain, [...locales, defaults.fallbackLocale], route, sessionToken)
+  const response = await pageView(
+    domain,
+    [...locales, defaults.fallbackLocale],
+    route,
+    sessionToken
+  )
 
   if (response.data?.site?.locale && !locales.includes(response.data.site.locale)) {
     locales.push(response.data.site.locale)

--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -21,10 +21,11 @@ export async function loadPage(
   const sessionToken = cookies.get("wikijump_token")
   let locales = parseAcceptLangHeader(request)
 
-  // Request data from backend
-  const response = await pageView(domain, locales, route, sessionToken)
-
   // TODO insert user preference at the beginning of the list
+
+  // Request data from backend
+  // Includes fallback locale in case there is no Accept-Language header
+  const response = await pageView(domain, [...locales, defaults.fallbackLocale], route, sessionToken)
 
   if (response.data?.site?.locale && !locales.includes(response.data.site.locale)) {
     locales.push(response.data.site.locale)


### PR DESCRIPTION
This addresses the case for no user locale and no Accept-Language header, which happen for example with docker curl polling the web container for health status.