### PR TITLE
[WJ-1165] Implement recurring job to add user name change tokens

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -25,6 +25,7 @@ CREATE TABLE "user" (
     name TEXT NOT NULL,
     slug TEXT NOT NULL,
     name_changes_left SMALLINT NOT NULL,  -- Default set in runtime configuration.
+    last_name_change_added_at TIMESTAMP WITH TIME ZONE,
     last_renamed_at TIMESTAMP WITH TIME ZONE,
     email TEXT NOT NULL,  -- Can be empty, for instance with system accounts.
     email_is_alias BOOLEAN,

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -25,7 +25,7 @@ CREATE TABLE "user" (
     name TEXT NOT NULL,
     slug TEXT NOT NULL,
     name_changes_left SMALLINT NOT NULL,  -- Default set in runtime configuration.
-    last_name_change_added_at TIMESTAMP WITH TIME ZONE,
+    last_name_change_added_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     last_renamed_at TIMESTAMP WITH TIME ZONE,
     email TEXT NOT NULL,  -- Can be empty, for instance with system accounts.
     email_is_alias BOOLEAN,

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -403,9 +403,11 @@ impl ConfigFile {
             special_page_banned,
             default_name_changes: i16::from(default_name_changes),
             maximum_name_changes: i16::from(maximum_name_changes),
-            refill_name_change: StdDuration::from_secs(
-                refill_name_change_days * 24 * 60 * 60,
-            ),
+            refill_name_change: if refill_name_change_days == 0 {
+                None
+            } else {
+                Some(StdDuration::from_secs(refill_name_change_days * 24 * 60 * 60))
+            },
             minimum_name_bytes,
             maximum_message_subject_bytes,
             maximum_message_body_bytes,

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -406,7 +406,9 @@ impl ConfigFile {
             refill_name_change: if refill_name_change_days == 0 {
                 None
             } else {
-                Some(StdDuration::from_secs(refill_name_change_days * 24 * 60 * 60))
+                Some(StdDuration::from_secs(
+                    refill_name_change_days * 24 * 60 * 60,
+                ))
             },
             minimum_name_bytes,
             maximum_message_subject_bytes,

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -184,7 +184,8 @@ pub struct Config {
     pub maximum_name_changes: i16,
 
     /// How long until a user gets another name change token.
-    pub refill_name_change: StdDuration,
+    /// `None` means that no name change tokens are refilled.
+    pub refill_name_change: Option<StdDuration>,
 
     /// Minimum length of bytes in a username.
     pub minimum_name_bytes: usize,

--- a/deepwell/src/endpoints/user.rs
+++ b/deepwell/src/endpoints/user.rs
@@ -88,5 +88,6 @@ pub async fn user_add_name_change(
 ) -> Result<i16> {
     let GetUser { user: reference } = params.parse()?;
     info!("Adding user name change token to {:?}", reference);
-    UserService::add_name_change_token(ctx, reference).await
+    let user = UserService::get(ctx, reference).await?;
+    UserService::add_name_change_token(ctx, &user).await
 }

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -19,6 +19,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text")]
     pub slug: String,
     pub name_changes_left: i16,
+    pub last_name_change_added_at: Option<TimeDateTimeWithTimeZone>,
     pub last_renamed_at: Option<TimeDateTimeWithTimeZone>,
     #[sea_orm(column_type = "Text")]
     pub email: String,

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -19,7 +19,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text")]
     pub slug: String,
     pub name_changes_left: i16,
-    pub last_name_change_added_at: Option<TimeDateTimeWithTimeZone>,
+    pub last_name_change_added_at: TimeDateTimeWithTimeZone,
     pub last_renamed_at: Option<TimeDateTimeWithTimeZone>,
     #[sea_orm(column_type = "Text")]
     pub email: String,

--- a/deepwell/src/services/job/worker.rs
+++ b/deepwell/src/services/job/worker.rs
@@ -22,7 +22,7 @@
 
 use super::prelude::*;
 use crate::api::ServerState;
-use crate::services::{PageRevisionService, SessionService, TextService};
+use crate::services::{PageRevisionService, SessionService, TextService, UserService};
 use crate::utils::debug_pointer;
 use rsmq_async::{PooledRsmq, RsmqConnection, RsmqMessage};
 use sea_orm::TransactionTrait;
@@ -204,11 +204,7 @@ impl JobWorker {
             }
             Job::NameChangeRefill => {
                 debug!("Checking users for those who can get a name change token refill");
-                // TODO implement name change refill
-                //
-                //      check users whose time since refill_name_change_days
-                //      refill_name_change_days being zero means disable
-                //      add user credits to each where they are above that time
+                UserService::refresh_name_change_tokens(ctx).await?;
                 NextJob::Next {
                     job: Job::NameChangeRefill,
                     delay: Some(self.state.config.job_name_change_refill),

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -563,9 +563,7 @@ impl UserService {
         Ok(())
     }
 
-    pub async fn refresh_name_change_tokens(
-        ctx: &ServiceContext<'_>,
-    ) -> Result<()> {
+    pub async fn refresh_name_change_tokens(ctx: &ServiceContext<'_>) -> Result<()> {
         info!("Refreshing name change tokens for all users who need one");
 
         let needs_token_time = match ctx.config().refill_name_change {
@@ -581,7 +579,11 @@ impl UserService {
             .all(txn)
             .await?;
 
-        debug!("Found {} users in need of a name refresh token", users.len());
+        debug!(
+            "Found {} users in need of a name refresh token",
+            users.len(),
+        );
+
         for user in users {
             Self::add_name_change_token(ctx, &user).await?;
         }

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -573,9 +573,7 @@ impl UserService {
 
         let txn = ctx.transaction();
         let users = User::find()
-            .filter(
-                user::Column::LastNameChangeAddedAt.gte(needs_token_time)
-            )
+            .filter(user::Column::LastNameChangeAddedAt.gte(needs_token_time))
             .all(txn)
             .await?;
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -569,15 +569,13 @@ impl UserService {
     /// The current number of rename tokens the user has.
     pub async fn add_name_change_token(
         ctx: &ServiceContext<'_>,
-        reference: Reference<'_>,
+        user_id: i64,
     ) -> Result<i16> {
         let txn = ctx.transaction();
-        let user = Self::get(ctx, reference).await?;
-
         let max_name_changes = ctx.config().maximum_name_changes;
         let name_changes = cmp::min(user.name_changes_left + 1, max_name_changes);
         let model = user::ActiveModel {
-            user_id: Set(user.user_id),
+            user_id: Set(user_id),
             name_changes_left: Set(name_changes),
             updated_at: Set(Some(now())),
             ..Default::default()

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -569,13 +569,13 @@ impl UserService {
     /// The current number of rename tokens the user has.
     pub async fn add_name_change_token(
         ctx: &ServiceContext<'_>,
-        user_id: i64,
+        user: &UserModel,
     ) -> Result<i16> {
         let txn = ctx.transaction();
         let max_name_changes = ctx.config().maximum_name_changes;
         let name_changes = cmp::min(user.name_changes_left + 1, max_name_changes);
         let model = user::ActiveModel {
-            user_id: Set(user_id),
+            user_id: Set(user.user_id),
             name_changes_left: Set(name_changes),
             updated_at: Set(Some(now())),
             ..Default::default()


### PR DESCRIPTION
Our plan for user renames is that they leave behind permanent redirects (if old enough), but since this a rather significant ability, we have name change tokens as a means of limiting how many someone can make. However, in order to allow people to still change their name and avoid lockout like in Wikidot, this job adds new tokens periodically, depending on the configuration in `deepwell.toml`.

Output during local test:
```sql
api-1       | deepwell::services::user::service Refreshing name change tokens for all users who need one
api-1       | sqlx::query summary="SELECT \"user\".\"user_id\", CAST(\"user\".\"user_type\" AS …" db.statement="\n\nSELECT\n  \"user\".\"user_id\",\n  CAST(\"user\".\"user_type\" AS text),\n  \"user\".\"created_at\",\n  \"user\".\"updated_at\",\n  \"user\".\"deleted_at\",\n  \"user\".\"from_wikidot\",\n  \"user\".\"name\",\n  \"user\".\"slug\",\n  \"user\".\"name_changes_left\",\n  \"user\".\"last_name_change_added_at\",\n  \"user\".\"last_renamed_at\",\n  \"user\".\"email\",\n  \"user\".\"email_is_alias\",\n  \"user\".\"email_verified_at\",\n  \"user\".\"password\",\n  \"user\".\"multi_factor_secret\",\n  \"user\".\"multi_factor_recovery_codes\",\n  \"user\".\"locales\",\n  \"user\".\"avatar_s3_hash\",\n  \"user\".\"real_name\",\n  \"user\".\"gender\",\n  \"user\".\"birthday\",\n  \"user\".\"location\",\n  \"user\".\"biography\",\n  \"user\".\"user_page\"\nFROM\n  \"user\"\nWHERE\n  \"user\".\"last_name_change_added_at\" IS NULL\n  OR \"user\".\"last_name_change_added_at\" >= $1\n" rows_affected=8 rows_returned=8 elapsed=8.600685ms elapsed_secs=0.008600685
api-1       | deepwell::services::user::service Found 8 users in need of a name refresh token
api-1       | deepwell::services::user::service Adding name change token to user ID 1 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=2.703251ms elapsed_secs=0.002703251
api-1       | deepwell::services::user::service Adding name change token to user ID 2 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=1.288532ms elapsed_secs=0.001288532
api-1       | deepwell::services::user::service Adding name change token to user ID 3 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=525.889µs elapsed_secs=0.000525889
api-1       | deepwell::services::user::service Adding name change token to user ID 4 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=496.683µs elapsed_secs=0.000496683
api-1       | deepwell::services::user::service Adding name change token to user ID 5 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=617.711µs elapsed_secs=0.000617711
api-1       | deepwell::services::user::service Adding name change token to user ID 6 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=525.958µs elapsed_secs=0.000525958
api-1       | deepwell::services::user::service Adding name change token to user ID 7 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=426.602µs elapsed_secs=0.000426602
api-1       | deepwell::services::user::service Adding name change token to user ID 8 (was 2, now 3, max 3)
api-1       | sqlx::query summary="UPDATE \"user\" SET \"updated_at\" …" db.statement="\n\nUPDATE\n  \"user\"\nSET\n  \"updated_at\" = $1,\n  \"name_changes_left\" = $2\nWHERE\n  \"user\".\"user_id\" = $3 RETURNING \"user_id\",\n  CAST(\"user_type\" AS text),\n  \"created_at\",\n  \"updated_at\",\n  \"deleted_at\",\n  \"from_wikidot\",\n  \"name\",\n  \"slug\",\n  \"name_changes_left\",\n  \"last_name_change_added_at\",\n  \"last_renamed_at\",\n  \"email\",\n  \"email_is_alias\",\n  \"email_verified_at\",\n  \"password\",\n  \"multi_factor_secret\",\n  \"multi_factor_recovery_codes\",\n  \"locales\",\n  \"avatar_s3_hash\",\n  \"real_name\",\n  \"gender\",\n  \"birthday\",\n  \"location\",\n  \"biography\",\n  \"user_page\"\n" rows_affected=0 rows_returned=1 elapsed=435.318µs elapsed_secs=0.000435318
```