### PR TITLE
[WJ-1281] Require passing in last revision ID for file operations

### DIFF
--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -85,6 +85,7 @@ pub struct EditFile {
     pub page_id: i64,
     pub file_id: i64,
     pub user_id: i64,
+    pub last_revision_id: i64,
     pub revision_comments: String,
 
     #[serde(flatten)]
@@ -110,6 +111,7 @@ pub struct MoveFile {
     pub site_id: i64,
     pub file_id: i64,
     pub user_id: i64,
+    pub last_revision_id: i64,
     pub name: Option<String>,
     pub current_page_id: i64,
     pub destination_page_id: i64,
@@ -119,6 +121,7 @@ pub type MoveFileOutput = CreateFileRevisionOutput;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct DeleteFile<'a> {
+    pub last_revision_id: i64,
     pub revision_comments: String,
     pub site_id: i64,
     pub page_id: i64,


### PR DESCRIPTION
See also #2117. This requires the last file revision to be passed in for any destructive file operations.