### PR TITLE
[chore] Bump framerail version to v2024.9.14

### DIFF
--- a/framerail/package.json
+++ b/framerail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "framerail",
-  "version": "2023.5.7",
+  "version": "2024.9.14",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
There have been significant recent changes and we haven't increased the framerail version number for a while.