### PR TITLE
Use lz4 as default PostgreSQL compression algorithm

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -234,7 +234,7 @@ CREATE TYPE page_revision_change AS ENUM (
 -- but since we can't we'll just verify the hash length.
 CREATE TABLE text (
     hash BYTEA PRIMARY KEY,
-    contents TEXT COMPRESSION pglz NOT NULL,
+    contents TEXT NOT NULL,
 
     CHECK (length(hash) = 16)  -- KangarooTwelve hash size, 128 bits
 );

--- a/install/files/postgres/init/02-seed.sql
+++ b/install/files/postgres/init/02-seed.sql
@@ -9,7 +9,7 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
-SET default_toast_compression=lz4;
+SET default_toast_compression = lz4;
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;

--- a/install/files/postgres/init/02-seed.sql
+++ b/install/files/postgres/init/02-seed.sql
@@ -9,6 +9,7 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
+SET default_toast_compression=lz4;
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;


### PR DESCRIPTION
By default, Postgres compresses large `EXTENDED` storage (such as `TEXT`) so the `COMPRESSION` directive on the column is unnecessary.

We also set the default compression algorithm to `lz4`, which is faster and has better compression than the default `pglz`. It was first added in Postgres 14.
