### PR TITLE
[WJ-1020] Require passing in last revision ID for page operations

### DIFF
--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -131,6 +131,9 @@ pub enum Error {
     #[error("Cannot hide the wikitext for the latest page revision")]
     CannotHideLatestRevision,
 
+    #[error("Revision ID passed for this operation is not the latest")]
+    NotLatestRevisionId,
+
     #[error("The regular expression found in the database is invalid")]
     FilterRegexInvalid(regex::Error),
 
@@ -388,6 +391,7 @@ impl Error {
             Error::BlobTooBig => 4023,
             Error::BlobNotUploaded => 4024,
             Error::BlobSizeMismatch => 4025,
+            Error::NotLatestRevisionId => 4027,
 
             // 4100 -- Localization
             Error::LocaleInvalid(_) => 4100,

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -110,7 +110,7 @@ impl PageService {
             ..Default::default()
         };
         let page = model.update(txn).await?;
-        check_latest_revision(&page);
+        assert_latest_revision(&page);
 
         // Build and return
         Ok(CreatePageOutput {
@@ -200,7 +200,7 @@ impl PageService {
             ..Default::default()
         };
         let page = model.update(txn).await?;
-        check_latest_revision(&page);
+        assert_latest_revision(&page);
 
         // Build and return
         Ok(revision_output)
@@ -282,7 +282,7 @@ impl PageService {
             ..Default::default()
         };
         let page = model.update(txn).await?;
-        check_latest_revision(&page);
+        assert_latest_revision(&page);
 
         // Build and return
 
@@ -343,7 +343,7 @@ impl PageService {
             ..Default::default()
         };
         let page = model.update(txn).await?;
-        check_latest_revision(&page);
+        assert_latest_revision(&page);
 
         Ok((output, page_id).into())
     }
@@ -413,7 +413,7 @@ impl PageService {
             ..Default::default()
         };
         let page = model.update(txn).await?;
-        check_latest_revision(&page);
+        assert_latest_revision(&page);
 
         Ok((output, slug).into())
     }
@@ -830,7 +830,7 @@ impl PageService {
     }
 }
 
-fn check_latest_revision(page: &PageModel) {
+fn assert_latest_revision(page: &PageModel) {
     // Even in production, we want to assert that this invariant holds.
     //
     // We cannot set the column itself to NOT NULL because of cyclic update

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -830,6 +830,7 @@ impl PageService {
     }
 }
 
+/// Ensure that the page has a properly-set `latest_revision_id` column.
 fn assert_latest_revision(page: &PageModel) {
     // Even in production, we want to assert that this invariant holds.
     //

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -21,6 +21,7 @@
 use super::prelude::*;
 use crate::models::page::{self, Entity as Page, Model as PageModel};
 use crate::models::page_category::Model as PageCategoryModel;
+use crate::models::page_revision::Model as PageRevisionModel;
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::page_revision::{
     CreateFirstPageRevision, CreateFirstPageRevisionOutput, CreatePageRevision,
@@ -126,6 +127,7 @@ impl PageService {
         EditPage {
             site_id,
             page: reference,
+            last_revision_id,
             revision_comments: comments,
             user_id,
             body:
@@ -138,7 +140,11 @@ impl PageService {
         }: EditPage<'_>,
     ) -> Result<Option<EditPageOutput>> {
         let txn = ctx.transaction();
-        let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
+        let PageModel {
+            page_id,
+            latest_revision_id,
+            ..
+        } = Self::get(ctx, site_id, reference).await?;
 
         // Perform filter validation
         Self::run_filter(
@@ -154,9 +160,11 @@ impl PageService {
         )
         .await?;
 
-        // Get latest revision
+        // Get and check latest revision
         let last_revision =
             PageRevisionService::get_latest(ctx, site_id, page_id).await?;
+
+        check_last_revision(Some(&last_revision), latest_revision_id, last_revision_id)?;
 
         // Create new revision
         //
@@ -213,17 +221,21 @@ impl PageService {
             site_id,
             page: reference,
             mut new_slug,
+            last_revision_id,
             revision_comments: comments,
             user_id,
         }: MovePage<'_>,
     ) -> Result<MovePageOutput> {
         let txn = ctx.transaction();
-
         let PageModel {
             page_id,
             slug: old_slug,
+            latest_revision_id,
             ..
         } = Self::get(ctx, site_id, reference).await?;
+
+        // Check last revision ID argument
+        check_last_revision(None, latest_revision_id, last_revision_id)?;
 
         // Check that a move is actually taking place,
         // and that a page with that slug doesn't already exist.
@@ -310,16 +322,23 @@ impl PageService {
         DeletePage {
             site_id,
             page: reference,
+            last_revision_id,
             user_id,
             revision_comments: comments,
         }: DeletePage<'_>,
     ) -> Result<DeletePageOutput> {
         let txn = ctx.transaction();
-        let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
+        let PageModel {
+            page_id,
+            latest_revision_id,
+            ..
+        } = Self::get(ctx, site_id, reference).await?;
 
-        // Get latest revision
+        // Get and check latest revision
         let last_revision =
             PageRevisionService::get_latest(ctx, site_id, page_id).await?;
+
+        check_last_revision(Some(&last_revision), latest_revision_id, last_revision_id)?;
 
         // Create tombstone revision
         // This also updates backlinks, includes, etc
@@ -430,19 +449,27 @@ impl PageService {
         RollbackPage {
             site_id,
             page: reference,
+            last_revision_id,
             revision_number,
             revision_comments: comments,
             user_id,
         }: RollbackPage<'_>,
     ) -> Result<Option<EditPageOutput>> {
         let txn = ctx.transaction();
-        let PageModel { page_id, .. } = Self::get(ctx, site_id, reference).await?;
+        let PageModel {
+            page_id,
+            latest_revision_id,
+            ..
+        } = Self::get(ctx, site_id, reference).await?;
 
         // Get target revision and latest revision
         let (target_revision, last_revision) = try_join!(
             PageRevisionService::get(ctx, site_id, page_id, revision_number),
             PageRevisionService::get_latest(ctx, site_id, page_id),
         )?;
+
+        // Check last revision ID
+        check_last_revision(Some(&last_revision), latest_revision_id, last_revision_id)?;
 
         // NOTE: we can't just copy the wikitext_hash because we
         //       need its actual value for rendering.
@@ -830,7 +857,45 @@ impl PageService {
     }
 }
 
+/// Verifies that a `last_revision_id` passed into this function is actually the latest.
+///
+/// This is to avoid issues wherein a user edits overs a more recently-updated page
+/// without realizing it, since attempting to make this edit would cause the backend
+/// to produce an error saying that the request had too old of a revision ID and thus
+/// the page would need to be refreshed.
+///
+/// This check is intended for before an operation has run.
+fn check_last_revision(
+    last_revision_model: Option<&PageRevisionModel>,
+    page_latest_revision_id: Option<i64>,
+    arg_last_revision_id: i64,
+) -> Result<()> {
+    // Only check if we have this model fetched anyways
+    if let Some(model) = last_revision_model {
+        assert_eq!(
+            model.revision_id,
+            page_latest_revision_id.expect("Page row has NULL latest_revision_id"),
+            "Page table has an inconsistent last_revision_id column value",
+        );
+    }
+
+    // Perform main check, ensure that the argument matches the latest
+    if page_latest_revision_id != Some(arg_last_revision_id) {
+        error!(
+            "Latest revision ID in page struct is {}, but user argument has ID {}",
+            page_latest_revision_id.unwrap(),
+            arg_last_revision_id,
+        );
+
+        return Err(Error::NotLatestRevisionId);
+    }
+
+    Ok(())
+}
+
 /// Ensure that the page has a properly-set `latest_revision_id` column.
+///
+/// This check is intended for after an operation has run.
 fn assert_latest_revision(page: &PageModel) {
     // Even in production, we want to assert that this invariant holds.
     //

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -444,7 +444,7 @@ impl PageService {
             PageRevisionService::get_latest(ctx, site_id, page_id),
         )?;
 
-        // Note: we can't just copy the wikitext_hash because we
+        // NOTE: we can't just copy the wikitext_hash because we
         //       need its actual value for rendering.
         //       This isn't run here, but in PageRevisionService::create().
         let wikitext = TextService::get(ctx, &target_revision.wikitext_hash).await?;

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -146,6 +146,7 @@ pub struct GetPageScoreOutput {
 pub struct EditPage<'a> {
     pub site_id: i64,
     pub page: Reference<'a>,
+    pub last_revision_id: i64,
     pub revision_comments: String,
     pub user_id: i64,
 
@@ -166,6 +167,7 @@ pub struct EditPageBody {
 pub struct MovePage<'a> {
     pub site_id: i64,
     pub page: Reference<'a>,
+    pub last_revision_id: i64,
     pub new_slug: String,
     pub revision_comments: String,
     pub user_id: i64,
@@ -185,6 +187,7 @@ pub struct MovePageOutput {
 pub struct DeletePage<'a> {
     pub site_id: i64,
     pub page: Reference<'a>,
+    pub last_revision_id: i64,
     pub revision_comments: String,
     pub user_id: i64,
 }
@@ -217,6 +220,7 @@ pub struct RestorePageOutput {
 pub struct RollbackPage<'a> {
     pub site_id: i64,
     pub page: Reference<'a>,
+    pub last_revision_id: i64,
     pub revision_number: i32,
     pub revision_comments: String,
     pub user_id: i64,


### PR DESCRIPTION
This is a safety measure to protect against the following case:

1. Alice opens page X, which at the time is at revision 10.
2. Bob opens page X, which is also at revision 10.
3. Bob makes an edit on page X, so it is now on revision 11.
4. Alice, with the page still open on X (but the editor is not open, avoiding any page lock conflicts), edits.
5. Alice's revision 12 has effectively overwritten Bob's edit 11, since she was not seeing the contents of revision 11 on her screen when she was drafting her changes.

Page locking does not help here since at no point are Alice and Bob attempting to commit the page at the same time. By requiring the frontend pass in the last revision ID for the page (which is already received by framerail as part of the page data), we ensure that if someone has an old version of the page locally loaded in their browser, they are effectively forced to reload if the page has been edited since.

This revision ID is only required for "destructive" operations, like edits, deletes, rollbacks, etc, where a user may possibly take a different action if they knew the page had been updated in the meantime.

I plan to make a similar change for file operations (see WJ-1281).