### PR TITLE
[WJ-1248] Add sqlx to DEEPWELL

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -41,7 +41,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     info!("Running seeder...");
 
     // Set up context
-    let txn = state.database.begin().await?;
+    let txn = state.database_seaorm.begin().await?;
     let ctx = ServiceContext::new(state, &txn);
 
     // Ensure seeding has not already been done

--- a/deepwell/src/services/job/worker.rs
+++ b/deepwell/src/services/job/worker.rs
@@ -170,7 +170,7 @@ impl JobWorker {
 
         debug!("Received job from queue: {job:?}");
         trace!("Setting up ServiceContext for job processing");
-        let txn = self.state.database.begin().await?;
+        let txn = self.state.database_seaorm.begin().await?;
         let ctx = &ServiceContext::new(&self.state, &txn);
 
         trace!("Beginning job processing");


### PR DESCRIPTION
See the parent issue [WJ-1247](https://scuttle.atlassian.net/browse/WJ-1247). This issue adds `sqlx` directly as a database dependency and in the internal state. This way we can start moving things from SeaORM to SQLx without spending a bunch of time on a giant refactor.

[WJ-1247]: https://scuttle.atlassian.net/browse/WJ-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ