### PR TITLE
Remove example user locale

### DIFF
--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -90,7 +90,7 @@
         "slug": "user",
         "email": "user@wikijump",
         "password": null,
-        "locales": ["en"],
+        "locales": [],
         "real_name": "Example User",
         "gender": null,
         "birthday": null,


### PR DESCRIPTION
Follow up for #1702: quick fix for the example user in seeder having a locale while being a "system" user, which fails the Deepwell validation.