### PR TITLE
Use newly-hosted rust-otp crate

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -899,7 +899,6 @@ dependencies = [
  "log",
  "notify",
  "once_cell",
- "otp",
  "paste",
  "rand 0.8.5",
  "redis",
@@ -907,6 +906,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rsmq_async",
+ "rust-otp",
  "rust-s3",
  "sea-orm",
  "sea-query",
@@ -2417,17 +2417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "otp"
-version = "1.0.0"
-source = "git+https://github.com/TimDumol/rust-otp#dd96dee878012ab7a9969e75b4427607ca4e7f6f"
-dependencies = [
- "ascii",
- "data-encoding",
- "err-derive",
- "ring 0.16.20",
-]
-
-[[package]]
 name = "ouroboros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3226,18 @@ checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust-otp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266f62d389dd986580d8439418a7c2952879fcd7c1ad10ab234e8f537cdc689e"
+dependencies = [
+ "ascii",
+ "data-encoding",
+ "err-derive",
+ "ring 0.16.20",
 ]
 
 [[package]]

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -40,7 +40,6 @@ jsonrpsee = { version = "0.20", features = ["macros", "server"] }
 log = "0.4"
 notify = { version = "6", optional = true }
 once_cell = "1"
-otp = { git = "https://github.com/TimDumol/rust-otp" }
 paste = "1"
 rand = "0.8"
 redis = { version = "0.23", features = ["aio", "connection-manager", "keep-alive", "tokio-comp"] }
@@ -49,6 +48,7 @@ regex = "1"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 rsmq_async = "8"
 rust-s3 = { version = "0.32", features = ["with-tokio"], default-features = false }
+rust-otp = "1"
 sea-orm = { version = "0.12", features = ["sqlx-postgres", "runtime-tokio-rustls", "postgres-array", "macros", "with-json", "with-time"], default-features = false }
 sea-query = "0.30"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
The otp crate we use is functional but unfortunately is not hosted on crates.io. See issue https://github.com/TimDumol/rust-otp/issues/4. However now there is [WesleyBatista/rust-otp](https://github.com/WesleyBatista/rust-otp) which is hosted on crates.io as [rust-otp](https://crates.io/crates/rust-otp). We should switch to this version so we can actually pin our dependencies.