### PR TITLE
[WJ-1270] Temporary fix for seeder issue

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2024.8.2"
+version = "2024.8.17"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2024.8.2"
+version = "2024.8.17"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/deepwell/seeder/pages.json
+++ b/deepwell/seeder/pages.json
@@ -5,6 +5,7 @@
             "name": "Wikijump",
             "tagline": "Fighting Ozone Pollution",
             "description": "Wikijump host site",
+            "layout": "wikijump",
             "locale": "en"
         },
         "aliases": [],
@@ -67,6 +68,7 @@
             "name": "Test site",
             "tagline": "The other kind of sandbox",
             "description": "Platform testing and experiments",
+            "layout": "wikidot",
             "locale": "en"
         },
         "aliases": ["check"],
@@ -114,6 +116,7 @@
             "name": "Default template site",
             "tagline": "",
             "description": "Template site (English)",
+            "layout": null,
             "locale": "en"
         },
         "aliases": [],

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -20,6 +20,7 @@
 
 use crate::models::sea_orm_active_enums::UserType;
 use anyhow::Result;
+use ftml::layout::Layout;
 use serde::Deserialize;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
@@ -114,6 +115,7 @@ pub struct Site {
     pub name: String,
     pub tagline: String,
     pub description: String,
+    pub layout: Option<Layout>,
     pub locale: String,
 }
 

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -152,6 +152,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                 name: site.name,
                 tagline: site.tagline,
                 description: site.description,
+                layout: site.layout,
                 locale: site.locale,
             },
         )
@@ -184,6 +185,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                     title: page.title,
                     alt_title: page.alt_title,
                     slug: page.slug,
+                    layout: None,
                     revision_comments: str!(""),
                     user_id: SYSTEM_USER_ID,
                     bypass_filter: true,

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -514,6 +514,21 @@ impl PageService {
     ) -> Result<()> {
         debug!("Setting page layout for site ID {site_id} page ID {page_id}");
 
+        let txn = ctx.transaction();
+        let model = page::ActiveModel {
+            page_id: Set(page_id),
+            layout: Set(layout.map(|l| str!(l.value()))),
+            ..Default::default()
+        };
+        model.update(txn).await?;
+        Ok(())
+
+        /*
+            TODO: Temporary workaround for seeding while we move to SQLx
+                  Use SeaORM instead of SQLx for this query
+
+                  See https://scuttle.atlassian.net/browse/WJ-1270
+
         let mut txn = ctx.sqlx().await?;
         let rows_affected = sqlx::query!(
             r"
@@ -537,6 +552,8 @@ impl PageService {
         } else {
             Err(Error::PageNotFound)
         }
+
+        */
     }
 
     #[inline]
@@ -589,6 +606,10 @@ impl PageService {
     ) -> Result<Layout> {
         debug!("Getting page layout for site ID {site_id} page ID {page_id}");
 
+        /*
+            TODO: Temporary workaround, see set_layout()
+                  See https://scuttle.atlassian.net/browse/WJ-1270
+
         #[derive(Debug)]
         struct Row {
             layout: Option<String>,
@@ -607,8 +628,16 @@ impl PageService {
         )?;
 
         txn.commit().await?;
+        */
 
-        match row.layout {
+        let page = Self::get(
+            ctx,
+            site_id,
+            Reference::Id(page_id),
+        )
+        .await?;
+
+        match page.layout {
             // Parse layout from string in page table
             Some(layout) => match layout.parse() {
                 Ok(layout) => Ok(layout),

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -48,6 +48,7 @@ impl PageService {
             title,
             alt_title,
             mut slug,
+            layout,
             revision_comments: comments,
             user_id,
             bypass_filter,
@@ -93,6 +94,7 @@ impl PageService {
             title,
             alt_title,
             slug: slug.clone(),
+            layout,
         };
 
         let CreateFirstPageRevisionOutput {

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -632,13 +632,7 @@ impl PageService {
         txn.commit().await?;
         */
 
-        let page = Self::get(
-            ctx,
-            site_id,
-            Reference::Id(page_id),
-        )
-        .await?;
-
+        let page = Self::get(ctx, site_id, Reference::Id(page_id)).await?;
         match page.layout {
             // Parse layout from string in page table
             Some(layout) => match layout.parse() {

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -34,6 +34,7 @@ pub struct CreatePage {
     pub title: String,
     pub alt_title: Option<String>,
     pub slug: String,
+    pub layout: Option<Layout>,
     pub revision_comments: String,
     pub user_id: i64,
 

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -328,15 +328,22 @@ impl PageRevisionService {
             title,
             alt_title,
             slug,
+            layout,
         }: CreateFirstPageRevision,
     ) -> Result<CreateFirstPageRevisionOutput> {
         let txn = ctx.transaction();
 
+        // If the page creation doesn't specify a preferred layout,
+        // use the default for the site.
+        let layout = match layout {
+            None => SiteService::get_layout(ctx, site_id).await?,
+            Some(layout) => layout,
+        };
+
         // Get ancillary page data
-        let (wikitext_hash, score, layout) = try_join!(
+        let (wikitext_hash, score) = try_join!(
             TextService::create(ctx, wikitext.clone()),
             ScoreService::score(ctx, page_id),
-            PageService::get_layout(ctx, site_id, page_id), // XXX
         )?;
 
         // Render first revision

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -336,7 +336,7 @@ impl PageRevisionService {
         let (wikitext_hash, score, layout) = try_join!(
             TextService::create(ctx, wikitext.clone()),
             ScoreService::score(ctx, page_id),
-            PageService::get_layout(ctx, site_id, page_id),
+            PageService::get_layout(ctx, site_id, page_id), // XXX
         )?;
 
         // Render first revision

--- a/deepwell/src/services/page_revision/structs.rs
+++ b/deepwell/src/services/page_revision/structs.rs
@@ -22,6 +22,7 @@ use super::prelude::*;
 use crate::models::sea_orm_active_enums::PageRevisionType;
 use crate::web::{FetchDirection, PageDetails};
 use ftml::parsing::ParseError;
+use ftml::layout::Layout;
 use std::num::NonZeroI32;
 use time::OffsetDateTime;
 
@@ -52,6 +53,7 @@ pub struct CreateFirstPageRevision {
     pub title: String,
     pub alt_title: Option<String>,
     pub slug: String,
+    pub layout: Option<Layout>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/page_revision/structs.rs
+++ b/deepwell/src/services/page_revision/structs.rs
@@ -21,8 +21,8 @@
 use super::prelude::*;
 use crate::models::sea_orm_active_enums::PageRevisionType;
 use crate::web::{FetchDirection, PageDetails};
-use ftml::parsing::ParseError;
 use ftml::layout::Layout;
+use ftml::parsing::ParseError;
 use std::num::NonZeroI32;
 use time::OffsetDateTime;
 

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -298,6 +298,10 @@ impl SiteService {
     pub async fn get_layout(ctx: &ServiceContext<'_>, site_id: i64) -> Result<Layout> {
         debug!("Getting page layout for site ID {site_id}");
 
+        /*
+            TODO: Temporary workaround, see set_layout()
+                  See https://scuttle.atlassian.net/browse/WJ-1270
+
         #[derive(Debug)]
         struct Row {
             layout: Option<String>,
@@ -310,8 +314,10 @@ impl SiteService {
                 .await?;
 
         txn.commit().await?;
+        */
 
-        match row.layout {
+        let site = Self::get(ctx, Reference::Id(site_id)).await?;
+        match site.layout {
             // Parse layout from string in site table
             Some(layout) => match layout.parse() {
                 Ok(layout) => Ok(layout),

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -44,6 +44,7 @@ impl SiteService {
             name,
             tagline,
             description,
+            layout,
             locale,
         }: CreateSite,
     ) -> Result<CreateSiteOutput> {
@@ -64,6 +65,7 @@ impl SiteService {
             name: Set(name),
             tagline: Set(tagline),
             description: Set(description.clone()),
+            layout: Set(layout.map(|l| str!(l.value()))),
             locale: Set(locale.clone()),
             ..Default::default()
         };

--- a/deepwell/src/services/site/structs.rs
+++ b/deepwell/src/services/site/structs.rs
@@ -30,6 +30,7 @@ pub struct CreateSite {
     pub name: String,
     pub tagline: String,
     pub description: String,
+    pub layout: Option<Layout>,
     pub locale: String,
 }
 

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -28,13 +28,5 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
-# Run migrations
-#
-# deepwell is able to do this itself, but we run it separately via
-# the sqlx CLI tool to avoid dependency cycles wherein the deepwell
-# build wants the database to be up, but the migrations running is
-# dependent on the build having finished and deepwell running.
-RUN sqlx migrate run
-
 EXPOSE 2747
 CMD ["/bin/wikijump-deepwell-start"]

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -22,6 +22,14 @@ COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
 
+# Run migrations
+#
+# deepwell is able to do this itself, but we run it separately via
+# the sqlx CLI tool to avoid dependency cycles wherein the deepwell
+# build wants the database to be up, but the migrations running is
+# dependent on the build having finished and deepwell running.
+RUN sqlx migrate run
+
 # Copy source
 # Don't build until container execution (see cargo-watch)
 RUN mkdir /src

--- a/install/local/dev/api/Dockerfile
+++ b/install/local/dev/api/Dockerfile
@@ -22,6 +22,12 @@ COPY install/files/api/health-check.sh /bin/wikijump-health-check
 
 # /opt/locales is provided via docker-compose.dev.yaml
 
+# Copy source
+# Don't build until container execution (see cargo-watch)
+RUN mkdir /src
+COPY ./deepwell /src/deepwell
+WORKDIR /src/deepwell
+
 # Run migrations
 #
 # deepwell is able to do this itself, but we run it separately via
@@ -29,12 +35,6 @@ COPY install/files/api/health-check.sh /bin/wikijump-health-check
 # build wants the database to be up, but the migrations running is
 # dependent on the build having finished and deepwell running.
 RUN sqlx migrate run
-
-# Copy source
-# Don't build until container execution (see cargo-watch)
-RUN mkdir /src
-COPY ./deepwell /src/deepwell
-WORKDIR /src/deepwell
 
 EXPOSE 2747
 CMD ["/bin/wikijump-deepwell-start"]


### PR DESCRIPTION
After having spent a day or so on it, the permanent fix for this will take more time, so for now I'll just do this as a temporary workaround so seeding works again. I also cherry-pick commits from the WJ-1270 permanent fix branch which is needed for the migration step.

This has two changes:
1. Fix for cyclic dependencies in the seeding and page creation process.
2. Use of temporary SeaORM implementations where the pages (and site) is only created in the SeaORM transaction and not yet in the database proper.