### PR TITLE
Fix ECR builds for dev services

### DIFF
--- a/.github/workflows/docker-build-api.prod.yaml
+++ b/.github/workflows/docker-build-api.prod.yaml
@@ -3,7 +3,7 @@ name: '[backend] Docker build API (prod)'
 on:
   pull_request:
     paths:
-      - 'deepwell/*'
+      - 'deepwell/**'
       - 'install/aws/prod/docker/api/Dockerfile'
       - '.github/workflows/docker-build-api.prod.yaml'
 

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - build-to-ecr # TEMP
     paths:
       - 'deepwell/**'
       - 'install/aws/dev/docker/api/**'

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download task definition
         run: |
-          aws ecs describe-task-definition --task-definition wikijump-deepwell --query taskDefinition > task-definition.json
+          aws ecs describe-task-definition --task-definition wikijump-deepwell-dev --query taskDefinition > task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: task-definition.json
-          container-name: api
+          container-name: deepwell
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -32,7 +32,7 @@ jobs:
         id: build-image
         env:
           DOCKER_BUILDKIT: 1
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ vars.ECR_REPOSITORY }}
           ECR_REPOSITORY: wikijump/deepwell
           IMAGE_TAG: ${{ github.sha }}
         run: |

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -32,17 +32,17 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: wikijump-dev/api
+          ECR_REPOSITORY: wikijump/deepwell
           IMAGE_TAG: ${{ github.sha }}
         run: |
           set -ex
-          docker build -f install/aws/dev/docker/api/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:develop .
+          docker build -f install/aws/dev/docker/api/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Download task definition
         run: |
-          aws ecs describe-task-definition --task-definition wikijump-dev-ec2 --query taskDefinition > task-definition.json
+          aws ecs describe-task-definition --task-definition wikijump-deepwell --query taskDefinition > task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -56,6 +56,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: wikijump-dev-svc
+          service: wikijump-deepwell-dev
           cluster: wikijump-dev
           wait-for-service-stability: true

--- a/.github/workflows/docker-build-push-api.dev.yaml
+++ b/.github/workflows/docker-build-push-api.dev.yaml
@@ -39,7 +39,7 @@ jobs:
           set -ex
           docker build -f install/aws/dev/docker/api/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Download task definition
         run: |

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
     paths:
+      - 'deepwell/migrations/*'
+      - 'deepwell/seeder/*'
       - 'install/aws/dev/docker/postgres/**'
       - '.github/workflows/docker-build-push-postgres.dev.yaml'
 

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -14,49 +14,49 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@v1
-          with:
-            aws-access-key-id: ${{ secrets.DOCKER_PUSH_KEY }}
-            aws-secret-access-key: ${{ secrets.DOCKER_PUSH_SECRET }}
-            aws-region: us-east-2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DOCKER_PUSH_KEY }}
+          aws-secret-access-key: ${{ secrets.DOCKER_PUSH_SECRET }}
+          aws-region: us-east-2
 
-        - name: Login to Amazon ECR
-          id: login-ecr
-          uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
-        - name: Build, tag, and push image to Amazon ECR
-          id: build-image
-          env:
-            DOCKER_BUILDKIT: 1
-            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-            ECR_REPOSITORY: wikijump/postgres
-            IMAGE_TAG: ${{ github.sha }}
-          run: |
-            set -ex
-            docker build -f install/aws/dev/docker/postgres/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
-            docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
-            echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          DOCKER_BUILDKIT: 1
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: wikijump/postgres
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          set -ex
+          docker build -f install/aws/dev/docker/postgres/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-        - name: Download task definition
-          run: |
-            aws ecs describe-task-definition --task-definition wikijump-postgres --query taskDefinition > task-definition.json
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition wikijump-postgres --query taskDefinition > task-definition.json
 
-        - name: Fill in the new image ID in the Amazon ECS task definition
-          id: task-def
-          uses: aws-actions/amazon-ecs-render-task-definition@v1
-          with:
-            task-definition: task-definition.json
-            container-name: postgres
-            image: ${{ steps.build-image.outputs.image }}
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: postgres
+          image: ${{ steps.build-image.outputs.image }}
 
-        - name: Deploy Amazon ECS task definition
-          uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-          with:
-            task-definition: ${{ steps.task-def.outputs.task-definition }}
-            service: wikijump-postgres-dev
-            cluster: wikijump-dev
-            wait-for-service-stability: true
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: wikijump-postgres-dev
+          cluster: wikijump-dev
+          wait-for-service-stability: true

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -40,7 +40,7 @@ jobs:
           set -ex
           docker build -f install/aws/dev/docker/postgres/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Download task definition
         run: |

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -33,30 +33,30 @@ jobs:
           env:
             DOCKER_BUILDKIT: 1
             ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-            ECR_REPOSITORY: wikijump-dev/postgres
+            ECR_REPOSITORY: wikijump/postgres
             IMAGE_TAG: ${{ github.sha }}
           run: |
             set -ex
-            docker build -f install/aws/dev/docker/postgres/Dockerfile --build-arg FILES_DOMAIN="wjfiles.dev" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:develop .
+            docker build -f install/aws/dev/docker/postgres/Dockerfile -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:dev .
             docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
             echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
         - name: Download task definition
           run: |
-            aws ecs describe-task-definition --task-definition wikijump-dev-ec2 --query taskDefinition > task-definition.json
+            aws ecs describe-task-definition --task-definition wikijump-postgres --query taskDefinition > task-definition.json
 
         - name: Fill in the new image ID in the Amazon ECS task definition
           id: task-def
           uses: aws-actions/amazon-ecs-render-task-definition@v1
           with:
             task-definition: task-definition.json
-            container-name: database
+            container-name: postgres
             image: ${{ steps.build-image.outputs.image }}
 
         - name: Deploy Amazon ECS task definition
           uses: aws-actions/amazon-ecs-deploy-task-definition@v1
           with:
             task-definition: ${{ steps.task-def.outputs.task-definition }}
-            service: wikijump-dev-svc
+            service: wikijump-postgres-dev
             cluster: wikijump-dev
             wait-for-service-stability: true

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Download task definition
         run: |
-          aws ecs describe-task-definition --task-definition wikijump-postgres --query taskDefinition > task-definition.json
+          aws ecs describe-task-definition --task-definition wikijump-postgres-dev --query taskDefinition > task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -33,7 +33,7 @@ jobs:
         id: build-image
         env:
           DOCKER_BUILDKIT: 1
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ vars.ECR_REPOSITORY }}
           ECR_REPOSITORY: wikijump/postgres
           IMAGE_TAG: ${{ github.sha }}
         run: |

--- a/.github/workflows/docker-build-push-postgres.dev.yaml
+++ b/.github/workflows/docker-build-push-postgres.dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - build-to-ecr # TEMP
     paths:
       - 'deepwell/migrations/*'
       - 'deepwell/seeder/*'


### PR DESCRIPTION
As part of the project of fixing dev deploys, we need to update the ECR build process that happens on push to the `develop` branch.