### PR TITLE
Update ftml dependency version

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.26.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbfbedcccfcb4e9756947e5de9eda51ee9d1ae4cf3559927689b6f4180b596a"
+checksum = "8b9e7d928f9c118863c143c3d3f84b8a726ce556acf105cb3d44f6c7f8b9a5b5"
 dependencies = [
  "built",
  "cfg-if",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -32,7 +32,7 @@ femme = "2"
 filemagic = "0.12"
 fluent = "0.16"
 fluent-syntax = "0"
-ftml = { version = "1.26", features = ["mathml"] }
+ftml = { version = "1.27", features = ["mathml"] }
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 hex = { version = "0.4", features = ["serde"] }
 hostname = "0.4"


### PR DESCRIPTION
This lets us integrate https://github.com/scpwiki/ftml/pull/22 into deepwell, to bring the anchor/link fix into local and dev deploys.