### PR TITLE
Add domains to app.yaml

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -6,6 +6,16 @@ alerts:
 
 static_sites: []
 
+domains:
+- domain: wikijump.dev
+  zone: wikijump.dev
+  type: PRIMARY
+  wildcard: true
+- domain: scpwiki.dev
+  zone: scpwiki.dev
+  type: ALIAS
+  wildcard: true
+
 services:
   - name: framerail
     source_dir: .


### PR DESCRIPTION
These were added in the control panel during rollout, but also need to be in the `app.yaml` to be persistent.