### PR TITLE
Run sqlx migrations separately rather than in deepwell

### DIFF
--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -595,14 +595,16 @@ impl PageService {
         }
 
         let mut txn = ctx.sqlx().await?;
-        let row = sqlx::query_as!(
-            Row,
-            r"SELECT layout FROM page WHERE site_id = $1 AND page_id = $2",
-            site_id,
-            page_id,
-        )
-        .fetch_one(&mut *txn)
-        .await?;
+        let row = find_or_error!(
+            sqlx::query_as!(
+                Row,
+                r"SELECT layout FROM page WHERE site_id = $1 AND page_id = $2",
+                site_id,
+                page_id,
+            )
+            .fetch_optional(&mut *txn),
+            Page,
+        )?;
 
         txn.commit().await?;
 

--- a/install/files/local/deepwell-start
+++ b/install/files/local/deepwell-start
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Run migrations
+#
+# deepwell is able to do this itself, but we run it separately via
+# the sqlx CLI tool to avoid dependency cycles wherein the deepwell
+# build wants the database to be up, but the migrations running is
+# dependent on the build having finished and deepwell running.
+sqlx migrate run
+
+# Start watcher
+#
+# This will recompile and restart the deepwell daemon on any source changes
+# The commandline being run for the daemon is "deepwell /etc/deepwell.toml".
+
+/usr/local/cargo/bin/cargo watch \
+    --why \
+    -w /src/deepwell \
+    -w /opt/locales \
+    -w /etc/deepwell.toml \
+    -x 'run -- /etc/deepwell.toml'

--- a/install/files/local/deepwell-start
+++ b/install/files/local/deepwell-start
@@ -6,7 +6,7 @@
 # the sqlx CLI tool to avoid dependency cycles wherein the deepwell
 # build wants the database to be up, but the migrations running is
 # dependent on the build having finished and deepwell running.
-sqlx migrate run
+/usr/local/cargo/bin/sqlx migrate run
 
 # Start watcher
 #

--- a/install/files/local/deepwell-start
+++ b/install/files/local/deepwell-start
@@ -13,7 +13,7 @@
 # This will recompile and restart the deepwell daemon on any source changes
 # The commandline being run for the daemon is "deepwell /etc/deepwell.toml".
 
-exec /usr/bin/env RUST_BACKTRACE=full \
+exec /usr/bin/env RUST_BACKTRACE=1 \
     /usr/local/cargo/bin/cargo watch \
         --why \
         -w /src/deepwell \

--- a/install/files/local/deepwell-start
+++ b/install/files/local/deepwell-start
@@ -13,9 +13,10 @@
 # This will recompile and restart the deepwell daemon on any source changes
 # The commandline being run for the daemon is "deepwell /etc/deepwell.toml".
 
-exec /usr/local/cargo/bin/cargo watch \
-    --why \
-    -w /src/deepwell \
-    -w /opt/locales \
-    -w /etc/deepwell.toml \
-    -x 'run -- /etc/deepwell.toml'
+exec /usr/bin/env RUST_BACKTRACE=full \
+    /usr/local/cargo/bin/cargo watch \
+        --why \
+        -w /src/deepwell \
+        -w /opt/locales \
+        -w /etc/deepwell.toml \
+        -x 'run -- /etc/deepwell.toml'

--- a/install/files/local/deepwell-start
+++ b/install/files/local/deepwell-start
@@ -13,7 +13,7 @@ sqlx migrate run
 # This will recompile and restart the deepwell daemon on any source changes
 # The commandline being run for the daemon is "deepwell /etc/deepwell.toml".
 
-/usr/local/cargo/bin/cargo watch \
+exec /usr/local/cargo/bin/cargo watch \
     --why \
     -w /src/deepwell \
     -w /opt/locales \

--- a/install/files/local/deepwell.toml
+++ b/install/files/local/deepwell.toml
@@ -7,7 +7,7 @@ address = "[::]:2747"
 pid-file = "/run/deepwell.pid"
 
 [database]
-run-migrations = true
+run-migrations = false
 run-seeder = true
 seeder-path = "seeder"
 

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -17,6 +17,7 @@ RUN cargo install cargo-watch sqlx-cli
 
 # Install files
 COPY install/files/local/deepwell.toml /etc/deepwell.toml
+COPY install/files/local/deepwell-start /bin/wikijump-deepwell-start
 COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
@@ -27,13 +28,5 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-# Run migrations
-#
-# deepwell is able to do this itself, but we run it separately via
-# the sqlx CLI tool to avoid dependency cycles wherein the deepwell
-# build wants the database to be up, but the migrations running is
-# dependent on the build having finished and deepwell running.
-RUN sqlx migrate run
-
 EXPOSE 2747
-CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run -- /etc/deepwell.toml"]
+CMD ["/bin/wikijump-deepwell-start"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -21,6 +21,12 @@ COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
 
+# Copy source
+# Don't build until container execution (see cargo-watch)
+RUN mkdir /src
+COPY ./deepwell /src/deepwell
+WORKDIR /src/deepwell
+
 # Run migrations
 #
 # deepwell is able to do this itself, but we run it separately via
@@ -28,12 +34,6 @@ COPY install/files/api/health-check.sh /bin/wikijump-health-check
 # build wants the database to be up, but the migrations running is
 # dependent on the build having finished and deepwell running.
 RUN sqlx migrate run
-
-# Copy source
-# Don't build until container execution (see cargo-watch)
-RUN mkdir /src
-COPY ./deepwell /src/deepwell
-WORKDIR /src/deepwell
 
 EXPOSE 2747
 CMD ["/usr/local/cargo/bin/cargo", "watch", "-w", "/src/deepwell", "-w", "/opt/locales", "-w", "/etc/deepwell.toml", "--why", "-x", "run -- /etc/deepwell.toml"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -13,13 +13,21 @@ RUN apt update
 RUN apt install -y libmagic-dev
 
 # Install helpers
-RUN cargo install cargo-watch
+RUN cargo install cargo-watch sqlx-cli
 
 # Install files
 COPY install/files/local/deepwell.toml /etc/deepwell.toml
 COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
+
+# Run migrations
+#
+# deepwell is able to do this itself, but we run it separately via
+# the sqlx CLI tool to avoid dependency cycles wherein the deepwell
+# build wants the database to be up, but the migrations running is
+# dependent on the build having finished and deepwell running.
+RUN sqlx migrate run
 
 # Copy source
 # Don't build until container execution (see cargo-watch)


### PR DESCRIPTION
Since we've started using sqlx directly (as part of a long-term effort to replace Sea-ORM, due to not really needing the ORM part and being able to use direct queries instead), we have been encountering an issue where builds fail because the database isn't up.

In such cases, the build is supposed to refer to the `.sqlx` directory for caching, but I guess in some cases the cache is not adequate.

As a relevant note, you can update this `.sqlx` directory using `cargo sqlx prepare`.

This issue produces errors like the following:

<details>
<summary>Docker logs / traceback</summary>

```rs
api-1       | error: error returned from database: relation "page" does not exist
api-1       |    --> src/services/page/service.rs:518:29
api-1       |     |
api-1       | 518 |           let rows_affected = sqlx::query!(
api-1       |     |  _____________________________^
api-1       | 519 | |             r"
api-1       | 520 | |             UPDATE page
api-1       | 521 | |             SET layout = $1
api-1       | ...   |
api-1       | 527 | |             page_id,
api-1       | 528 | |         )
api-1       |     | |_________^
api-1       |     |
api-1       |     = note: this error originates in the macro `$crate::sqlx_macros::expand_query` which comes from the expansion of the macro `sqlx::query` (in Nightly builds, run with -Z macro-backtrace for more info)
api-1       | 
database-1  | 2024-08-05 07:11:19.358 UTC [603] ERROR:  relation "page" does not exist at character 20
database-1  | 2024-08-05 07:11:19.358 UTC [603] STATEMENT:  SELECT layout FROM page WHERE site_id = $1 AND page_id = $2
api-1       | error: error returned from database: relation "page" does not exist
api-1       |    --> src/services/page/service.rs:598:19
api-1       |     |
api-1       | 598 |           let row = sqlx::query_as!(
api-1       |     |  ___________________^
api-1       | 599 | |             Row,
api-1       | 600 | |             r"SELECT layout FROM page WHERE site_id = $1 AND page_id = $2",
api-1       | 601 | |             site_id,
api-1       | 602 | |             page_id,
api-1       | 603 | |         )
api-1       |     | |_________^
api-1       |     |
api-1       |     = note: this error originates in the macro `$crate::sqlx_macros::expand_query` which comes from the expansion of the macro `sqlx::query_as` (in Nightly builds, run with -Z macro-backtrace for more info)
api-1       | 
api-1       | error: error returned from database: relation "site" does not exist
api-1       |    --> src/services/site/service.rs:306:13
database-1  | 2024-08-05 07:11:19.632 UTC [603] ERROR:  relation "site" does not exist at character 20
api-1       |     |
database-1  | 2024-08-05 07:11:19.632 UTC [603] STATEMENT:  SELECT layout FROM site WHERE site_id = $1
api-1       | 306 |             sqlx::query_as!(Row, r"SELECT layout FROM site WHERE site_id = $1", site_id)
api-1       |     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1       |     |
api-1       |     = note: this error originates in the macro `$crate::sqlx_macros::expand_query` which comes from the expansion of the macro `sqlx::query_as` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>

As noted in a code comment in the new start script, this creates a dependency cycle where you have two blocking forces:
* Migrations are run after DEEPWELL builds, as a runtime step.
* DEEPWELL cannot run until it builds, and it cannot build until it has a migrated database it can connect to.

We can fix this by disabling the auto-migration-on-start step for local docker instances and instead running `sqlx migrate run` (which is effectively what DEEPWELL is doing at start time) as a separate Docker step instead, to set up the database schema. One downside is that two cargo tools need to be built rather than one; however this step is earlier and so should be cached even when you are making iterative changes during development.

Also fixes part of an unrelated bug in the seeder related to sqlx. The error is both not handling an error case properly, and not being able to fetch data that is in a transaction in SeaORM. However a full fix will require migrating more of DEEPWELL to use plain SQLx.