### PR TITLE
Update stylelint rules

### DIFF
--- a/framerail/.stylelintrc.yaml
+++ b/framerail/.stylelintrc.yaml
@@ -19,7 +19,6 @@ rules:
   function-linear-gradient-no-nonstandard-direction: true
   length-zero-no-unit: true
   shorthand-property-no-redundant-values: true
-  property-case: lower
   comment-no-empty: true
   scss/selector-no-redundant-nesting-selector: true
 

--- a/web/.stylelintrc.yaml
+++ b/web/.stylelintrc.yaml
@@ -18,7 +18,6 @@ rules:
   function-linear-gradient-no-nonstandard-direction: true
   length-zero-no-unit: true
   shorthand-property-no-redundant-values: true
-  property-case: lower
   comment-no-empty: true
   scss/selector-no-redundant-nesting-selector: true
 


### PR DESCRIPTION
The rule `property-case` was deprecated in stylelint v15 and removed in v16.

The equivalent lint should be covered by prettier if I'm not mistaken. If we find out later on that wasn't the case, we can introduce [`stylelint-stylistic`](https://github.com/stylelint-stylistic/stylelint-stylistic) that brings back the deprecated rules.