### PR TITLE
[chore] [WJ-99] Upgrade ftml version to 1.24.0

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.23.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6777083ba47f112ec0aafe612a14355de6ad08fdaa88db2ea4435cb8d72d8ed4"
+checksum = "68cb8bc8569c182a70a37de10f2ef9cde08983ec3b48d65979e970b76ecc8135"
 dependencies = [
  "built",
  "cfg-if",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -31,7 +31,7 @@ femme = "2"
 filemagic = "0.12"
 fluent = "0.16"
 fluent-syntax = "0"
-ftml = { version = "1.23", features = ["mathml"] }
+ftml = { version = "1.24", features = ["mathml"] }
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 hex = { version = "0.4", features = ["serde"] }
 hostname = "0.4"


### PR DESCRIPTION
This is part of the changes for adding HTML and code block exposure support (e.g. `/code/1`).