### PR TITLE
Add setting to disable csrf on local

### DIFF
--- a/framerail/svelte.config.js
+++ b/framerail/svelte.config.js
@@ -11,7 +11,7 @@ const config = {
     adapter: adapter(),
     csrf: {
       // Allow flexible hosts on local, since we don't have real DNS
-      checkOrigin: process.env.FRAMERAIL_ENV !== 'local',
+      checkOrigin: process.env.FRAMERAIL_ENV !== "local"
     }
   },
 

--- a/framerail/svelte.config.js
+++ b/framerail/svelte.config.js
@@ -8,7 +8,11 @@ const config = {
   preprocess: preprocess(),
 
   kit: {
-    adapter: adapter()
+    adapter: adapter(),
+    csrf: {
+      // Allow flexible hosts on local, since we don't have real DNS
+      checkOrigin: process.env.FRAMERAIL_ENV !== 'local',
+    }
   },
 
   compilerOptions: {

--- a/install/aws/prod/docker/web/Dockerfile
+++ b/install/aws/prod/docker/web/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 # Run command
 USER node:node
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV FRAMERAIL_ENV=prod
 EXPOSE 3000
 
 CMD ["/usr/local/bin/node", "build"]

--- a/install/dev/digitalocean/web/Dockerfile
+++ b/install/dev/digitalocean/web/Dockerfile
@@ -23,6 +23,7 @@ RUN \
 # Run command
 USER node:node
 ENV NODE_ENV=production
+ENV FRAMERAIL_ENV=dev
 ENV PORT=3000
 EXPOSE 3000
 

--- a/install/local/dev/web/Dockerfile
+++ b/install/local/dev/web/Dockerfile
@@ -13,4 +13,5 @@ WORKDIR /app
 RUN pnpm install
 
 EXPOSE 3000
+ENV FRAMERAIL_ENV=local
 CMD ["pnpm", "dev"]


### PR DESCRIPTION
Since we have a local nginx instance, it is causing the domain to differ which is messing with `ORIGIN` checking in the CSRF safety check.

See also: https://stackoverflow.com/questions/73790956/cross-site-post-form-submissions-are-forbidden