### PR TITLE
[WJ-994] Add health check script for DEEPWELL

### DIFF
--- a/install/aws/dev/docker/api/Dockerfile
+++ b/install/aws/dev/docker/api/Dockerfile
@@ -30,8 +30,9 @@ ENV LOCALIZATION_PATH="/opt/locales"
 
 RUN apk add --no-cache curl libmagic
 COPY --from=rust /src/deepwell/target/release/deepwell /usr/local/bin/deepwell
-COPY ./locales/fluent /opt/locales/fluent
+COPY ./install/files/api/health-check.sh /bin/wikijump-health-check
 COPY ./install/files/dev/api_env /.env
+COPY ./locales/fluent /opt/locales/fluent
 
 USER daemon
 CMD ["/usr/local/bin/deepwell"]

--- a/install/files/api/health-check.sh
+++ b/install/files/api/health-check.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+curl -i -X POST --json '{"jsonrpc":"2.0","method":"ping","id":0}' http://localhost:2747/jsonrpc

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -15,8 +15,9 @@ RUN apt install -y libmagic-dev
 # Install helpers
 RUN cargo install cargo-watch
 
-# Install development configuration file
+# Install files
 COPY install/files/local/deepwell.toml /etc/deepwell.toml
+COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
 

--- a/install/local/dev/docker-compose.dev.yaml
+++ b/install/local/dev/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api:
     volumes:

--- a/install/local/dev/docker-compose.yaml
+++ b/install/local/dev/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   database:
     build:


### PR DESCRIPTION
One of the checklist items on [WJ-994](https://scuttle.atlassian.net/browse/WJ-994). I also remove the deprecated `docker-compose.yaml` fields.

[WJ-994]: https://scuttle.atlassian.net/browse/WJ-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ