### PR TITLE
Fix 4-dot ellipsis typography (WJ-1099)

### DIFF
--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -118,7 +118,7 @@ impl Replacer {
                             .expect("Regular expression lacks a full match");
                         let mtch = capture.name("repl").unwrap_or(full_match);
 
-                        offset = mtch.start() + repl_len;
+                        offset = mtch.start() + replacement.len();
 
                         mtch.range()
                     };

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -109,7 +109,6 @@ impl Replacer {
                 );
 
                 let mut offset = 0;
-                let repl_len = replacement.len();
 
                 while let Some(capture) = regex.captures_at(text, offset) {
                     let range = {
@@ -197,30 +196,35 @@ const TEST_CASES: [(&str, &str); 21] = [
     ),
     ("Whales... they are cool", "Whales… they are cool"),
     ("Whales ... they are cool", "Whales … they are cool"),
+    ("Whales. . . they are cool", "Whales… they are cool"),
+    ("Whales . . . they are cool", "Whales … they are cool"),
     ("...why would you think that?", "…why would you think that?"),
-    ("how could you...", "how could you…"),
     (
         "... why would you think that?",
         "… why would you think that?",
     ),
-    ("how could you ...", "how could you …"),
-    ("Whales. . . they are cool", "Whales… they are cool"),
     (
         ". . .why would you think that?",
         "…why would you think that?",
     ),
-    ("how could you. . .", "how could you…"),
-    ("Whales . . . they are cool", "Whales … they are cool"),
     (
         ". . . why would you think that?",
         "… why would you think that?",
     ),
+    ("how could you...", "how could you…"),
+    ("how could you ...", "how could you …"),
+    ("how could you. . .", "how could you…"),
     ("how could you . . .", "how could you …"),
-    (".... ..", ".... .."),
+    // Spaced with extra dot after 3rd
     (". . .. ....", ". . .. ...."),
+    // Multiple spaced dots in a row
     ("... . . . . . .", "… … …"),
+    // Too many dots
+    (".... ..", ".... .."),
     ("..........", ".........."),
+    // Groups of three dots
     ("... ... ...", "… … …"),
+    // Groups of three, mixed spaced and continuous
     ("... . . . ...", "… … …"),
 ];
 

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -116,7 +116,7 @@ impl Replacer {
                         let full_match = capture
                             .get(0)
                             .expect("Regular expression lacks a full match");
-                        let mtch = capture.name("repl").or(Some(full_match)).unwrap();
+                        let mtch = capture.name("repl").unwrap_or(full_match);
 
                         offset = mtch.start() + repl_len;
 

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -113,10 +113,10 @@ impl Replacer {
 
                 while let Some(capture) = regex.captures_at(text, offset) {
                     let range = {
-                        let full_match = capture.get(0).expect("Regular expression lacks a full match");
-                        let mtch = capture
-                            .name("repl")
-                            .or(Some(full_match)).unwrap();
+                        let full_match = capture
+                            .get(0)
+                            .expect("Regular expression lacks a full match");
+                        let mtch = capture.name("repl").or(Some(full_match)).unwrap();
 
                         offset = mtch.start() + repl_len;
 
@@ -148,7 +148,7 @@ impl Replacer {
                             .get(0)
                             .expect("Regular expression lacks a full match");
 
-                        mtch.start()..mtch.end()
+                        mtch.range()
                     };
 
                     buffer.clear();
@@ -192,84 +192,37 @@ const TEST_CASES: [(&str, &str); 21] = [
         ",,あんたは馬鹿です！''\n``Ehh?''\n,,本当！''\n[[footnoteblock]]",
         "„あんたは馬鹿です！”\n“Ehh?”\n„本当！”\n[[footnoteblock]]",
     ),
-
-    // Ellipsis tests
     (
         "**ENTITY MAKES DRAMATIC MOTION** . . . ",
         "**ENTITY MAKES DRAMATIC MOTION** … ",
     ),
-    (
-        "Whales... they are cool",
-        "Whales… they are cool",
-    ),
-    (
-        "Whales ... they are cool",
-        "Whales … they are cool",
-    ),
-    (
-        "...why would you think that?",
-        "…why would you think that?",
-    ),
-    (
-        "how could you...",
-        "how could you…",
-    ),
+    ("Whales... they are cool", "Whales… they are cool"),
+    ("Whales ... they are cool", "Whales … they are cool"),
+    ("...why would you think that?", "…why would you think that?"),
+    ("how could you...", "how could you…"),
     (
         "... why would you think that?",
         "… why would you think that?",
     ),
-    (
-        "how could you ...",
-        "how could you …",
-    ),
-    (
-        "Whales. . . they are cool",
-        "Whales… they are cool",
-    ),
+    ("how could you ...", "how could you …"),
+    ("Whales. . . they are cool", "Whales… they are cool"),
     (
         ". . .why would you think that?",
         "…why would you think that?",
     ),
-    (
-        "how could you. . .",
-        "how could you…",
-    ),
-    (
-        "Whales . . . they are cool",
-        "Whales … they are cool",
-    ),
+    ("how could you. . .", "how could you…"),
+    ("Whales . . . they are cool", "Whales … they are cool"),
     (
         ". . . why would you think that?",
         "… why would you think that?",
     ),
-    (
-        "how could you . . .",
-        "how could you …",
-    ),
-    (
-        ".... ..",
-        ".... ..",
-    ),
-    (
-        ". . .. ....",
-        ". . .. ....",
-    ),
-    (
-        "... . . . . . .",
-        "… … …",
-    ),
-    (
-        "..........",
-        ".........."
-    ),
-    (
-        "... ... ...",
-        "… … …",
-    ),
-    (
-        "... . . . ...",
-        "… … …",
-    ),
+    ("how could you . . .", "how could you …"),
+    (".... ..", ".... .."),
+    (". . .. ....", ". . .. ...."),
+    ("... . . . . . .", "… … …"),
+    ("..........", ".........."),
+    ("... ... ...", "… … …"),
+    ("... . . . ...", "… … …"),
 ];
 
 #[test]

--- a/ftml/src/preproc/typography.rs
+++ b/ftml/src/preproc/typography.rs
@@ -119,7 +119,6 @@ impl Replacer {
                         let mtch = capture.name("repl").unwrap_or(full_match);
 
                         offset = mtch.start() + replacement.len();
-
                         mtch.range()
                     };
 


### PR DESCRIPTION
This fix should make it so that only ellipsis not bordered by dots are replaced. Also expands the typography RegexReplace, though this is not used besides ellipsis. Adds a lot of ellipsis tests.