### PR TITLE
Fix wrongly-failing workflows

### DIFF
--- a/.github/workflows/ftml.yaml
+++ b/.github/workflows/ftml.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Library
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -A unused -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
     name: WebASM
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -A unused -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -A unused -D warnings
 
     steps:
       - name: Checkout
@@ -130,7 +130,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -A unused -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -39,7 +39,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings
+      RUSTFLAGS: -A unused -D warnings
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Annoyingly, at some point in the past, imports began to be considered "unused" even if publicly exposed. Because we error on warnings, this fails builds, but we don't want that.

We've patched this before, but it's appearing again. [Example here](https://github.com/scpwiki/wikijump/actions/runs/7525167707/job/20481089470)

This adds `-A unused` to _all_ the workflow files, which should silence this issue.