### PR TITLE
Use SQLx in ping query

### DIFF
--- a/deepwell/.sqlx/query-c3b9b519cbdd6e6936318bc24556cc9b7e8a8d118584fa470b98b5869285a031.json
+++ b/deepwell/.sqlx/query-c3b9b519cbdd6e6936318bc24556cc9b7e8a8d118584fa470b98b5869285a031.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT 1 AS x",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "x",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c3b9b519cbdd6e6936318bc24556cc9b7e8a8d118584fa470b98b5869285a031"
+}

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2024.5.12"
+version = "2024.7.15"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2024.5.12"
+version = "2024.7.15"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -31,6 +31,14 @@ If you have [`sea-orm-cli`](https://www.sea-ql.org/SeaORM/docs/generate-entity/s
 $ scripts/generate-models.sh
 ```
 
+When adding SQLx queries, they need to be cached. After `source .env` (to set `DATABASE_URL`), run the following to update the query list:
+
+```sh
+$ cargo sqlx prepare
+```
+
+Then commit any new files into the branch.
+
 #### Structure
 
 The primary organization of the crate is as follows:

--- a/deepwell/src/endpoints/misc.rs
+++ b/deepwell/src/endpoints/misc.rs
@@ -25,11 +25,9 @@ use wikidot_normalize::normalize;
 
 async fn postgres_check(ctx: &ServiceContext<'_>) -> Result<()> {
     let mut txn = ctx.sqlx().await?;
-    let _ = sqlx::query!(r"SELECT 1 AS x")
-        .fetch_one(&mut *txn)
-        .await?;
-
+    let _ = sqlx::query!(r"SELECT 1 AS x").fetch_one(&mut *txn).await?;
     txn.commit().await?;
+
     debug!("Successfully pinged Postgres");
     Ok(())
 }

--- a/deepwell/src/endpoints/misc.rs
+++ b/deepwell/src/endpoints/misc.rs
@@ -20,18 +20,16 @@
 
 use super::prelude::*;
 use crate::info;
-use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 use std::path::PathBuf;
 use wikidot_normalize::normalize;
 
 async fn postgres_check(ctx: &ServiceContext<'_>) -> Result<()> {
-    ctx.transaction()
-        .execute(Statement::from_string(
-            DatabaseBackend::Postgres,
-            str!("SELECT 1"),
-        ))
+    let mut txn = ctx.sqlx().await?;
+    let _ = sqlx::query!(r"SELECT 1 AS x")
+        .fetch_one(&mut *txn)
         .await?;
 
+    txn.commit().await?;
     debug!("Successfully pinged Postgres");
     Ok(())
 }

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -91,4 +91,10 @@ impl<'txn> ServiceContext<'txn> {
     pub fn transaction(&self) -> &'txn DatabaseTransaction {
         self.transaction
     }
+
+    #[inline]
+    pub async fn sqlx(&self) -> Result<sqlx::Transaction<sqlx::Postgres>> {
+        let txn = self.state.database_sqlx.begin().await?;
+        Ok(txn)
+    }
 }

--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error("Database error: {0}")]
     Database(DbErr),
 
+    #[error("Database error: {0}")]
+    Database2(#[from] sqlx::Error),
+
     #[error("Redis error: {0}")]
     Redis(#[from] redis::RedisError),
 
@@ -340,7 +343,7 @@ impl Error {
 
             // 3200 -- Backend issues
             Error::Serde(_) => 3200,
-            Error::Database(_) => 3201,
+            Error::Database(_) | Error::Database2(_) => 3201,
             Error::Cryptography(_) => 3202,
             Error::Magic(_) => 3204,
             Error::Otp(_) => 3205,


### PR DESCRIPTION
The first migrated query, this one is an ad hoc one to ensure the database is connected, so doesn't benefit from SeaORM at all.

```
api-1       | sqlx::query summary="SELECT 1" db.statement="" rows_affected=1 rows_returned=1 elapsed=1.104059ms elapsed_secs=0.001104059
api-1       | deepwell::endpoints::misc Successfully pinged Postgres
api-1       | deepwell::endpoints::misc Successfully pinged Redis
api-1       | sqlx::query summary="COMMIT" db.statement="" rows_affected=0 rows_returned=0 elapsed=232.294µs elapsed_secs=0.000232294
```

Also bumps the deepwell version since it's been a while.