### PR TITLE
Install sqlx into Dokku dev container

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: /usr/bin/node /app/framerail/build
-api: /usr/local/bin/deepwell /etc/deepwell.toml
+api: /usr/local/bin/deepwell-start

--- a/install/dev/dokku/Dockerfile
+++ b/install/dev/dokku/Dockerfile
@@ -8,6 +8,9 @@ FROM rust:alpine AS rust
 RUN apk update
 RUN apk add --no-cache build-base libmagic-static file
 
+# Install helpers
+RUN cargo install sqlx-cli
+
 # Copy source
 RUN mkdir /src
 COPY ./deepwell /src/deepwell
@@ -49,18 +52,20 @@ FROM alpine:latest
 
 ENV LOCALIZATION_PATH="/opt/locales"
 
-RUN mkdir /app
+RUN mkdir /app /opt/database
 WORKDIR /app
 
 RUN apk update
 RUN apk add --no-cache curl nodejs libmagic-static file
 
+COPY --from=rust /usr/local/cargo/bin/sqlx /usr/local/cargo/bin/sqlx
 COPY --from=rust /src/deepwell/target/release/deepwell /usr/local/bin/deepwell
 COPY --from=node /app /app/framerail
 
 COPY ./install/files/api/health-check.sh /bin/deepwell-health-check
 COPY ./install/files/dev/deepwell.toml /etc/deepwell.toml
 COPY ./locales/fluent /opt/locales/fluent
-COPY ./deepwell/seeder /opt/seeder
+COPY ./deepwell/seeder /opt/database/seeder
+COPY ./deepwell/migrations /opt/database/migrations
 
 USER daemon

--- a/install/dev/dokku/Dockerfile
+++ b/install/dev/dokku/Dockerfile
@@ -64,6 +64,7 @@ COPY --from=node /app /app/framerail
 
 COPY ./install/files/api/health-check.sh /bin/deepwell-health-check
 COPY ./install/files/dev/deepwell.toml /etc/deepwell.toml
+COPY ./install/files/dev/deepwell-start /usr/local/bin/wikijump-deepwell-start
 COPY ./locales/fluent /opt/locales/fluent
 COPY ./deepwell/seeder /opt/database/seeder
 COPY ./deepwell/migrations /opt/database/migrations

--- a/install/dev/dokku/Dockerfile
+++ b/install/dev/dokku/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update
 RUN apk add --no-cache build-base libmagic-static file
 
 # Install helpers
-RUN cargo install sqlx-cli
+RUN cargo install sqlx-cli --no-default-features --features rustls,postgres
 
 # Copy source
 RUN mkdir /src

--- a/install/files/dev/deepwell-start
+++ b/install/files/dev/deepwell-start
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Run migrations
+cd /opt/database
+/usr/local/cargo/bin/sqlx migrate run
+
+# Start daemon
+/usr/local/bin/deepwell /etc/deepwell.toml

--- a/install/files/dev/deepwell.toml
+++ b/install/files/dev/deepwell.toml
@@ -8,7 +8,7 @@ pid-file = ""
 
 [database]
 run-seeder = true
-seeder-path = "/opt/seeder"
+seeder-path = "/opt/database/seeder"
 
 [security]
 authentication-fail-delay-ms = 100


### PR DESCRIPTION
I noticed, while trying to run manual db migrations for our current wikijump.dev Dokku deploy, that we don't have sqlx installed in the container, which prevents us from running migrations.

I copied several parts of the `digitalocean` branch and the upcoming DO dev deploy as a fix in the current Dokku dev environment for now.