### PR TITLE
[WJ-964] Also add compatibility IDs for page categories

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -258,6 +258,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     restart_sequence_with(&txn, "site_site_id_seq", 6000000).await?;
     restart_sequence_with(&txn, "page_page_id_seq", 3000000000).await?;
     restart_sequence_with(&txn, "page_revision_revision_id_seq", 3000000000).await?;
+    restart_sequence_with(&txn, "page_category_category_id_seq", 100000000).await?;
 
     /*
      * TODO: tables which don't exist yet:

--- a/docs/compatibility-ids.md
+++ b/docs/compatibility-ids.md
@@ -9,6 +9,7 @@ The approach used here is to set the starting ID value to be higher than Wikidot
 ```
 - Page           -- 3000000000 (sample       1331370625)
 - Revision       -- 3000000000 (sample       1388179085)
+- Page Category  --  100000000 (sample         43202888)
 - Forum Post     --    7000000 (sample          5174477)
 - Forum Thread   --   30000000 (sample         14447612)
 - Forum Category --    9000000 (sample          7412040)


### PR DESCRIPTION
An amendment to the already-finished [WJ-964](https://scuttle.atlassian.net/browse/WJ-964) to add page categories as one type of compatibility ID. Since we will pick this data up during backups along with page IDs, we can store this data as well.

[WJ-964]: https://scuttle.atlassian.net/browse/WJ-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ