### PR TITLE
[WJ-1284] Rename module and enum

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -31,7 +31,7 @@ use crate::services::page::{CreatePage, PageService};
 use crate::services::site::{CreateSite, CreateSiteOutput, SiteService};
 use crate::services::user::{CreateUser, CreateUserOutput, UpdateUserBody, UserService};
 use crate::services::ServiceContext;
-use crate::web::{ProvidedValue, Reference};
+use crate::types::{ProvidedValue, Reference};
 use anyhow::Result;
 use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseTransaction, Statement, TransactionTrait,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -31,7 +31,7 @@ use crate::services::page::{CreatePage, PageService};
 use crate::services::site::{CreateSite, CreateSiteOutput, SiteService};
 use crate::services::user::{CreateUser, CreateUserOutput, UpdateUserBody, UserService};
 use crate::services::ServiceContext;
-use crate::types::{ProvidedValue, Reference};
+use crate::types::{Maybe, Reference};
 use anyhow::Result;
 use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseTransaction, Statement, TransactionTrait,
@@ -95,13 +95,13 @@ pub async fn seed(state: &ServerState) -> Result<()> {
             &ctx,
             Reference::Id(user_id),
             UpdateUserBody {
-                email_verified: ProvidedValue::Set(true),
-                real_name: ProvidedValue::Set(user.real_name),
-                gender: ProvidedValue::Set(user.gender),
-                birthday: ProvidedValue::Set(user.birthday),
-                location: ProvidedValue::Set(user.location),
-                biography: ProvidedValue::Set(user.biography),
-                user_page: ProvidedValue::Set(user.user_page),
+                email_verified: Maybe::Set(true),
+                real_name: Maybe::Set(user.real_name),
+                gender: Maybe::Set(user.gender),
+                birthday: Maybe::Set(user.birthday),
+                location: Maybe::Set(user.location),
+                biography: Maybe::Set(user.biography),
+                user_page: Maybe::Set(user.user_page),
                 ..Default::default()
             },
         )

--- a/deepwell/src/endpoints/blob.rs
+++ b/deepwell/src/endpoints/blob.rs
@@ -23,7 +23,7 @@ use crate::services::blob::{
     BlobMetadata, CancelBlobUpload, GetBlobOutput, StartBlobUpload, StartBlobUploadOutput,
 };
 use crate::services::Result;
-use crate::web::Bytes;
+use crate::types::Bytes;
 
 /// Temporary endpoint to get any blob by hash.
 /// Primarily for user avatars, which have no other

--- a/deepwell/src/endpoints/file.rs
+++ b/deepwell/src/endpoints/file.rs
@@ -28,7 +28,7 @@ use crate::services::file::{
     RestoreFileOutput,
 };
 use crate::services::Result;
-use crate::web::{Bytes, FileDetails};
+use crate::types::{Bytes, FileDetails};
 
 pub async fn file_get(
     ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/page.rs
+++ b/deepwell/src/endpoints/page.rs
@@ -27,7 +27,7 @@ use crate::services::page::{
     MovePageOutput, RestorePage, RestorePageOutput, RollbackPage, SetPageLayout,
 };
 use crate::services::{Result, TextService};
-use crate::web::{PageDetails, Reference};
+use crate::types::{PageDetails, Reference};
 use futures::future::try_join_all;
 
 pub async fn page_create(

--- a/deepwell/src/endpoints/page_revision.rs
+++ b/deepwell/src/endpoints/page_revision.rs
@@ -26,7 +26,7 @@ use crate::services::page_revision::{
     PageRevisionCountOutput, PageRevisionModelFiltered, UpdatePageRevisionDetails,
 };
 use crate::services::{Result, TextService};
-use crate::web::PageDetails;
+use crate::types::PageDetails;
 
 pub async fn page_revision_count(
     ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/parent.rs
+++ b/deepwell/src/endpoints/parent.rs
@@ -25,7 +25,7 @@ use crate::services::parent::{
     GetParentRelationships, ParentDescription, RemoveParentOutput, UpdateParents,
     UpdateParentsOutput,
 };
-use crate::web::Reference;
+use crate::types::Reference;
 use futures::future::try_join_all;
 
 pub async fn parent_relationships_get(

--- a/deepwell/src/endpoints/text.rs
+++ b/deepwell/src/endpoints/text.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::web::Bytes;
+use crate::types::Bytes;
 
 pub async fn text_create(
     ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/user_bot.rs
+++ b/deepwell/src/endpoints/user_bot.rs
@@ -26,7 +26,7 @@ use crate::services::user_bot_owner::{
     BotOwner, BotUserOutput, CreateBotOwner, CreateBotUser, RemoveBotOwner,
     RemoveBotOwnerOutput, UserBotOwnerService,
 };
-use crate::web::{ProvidedValue, Reference};
+use crate::types::{ProvidedValue, Reference};
 
 pub async fn bot_user_create(
     ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/user_bot.rs
+++ b/deepwell/src/endpoints/user_bot.rs
@@ -26,7 +26,7 @@ use crate::services::user_bot_owner::{
     BotOwner, BotUserOutput, CreateBotOwner, CreateBotUser, RemoveBotOwner,
     RemoveBotOwnerOutput, UserBotOwnerService,
 };
-use crate::types::{ProvidedValue, Reference};
+use crate::types::{Maybe, Reference};
 
 pub async fn bot_user_create(
     ctx: &ServiceContext<'_>,
@@ -70,7 +70,7 @@ pub async fn bot_user_create(
         ctx,
         Reference::Id(bot_user_id),
         UpdateUserBody {
-            biography: ProvidedValue::Set(Some(purpose)),
+            biography: Maybe::Set(Some(purpose)),
             ..Default::default()
         },
     )

--- a/deepwell/src/main.rs
+++ b/deepwell/src/main.rs
@@ -52,8 +52,8 @@ mod info;
 mod locales;
 mod redis;
 mod services;
+mod types;
 mod utils;
-mod web;
 
 #[cfg(feature = "notify")]
 use self::watch::setup_autorestart;

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -26,7 +26,7 @@ use crate::models::user::{self, Entity as User};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{FilterService, SiteService, UserService};
 use crate::utils::get_regular_slug;
-use crate::web::Reference;
+use crate::types::Reference;
 
 #[derive(Debug)]
 pub struct AliasService;

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -25,8 +25,8 @@ use crate::models::site::{self, Entity as Site};
 use crate::models::user::{self, Entity as User};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{FilterService, SiteService, UserService};
-use crate::utils::get_regular_slug;
 use crate::types::Reference;
+use crate::utils::get_regular_slug;
 
 #[derive(Debug)]
 pub struct AliasService;

--- a/deepwell/src/services/category/structs.rs
+++ b/deepwell/src/services/category/structs.rs
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::web::Reference;
+use crate::types::Reference;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct GetCategory<'a> {

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -134,7 +134,7 @@ impl FileService {
         //
         // If the name isn't changing, then we already verified this
         // when the file was originally created.
-        if let ProvidedValue::Set(ref name) = name {
+        if let Maybe::Set(ref name) = name {
             Self::check_conflicts(ctx, page_id, name, "update").await?;
 
             if !bypass_filter {
@@ -147,8 +147,8 @@ impl FileService {
         // Get the blob struct for conditionally adding to
         // the CreateFileRevisionBody.
         let blob = match uploaded_blob_id {
-            ProvidedValue::Unset => ProvidedValue::Unset,
-            ProvidedValue::Set(ref id) => {
+            Maybe::Unset => Maybe::Unset,
+            Maybe::Set(ref id) => {
                 let FinalizeBlobUploadOutput {
                     hash: s3_hash,
                     mime: mime_hint,
@@ -156,7 +156,7 @@ impl FileService {
                     created: blob_created,
                 } = BlobService::finish_upload(ctx, user_id, id).await?;
 
-                ProvidedValue::Set(FileBlob {
+                Maybe::Set(FileBlob {
                     s3_hash,
                     mime_hint,
                     size_hint,
@@ -248,7 +248,7 @@ impl FileService {
                 user_id,
                 revision_comments,
                 body: CreateFileRevisionBody {
-                    page_id: ProvidedValue::Set(destination_page_id),
+                    page_id: Maybe::Set(destination_page_id),
                     ..Default::default()
                 },
             },

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -22,7 +22,7 @@ use crate::models::sea_orm_active_enums::FileRevisionType;
 use crate::services::file_revision::{
     CreateFileRevisionOutput, CreateFirstFileRevisionOutput,
 };
-use crate::web::{Bytes, FileDetails, ProvidedValue, Reference};
+use crate::types::{Bytes, FileDetails, ProvidedValue, Reference};
 use serde_json::Value as JsonValue;
 use time::OffsetDateTime;
 

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -22,7 +22,7 @@ use crate::models::sea_orm_active_enums::FileRevisionType;
 use crate::services::file_revision::{
     CreateFileRevisionOutput, CreateFirstFileRevisionOutput,
 };
-use crate::types::{Bytes, FileDetails, ProvidedValue, Reference};
+use crate::types::{Bytes, FileDetails, Maybe, Reference};
 use serde_json::Value as JsonValue;
 use time::OffsetDateTime;
 
@@ -106,9 +106,9 @@ pub struct EditFile {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct EditFileBody {
-    pub name: ProvidedValue<String>,
-    pub licensing: ProvidedValue<serde_json::Value>,
-    pub uploaded_blob_id: ProvidedValue<String>,
+    pub name: Maybe<String>,
+    pub licensing: Maybe<serde_json::Value>,
+    pub uploaded_blob_id: Maybe<String>,
 }
 
 pub type EditFileOutput = CreateFileRevisionOutput;

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -71,7 +71,7 @@ impl FileRevisionService {
 
         // Fields to create in the revision
         let mut changes = Vec::new();
-        let mut blob_created = ProvidedValue::Unset;
+        let mut blob_created = Maybe::Unset;
         let FileRevisionModel {
             mut name,
             mut s3_hash,
@@ -86,21 +86,21 @@ impl FileRevisionService {
         // We check the values so that the only listed "changes"
         // are those that actually are different.
 
-        if let ProvidedValue::Set(new_page_id) = body.page_id {
+        if let Maybe::Set(new_page_id) = body.page_id {
             if page_id != new_page_id {
                 changes.push(str!("page"));
                 page_id = new_page_id;
             }
         }
 
-        if let ProvidedValue::Set(new_name) = body.name {
+        if let Maybe::Set(new_name) = body.name {
             if name != new_name {
                 changes.push(str!("name"));
                 name = new_name;
             }
         }
 
-        if let ProvidedValue::Set(new_blob) = body.blob {
+        if let Maybe::Set(new_blob) = body.blob {
             if s3_hash != new_blob.s3_hash
                 || size_hint != new_blob.size_hint
                 || mime_hint != new_blob.mime_hint
@@ -109,11 +109,11 @@ impl FileRevisionService {
                 s3_hash = new_blob.s3_hash.to_vec();
                 size_hint = new_blob.size_hint;
                 mime_hint = new_blob.mime_hint;
-                blob_created = ProvidedValue::Set(new_blob.blob_created);
+                blob_created = Maybe::Set(new_blob.blob_created);
             }
         }
 
-        if let ProvidedValue::Set(new_licensing) = body.licensing {
+        if let Maybe::Set(new_licensing) = body.licensing {
             if licensing != new_licensing {
                 changes.push(str!("licensing"));
                 licensing = new_licensing;
@@ -292,7 +292,7 @@ impl FileRevisionService {
         Ok(CreateFileRevisionOutput {
             file_revision_id: revision_id,
             file_revision_number: revision_number,
-            blob_created: ProvidedValue::Unset,
+            blob_created: Maybe::Unset,
         })
     }
 
@@ -380,7 +380,7 @@ impl FileRevisionService {
         Ok(CreateFileRevisionOutput {
             file_revision_id: revision_id,
             file_revision_number: revision_number,
-            blob_created: ProvidedValue::Unset,
+            blob_created: Maybe::Unset,
         })
     }
 

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -24,7 +24,7 @@ use crate::models::file_revision::{
 };
 use crate::services::blob::{FinalizeBlobUploadOutput, EMPTY_BLOB_HASH, EMPTY_BLOB_MIME};
 use crate::services::{BlobService, OutdateService, PageService};
-use crate::web::{Bytes, FetchDirection};
+use crate::types::{Bytes, FetchDirection};
 use once_cell::sync::Lazy;
 use std::num::NonZeroI32;
 

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -35,10 +35,10 @@ pub struct CreateFileRevision {
 
 #[derive(Debug, Default, Clone)]
 pub struct CreateFileRevisionBody {
-    pub page_id: ProvidedValue<i64>, // for changing the page this file is on
-    pub name: ProvidedValue<String>,
-    pub blob: ProvidedValue<FileBlob>,
-    pub licensing: ProvidedValue<serde_json::Value>,
+    pub page_id: Maybe<i64>, // for changing the page this file is on
+    pub name: Maybe<String>,
+    pub blob: Maybe<FileBlob>,
+    pub licensing: Maybe<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,8 +54,8 @@ pub struct CreateFileRevisionOutput {
     pub file_revision_id: i64,
     pub file_revision_number: i32,
 
-    #[serde(default, skip_serializing_if = "ProvidedValue::is_unset")]
-    pub blob_created: ProvidedValue<bool>,
+    #[serde(default, skip_serializing_if = "Maybe::is_unset")]
+    pub blob_created: Maybe<bool>,
 }
 
 #[derive(Debug, Clone)]

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 use crate::hash::BlobHash;
 use crate::services::page_revision::PageRevisionCountOutput;
-use crate::web::{Bytes, FetchDirection};
+use crate::types::{Bytes, FetchDirection};
 
 #[derive(Debug, Clone)]
 pub struct CreateFileRevision {

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -101,19 +101,19 @@ impl FilterService {
         };
 
         // Handle case-sensitivity logic
-        if let ProvidedValue::Set(case_sensitive) = case_sensitive {
+        if let Maybe::Set(case_sensitive) = case_sensitive {
             match regex {
                 // If the regex is being changed, add case-insensitivity flag if case-insensitive.
-                ProvidedValue::Set(ref mut regex) if !case_sensitive => {
+                Maybe::Set(ref mut regex) if !case_sensitive => {
                     regex.insert_str(0, "(?i)")
                 }
 
                 // If the regex is being changed but is case-sensitive, do not touch it.
-                ProvidedValue::Set(_) => {}
+                Maybe::Set(_) => {}
 
                 // If the regex is not being changed, remove (and conditionally readd) the
                 // case-insensitivity flag from the database's regex.
-                ProvidedValue::Unset => {
+                Maybe::Unset => {
                     let mut model_regex = str!(model.get(filter::Column::Regex).as_ref());
                     trim_start_matches_in_place(&mut model_regex, "(?i)");
 
@@ -127,31 +127,31 @@ impl FilterService {
         };
 
         // Set fields
-        if let ProvidedValue::Set(affects) = affects_user {
+        if let Maybe::Set(affects) = affects_user {
             model.affects_user = Set(affects);
         }
 
-        if let ProvidedValue::Set(affects) = affects_email {
+        if let Maybe::Set(affects) = affects_email {
             model.affects_email = Set(affects);
         }
 
-        if let ProvidedValue::Set(affects) = affects_page {
+        if let Maybe::Set(affects) = affects_page {
             model.affects_page = Set(affects);
         }
 
-        if let ProvidedValue::Set(affects) = affects_file {
+        if let Maybe::Set(affects) = affects_file {
             model.affects_file = Set(affects);
         }
 
-        if let ProvidedValue::Set(affects) = affects_forum {
+        if let Maybe::Set(affects) = affects_forum {
             model.affects_forum = Set(affects);
         }
 
-        if let ProvidedValue::Set(regex) = regex {
+        if let Maybe::Set(regex) = regex {
             model.regex = Set(regex);
         }
 
-        if let ProvidedValue::Set(description) = description {
+        if let Maybe::Set(description) = description {
             model.description = Set(description);
         }
 

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -19,7 +19,7 @@
  */
 
 use crate::models::filter;
-use crate::web::ProvidedValue;
+use crate::types::ProvidedValue;
 use sea_orm::{ColumnTrait, Condition};
 
 /// Denotes what class of filter is being selected.

--- a/deepwell/src/services/filter/structs.rs
+++ b/deepwell/src/services/filter/structs.rs
@@ -19,7 +19,7 @@
  */
 
 use crate::models::filter;
-use crate::types::ProvidedValue;
+use crate::types::Maybe;
 use sea_orm::{ColumnTrait, Condition};
 
 /// Denotes what class of filter is being selected.
@@ -32,7 +32,7 @@ use sea_orm::{ColumnTrait, Condition};
 /// mirroring how it was stored in the database. However, this had
 /// some issues:
 ///
-/// One is that it is semantically unclear, and similar to `ProvidedValue`,
+/// One is that it is semantically unclear, and similar to `Maybe`,
 /// we should make a cheap enum wrapper to provide semantics to what is
 /// essentially just an `Option<i64>`.
 ///
@@ -163,12 +163,12 @@ pub struct CreateFilter {
 #[derive(Deserialize, Debug, Clone)]
 pub struct UpdateFilter {
     pub filter_id: i64,
-    pub affects_user: ProvidedValue<bool>,
-    pub affects_email: ProvidedValue<bool>,
-    pub affects_page: ProvidedValue<bool>,
-    pub affects_file: ProvidedValue<bool>,
-    pub affects_forum: ProvidedValue<bool>,
-    pub case_sensitive: ProvidedValue<bool>,
-    pub regex: ProvidedValue<String>,
-    pub description: ProvidedValue<String>,
+    pub affects_user: Maybe<bool>,
+    pub affects_email: Maybe<bool>,
+    pub affects_page: Maybe<bool>,
+    pub affects_file: Maybe<bool>,
+    pub affects_forum: Maybe<bool>,
+    pub case_sensitive: Maybe<bool>,
+    pub regex: Maybe<String>,
+    pub description: Maybe<String>,
 }

--- a/deepwell/src/services/link/service.rs
+++ b/deepwell/src/services/link/service.rs
@@ -24,7 +24,7 @@ use crate::models::page_connection::{self, Entity as PageConnection};
 use crate::models::page_connection_missing::{self, Entity as PageConnectionMissing};
 use crate::models::page_link::{self, Entity as PageLink, Model as PageLinkModel};
 use crate::services::{PageService, SiteService};
-use crate::web::ConnectionType;
+use crate::types::ConnectionType;
 use ftml::data::{Backlinks, PageRef};
 use sea_orm::NotSet;
 use std::collections::HashMap;

--- a/deepwell/src/services/link/structs.rs
+++ b/deepwell/src/services/link/structs.rs
@@ -21,7 +21,7 @@
 use crate::models::page_connection::Model as PageConnectionModel;
 use crate::models::page_connection_missing::Model as PageConnectionMissingModel;
 use crate::models::page_link::Model as PageLinkModel;
-use crate::web::Reference;
+use crate::types::Reference;
 use time::OffsetDateTime;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/message/service.rs
+++ b/deepwell/src/services/message/service.rs
@@ -85,8 +85,8 @@ impl MessageService {
                 locale,
                 subject,
                 wikitext,
-                reply_to: ProvidedValue::Set(reply_to),
-                forwarded_from: ProvidedValue::Set(forwarded_from),
+                reply_to: Maybe::Set(reply_to),
+                forwarded_from: Maybe::Set(forwarded_from),
             },
         )
         .await?
@@ -130,8 +130,8 @@ impl MessageService {
                 locale,
                 subject,
                 wikitext,
-                reply_to: ProvidedValue::Unset,
-                forwarded_from: ProvidedValue::Unset,
+                reply_to: Maybe::Unset,
+                forwarded_from: Maybe::Unset,
             },
         )
         .await?
@@ -613,6 +613,6 @@ struct DraftProcess {
     locale: String,
     subject: String,
     wikitext: String,
-    reply_to: ProvidedValue<Option<String>>,
-    forwarded_from: ProvidedValue<Option<String>>,
+    reply_to: Maybe<Option<String>>,
+    forwarded_from: Maybe<Option<String>>,
 }

--- a/deepwell/src/services/mod.rs
+++ b/deepwell/src/services/mod.rs
@@ -41,7 +41,7 @@ mod prelude {
     pub use super::error::*;
     pub use crate::config::Config;
     pub use crate::utils::now;
-    pub use crate::web::{ProvidedValue, Reference};
+    pub use crate::types::{ProvidedValue, Reference};
     pub use paste::paste;
     pub use sea_orm::{
         ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DeleteResult,

--- a/deepwell/src/services/mod.rs
+++ b/deepwell/src/services/mod.rs
@@ -40,8 +40,8 @@ mod prelude {
     pub use super::context::ServiceContext;
     pub use super::error::*;
     pub use crate::config::Config;
+    pub use crate::types::{Maybe, Reference};
     pub use crate::utils::now;
-    pub use crate::types::{ProvidedValue, Reference};
     pub use paste::paste;
     pub use sea_orm::{
         ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, DeleteResult,

--- a/deepwell/src/services/outdate.rs
+++ b/deepwell/src/services/outdate.rs
@@ -21,8 +21,8 @@
 use super::prelude::*;
 use crate::models::page::Model as PageModel;
 use crate::services::{JobService, LinkService, PageService};
-use crate::utils::split_category_name;
 use crate::types::{ConnectionType, PageOrder};
+use crate::utils::split_category_name;
 
 #[derive(Debug)]
 pub struct OutdateService;

--- a/deepwell/src/services/outdate.rs
+++ b/deepwell/src/services/outdate.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::page::Model as PageModel;
 use crate::services::{JobService, LinkService, PageService};
 use crate::utils::split_category_name;
-use crate::web::{ConnectionType, PageOrder};
+use crate::types::{ConnectionType, PageOrder};
 
 #[derive(Debug)]
 pub struct OutdateService;

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -32,7 +32,7 @@ use crate::services::{
     CategoryService, FilterService, PageRevisionService, SiteService, TextService,
 };
 use crate::utils::{get_category_name, trim_default};
-use crate::web::PageOrder;
+use crate::types::PageOrder;
 use ftml::layout::Layout;
 use sea_orm::ActiveValue;
 use wikidot_normalize::normalize;

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -31,8 +31,8 @@ use crate::services::page_revision::{
 use crate::services::{
     CategoryService, FilterService, PageRevisionService, SiteService, TextService,
 };
-use crate::utils::{get_category_name, trim_default};
 use crate::types::PageOrder;
+use crate::utils::{get_category_name, trim_default};
 use ftml::layout::Layout;
 use sea_orm::ActiveValue;
 use wikidot_normalize::normalize;
@@ -154,7 +154,7 @@ impl PageService {
             title.to_option(),
             // Flatten what is essentially Option<Option<_>>
             match alt_title {
-                ProvidedValue::Set(Some(ref alt_title)) => Some(alt_title),
+                Maybe::Set(Some(ref alt_title)) => Some(alt_title),
                 _ => None,
             },
         )
@@ -261,7 +261,7 @@ impl PageService {
             user_id,
             comments,
             body: CreatePageRevisionBody {
-                slug: ProvidedValue::Set(new_slug.clone()),
+                slug: Maybe::Set(new_slug.clone()),
                 ..Default::default()
             },
         };
@@ -484,11 +484,11 @@ impl PageService {
             user_id,
             comments,
             body: CreatePageRevisionBody {
-                wikitext: ProvidedValue::Set(wikitext),
-                title: ProvidedValue::Set(target_revision.title),
-                alt_title: ProvidedValue::Set(target_revision.alt_title),
-                tags: ProvidedValue::Set(target_revision.tags),
-                slug: ProvidedValue::Unset, // rollbacks should never move a page
+                wikitext: Maybe::Set(wikitext),
+                title: Maybe::Set(target_revision.title),
+                alt_title: Maybe::Set(target_revision.alt_title),
+                tags: Maybe::Set(target_revision.tags),
+                slug: Maybe::Unset, // rollbacks should never move a page
             },
         };
 

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -171,10 +171,10 @@ pub struct EditPage<'a> {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct EditPageBody {
-    pub wikitext: ProvidedValue<String>,
-    pub title: ProvidedValue<String>,
-    pub alt_title: ProvidedValue<Option<String>>,
-    pub tags: ProvidedValue<Vec<String>>,
+    pub wikitext: Maybe<String>,
+    pub title: Maybe<String>,
+    pub alt_title: Maybe<Option<String>>,
+    pub tags: Maybe<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/page/structs.rs
+++ b/deepwell/src/services/page/structs.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::sea_orm_active_enums::PageRevisionType;
 use crate::services::page_revision::CreatePageRevisionOutput;
 use crate::services::score::ScoreValue;
-use crate::web::PageDetails;
+use crate::types::PageDetails;
 use ftml::layout::Layout;
 use ftml::parsing::ParseError;
 use time::OffsetDateTime;

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -29,8 +29,8 @@ use crate::services::{
     LinkService, OutdateService, PageService, ParentService, RenderService, ScoreService,
     SettingsService, SiteService, TextService,
 };
-use crate::utils::{split_category, split_category_name};
 use crate::types::FetchDirection;
+use crate::utils::{split_category, split_category_name};
 use ftml::data::PageInfo;
 use ftml::layout::Layout;
 use ftml::settings::{WikitextMode, WikitextSettings};
@@ -129,21 +129,21 @@ impl PageRevisionService {
         // We check the values so that the only listed "changes"
         // are those that actually are different.
 
-        if let ProvidedValue::Set(new_title) = body.title {
+        if let Maybe::Set(new_title) = body.title {
             if title != new_title {
                 changes.push(str!("title"));
                 title = new_title;
             }
         }
 
-        if let ProvidedValue::Set(new_alt_title) = body.alt_title {
+        if let Maybe::Set(new_alt_title) = body.alt_title {
             if alt_title != new_alt_title {
                 changes.push(str!("alt_title"));
                 alt_title = new_alt_title;
             }
         }
 
-        if let ProvidedValue::Set(new_slug) = body.slug {
+        if let Maybe::Set(new_slug) = body.slug {
             if slug != new_slug {
                 changes.push(str!("slug"));
                 old_slug = Some(slug);
@@ -151,7 +151,7 @@ impl PageRevisionService {
             }
         }
 
-        if let ProvidedValue::Set(new_tags) = body.tags {
+        if let Maybe::Set(new_tags) = body.tags {
             if tags != new_tags {
                 changes.push(str!("tags"));
                 tags = new_tags;
@@ -164,7 +164,7 @@ impl PageRevisionService {
         // Get wikitext, set wikitext hash
         let wikitext = match body.wikitext {
             // Insert new wikitext and update hash
-            ProvidedValue::Set(new_wikitext) => {
+            Maybe::Set(new_wikitext) => {
                 let new_hash = TextService::create(ctx, new_wikitext.clone()).await?;
 
                 if wikitext_hash != new_hash {
@@ -176,7 +176,7 @@ impl PageRevisionService {
             }
 
             // Use previous revision's wikitext
-            ProvidedValue::Unset => TextService::get(ctx, &wikitext_hash).await?,
+            Maybe::Unset => TextService::get(ctx, &wikitext_hash).await?,
         };
 
         // If nothing has changed, then don't create a new revision

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -30,7 +30,7 @@ use crate::services::{
     SettingsService, SiteService, TextService,
 };
 use crate::utils::{split_category, split_category_name};
-use crate::web::FetchDirection;
+use crate::types::FetchDirection;
 use ftml::data::PageInfo;
 use ftml::layout::Layout;
 use ftml::settings::{WikitextMode, WikitextSettings};

--- a/deepwell/src/services/page_revision/structs.rs
+++ b/deepwell/src/services/page_revision/structs.rs
@@ -20,7 +20,7 @@
 
 use super::prelude::*;
 use crate::models::sea_orm_active_enums::PageRevisionType;
-use crate::web::{FetchDirection, PageDetails};
+use crate::types::{FetchDirection, PageDetails};
 use ftml::layout::Layout;
 use ftml::parsing::ParseError;
 use std::num::NonZeroI32;

--- a/deepwell/src/services/page_revision/structs.rs
+++ b/deepwell/src/services/page_revision/structs.rs
@@ -38,11 +38,11 @@ pub struct CreatePageRevision {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct CreatePageRevisionBody {
-    pub wikitext: ProvidedValue<String>,
-    pub title: ProvidedValue<String>,
-    pub alt_title: ProvidedValue<Option<String>>,
-    pub slug: ProvidedValue<String>,
-    pub tags: ProvidedValue<Vec<String>>,
+    pub wikitext: Maybe<String>,
+    pub title: Maybe<String>,
+    pub alt_title: Maybe<Option<String>>,
+    pub slug: Maybe<String>,
+    pub tags: Maybe<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/parent/structs.rs
+++ b/deepwell/src/services/parent/structs.rs
@@ -19,7 +19,7 @@
  */
 
 use crate::services::Error;
-use crate::web::Reference;
+use crate::types::Reference;
 use std::str::FromStr;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -98,7 +98,7 @@ impl SiteService {
             ctx,
             Reference::Id(user.user_id),
             UpdateUserBody {
-                biography: ProvidedValue::Set(Some(description)),
+                biography: Maybe::Set(Some(description)),
                 ..Default::default()
             },
         )
@@ -142,32 +142,32 @@ impl SiteService {
             RelationService::get_site_user_id_for_site(ctx, site.site_id).await?;
         let mut site_user_body = UpdateUserBody::default();
 
-        if let ProvidedValue::Set(name) = input.name {
+        if let Maybe::Set(name) = input.name {
             model.name = Set(name);
         }
 
-        if let ProvidedValue::Set(new_slug) = input.slug {
+        if let Maybe::Set(new_slug) = input.slug {
             Self::update_slug(ctx, &site, &new_slug, updating_user_id).await?;
-            site_user_body.name = ProvidedValue::Set(format!("site:{new_slug}"));
+            site_user_body.name = Maybe::Set(format!("site:{new_slug}"));
             model.slug = Set(new_slug);
         }
 
-        if let ProvidedValue::Set(tagline) = input.tagline {
+        if let Maybe::Set(tagline) = input.tagline {
             model.tagline = Set(tagline);
         }
 
-        if let ProvidedValue::Set(description) = input.description {
+        if let Maybe::Set(description) = input.description {
             model.description = Set(description.clone());
-            site_user_body.biography = ProvidedValue::Set(Some(description))
+            site_user_body.biography = Maybe::Set(Some(description))
         }
 
-        if let ProvidedValue::Set(locale) = input.locale {
+        if let Maybe::Set(locale) = input.locale {
             validate_locale(&locale)?;
             model.locale = Set(locale.clone());
-            site_user_body.locales = ProvidedValue::Set(vec![locale]);
+            site_user_body.locales = Maybe::Set(vec![locale]);
         }
 
-        if let ProvidedValue::Set(layout) = input.layout {
+        if let Maybe::Set(layout) = input.layout {
             model.layout = Set(layout.map(|l| str!(l.value())));
         }
 

--- a/deepwell/src/services/site/structs.rs
+++ b/deepwell/src/services/site/structs.rs
@@ -21,7 +21,7 @@
 use crate::models::alias::Model as AliasModel;
 use crate::models::site::Model as SiteModel;
 use crate::models::site_domain::Model as SiteDomainModel;
-use crate::web::{ProvidedValue, Reference};
+use crate::types::{ProvidedValue, Reference};
 use ftml::layout::Layout;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/site/structs.rs
+++ b/deepwell/src/services/site/structs.rs
@@ -21,7 +21,7 @@
 use crate::models::alias::Model as AliasModel;
 use crate::models::site::Model as SiteModel;
 use crate::models::site_domain::Model as SiteDomainModel;
-use crate::types::{ProvidedValue, Reference};
+use crate::types::{Maybe, Reference};
 use ftml::layout::Layout;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -67,10 +67,10 @@ pub struct UpdateSite<'a> {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct UpdateSiteBody {
-    pub name: ProvidedValue<String>,
-    pub slug: ProvidedValue<String>,
-    pub tagline: ProvidedValue<String>,
-    pub description: ProvidedValue<String>,
-    pub locale: ProvidedValue<String>,
-    pub layout: ProvidedValue<Option<Layout>>,
+    pub name: Maybe<String>,
+    pub slug: Maybe<String>,
+    pub tagline: Maybe<String>,
+    pub description: Maybe<String>,
+    pub locale: Maybe<String>,
+    pub layout: Maybe<Option<Layout>>,
 }

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -21,8 +21,8 @@
 use super::prelude::*;
 use crate::models::site::Model as SiteModel;
 use crate::services::{PageRevisionService, PageService, RenderService, TextService};
-use crate::utils::split_category;
 use crate::types::Reference;
+use crate::utils::split_category;
 use fluent::{FluentArgs, FluentValue};
 use ftml::prelude::*;
 use ref_map::*;

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::site::Model as SiteModel;
 use crate::services::{PageRevisionService, PageService, RenderService, TextService};
 use crate::utils::split_category;
-use crate::web::Reference;
+use crate::types::Reference;
 use fluent::{FluentArgs, FluentValue};
 use ftml::prelude::*;
 use ref_map::*;

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -358,11 +358,11 @@ impl UserService {
         };
 
         // Add each field
-        if let ProvidedValue::Set(name) = input.name {
+        if let Maybe::Set(name) = input.name {
             Self::update_name(ctx, name, &user, &mut model, input.bypass_filter).await?;
         }
 
-        if let ProvidedValue::Set(email) = input.email {
+        if let Maybe::Set(email) = input.email {
             if !input.bypass_filter {
                 Self::run_email_filter(ctx, &email).await?;
             }
@@ -382,46 +382,46 @@ impl UserService {
             model.email_verified_at = Set(Some(now()))
         }
 
-        if let ProvidedValue::Set(email_verified) = input.email_verified {
+        if let Maybe::Set(email_verified) = input.email_verified {
             let timestamp = if email_verified { Some(now()) } else { None };
             model.email_verified_at = Set(timestamp);
         }
 
-        if let ProvidedValue::Set(password) = input.password {
+        if let Maybe::Set(password) = input.password {
             let password_hash = PasswordService::new_hash(&password)?;
             model.password = Set(password_hash);
         }
 
-        if let ProvidedValue::Set(locales) = input.locales {
+        if let Maybe::Set(locales) = input.locales {
             Self::validate_locales(user.user_type, &locales)?;
             model.locales = Set(locales);
         }
 
-        if let ProvidedValue::Set(real_name) = input.real_name {
+        if let Maybe::Set(real_name) = input.real_name {
             model.real_name = Set(real_name);
         }
 
-        if let ProvidedValue::Set(gender) = input.gender {
+        if let Maybe::Set(gender) = input.gender {
             model.gender = Set(gender);
         }
 
-        if let ProvidedValue::Set(birthday) = input.birthday {
+        if let Maybe::Set(birthday) = input.birthday {
             model.birthday = Set(birthday);
         }
 
-        if let ProvidedValue::Set(location) = input.location {
+        if let Maybe::Set(location) = input.location {
             model.location = Set(location);
         }
 
-        if let ProvidedValue::Set(biography) = input.biography {
+        if let Maybe::Set(biography) = input.biography {
             model.biography = Set(biography);
         }
 
-        if let ProvidedValue::Set(user_page) = input.user_page {
+        if let Maybe::Set(user_page) = input.user_page {
             model.user_page = Set(user_page);
         }
 
-        if let ProvidedValue::Set(uploaded_blob_id) = input.avatar_uploaded_blob_id {
+        if let Maybe::Set(uploaded_blob_id) = input.avatar_uploaded_blob_id {
             let s3_hash = match uploaded_blob_id {
                 None => None,
                 Some(uploaded_blob_id) => {

--- a/deepwell/src/services/user/structs.rs
+++ b/deepwell/src/services/user/structs.rs
@@ -68,18 +68,18 @@ pub struct UpdateUser<'a> {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct UpdateUserBody {
-    pub name: ProvidedValue<String>,
-    pub email: ProvidedValue<String>,
-    pub email_verified: ProvidedValue<bool>,
-    pub password: ProvidedValue<String>,
-    pub locales: ProvidedValue<Vec<String>>,
-    pub avatar_uploaded_blob_id: ProvidedValue<Option<String>>,
-    pub real_name: ProvidedValue<Option<String>>,
-    pub gender: ProvidedValue<Option<String>>,
-    pub birthday: ProvidedValue<Option<Date>>,
-    pub location: ProvidedValue<Option<String>>,
-    pub biography: ProvidedValue<Option<String>>,
-    pub user_page: ProvidedValue<Option<String>>,
+    pub name: Maybe<String>,
+    pub email: Maybe<String>,
+    pub email_verified: Maybe<bool>,
+    pub password: Maybe<String>,
+    pub locales: Maybe<Vec<String>>,
+    pub avatar_uploaded_blob_id: Maybe<Option<String>>,
+    pub real_name: Maybe<Option<String>>,
+    pub gender: Maybe<Option<String>>,
+    pub birthday: Maybe<Option<Date>>,
+    pub location: Maybe<Option<String>>,
+    pub biography: Maybe<Option<String>>,
+    pub user_page: Maybe<Option<String>>,
 
     #[serde(default)]
     pub bypass_filter: bool,

--- a/deepwell/src/services/user/structs.rs
+++ b/deepwell/src/services/user/structs.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::alias::Model as AliasModel;
 use crate::models::sea_orm_active_enums::UserType;
 use crate::models::user::Model as UserModel;
-use crate::web::Bytes;
+use crate::types::Bytes;
 use time::Date;
 
 #[derive(Deserialize, Debug, Clone)]

--- a/deepwell/src/services/user_bot_owner/structs.rs
+++ b/deepwell/src/services/user_bot_owner/structs.rs
@@ -19,7 +19,7 @@
  */
 
 use crate::models::user::Model as UserModel;
-use crate::web::Reference;
+use crate::types::Reference;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct CreateBotUser {

--- a/deepwell/src/types/bytes.rs
+++ b/deepwell/src/types/bytes.rs
@@ -1,5 +1,5 @@
 /*
- * web/bytes.rs
+ * types/bytes.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team

--- a/deepwell/src/types/connection_type.rs
+++ b/deepwell/src/types/connection_type.rs
@@ -1,5 +1,5 @@
 /*
- * web/fetch_direction.rs
+ * types/connection_type.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team
@@ -22,56 +22,49 @@ use crate::services::Error as ServiceError;
 use std::str::FromStr;
 use strum_macros::EnumIter;
 
-#[derive(
-    EnumIter,
-    Serialize,
-    Deserialize,
-    Debug,
-    Copy,
-    Clone,
-    Hash,
-    PartialOrd,
-    Ord,
-    PartialEq,
-    Eq,
-)]
+#[derive(EnumIter, Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum FetchDirection {
-    /// Retrieves items prior (earlier) to this one.
-    Before,
-
-    /// Retrieves items after (later than) this one.
-    After,
+pub enum ConnectionType {
+    IncludeMessy,
+    IncludeElements,
+    Component,
+    Link,
+    Redirect,
 }
 
-impl FetchDirection {
-    #[cfg(test)]
+impl ConnectionType {
     pub fn name(self) -> &'static str {
         match self {
-            FetchDirection::Before => "before",
-            FetchDirection::After => "after",
+            ConnectionType::IncludeMessy => "include-messy",
+            ConnectionType::IncludeElements => "include-elements",
+            ConnectionType::Component => "component",
+            ConnectionType::Link => "link",
+            ConnectionType::Redirect => "redirect",
         }
     }
 }
 
-impl FromStr for FetchDirection {
+impl FromStr for ConnectionType {
     type Err = ServiceError;
 
-    fn from_str(value: &str) -> Result<FetchDirection, ServiceError> {
+    fn from_str(value: &str) -> Result<ConnectionType, ServiceError> {
         match value {
-            "before" => Ok(FetchDirection::Before),
-            "after" => Ok(FetchDirection::After),
+            "include-messy" => Ok(ConnectionType::IncludeMessy),
+            "include-elements" => Ok(ConnectionType::IncludeElements),
+            "component" => Ok(ConnectionType::Component),
+            "link" => Ok(ConnectionType::Link),
+            "redirect" => Ok(ConnectionType::Redirect),
             _ => Err(ServiceError::InvalidEnumValue),
         }
     }
 }
 
-/// Ensure `FetchDirection::name()` produces the same output as serde.
+/// Ensure `ConnectionType::name()` produces the same output as serde.
 #[test]
 fn name_serde() {
     use strum::IntoEnumIterator;
 
-    for variant in FetchDirection::iter() {
+    for variant in ConnectionType::iter() {
         let output = serde_json::to_string(&variant).expect("Unable to serialize JSON");
         let serde_name: String =
             serde_json::from_str(&output).expect("Unable to deserialize JSON");
@@ -82,7 +75,7 @@ fn name_serde() {
             "Serde name does not match variant name",
         );
 
-        let converted: FetchDirection =
+        let converted: ConnectionType =
             serde_name.as_str().parse().expect("Could not convert item");
 
         assert_eq!(converted, variant, "Converted item does not match variant");

--- a/deepwell/src/types/fetch_direction.rs
+++ b/deepwell/src/types/fetch_direction.rs
@@ -1,5 +1,5 @@
 /*
- * web/connection_type.rs
+ * types/fetch_direction.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team
@@ -22,49 +22,56 @@ use crate::services::Error as ServiceError;
 use std::str::FromStr;
 use strum_macros::EnumIter;
 
-#[derive(EnumIter, Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(
+    EnumIter,
+    Serialize,
+    Deserialize,
+    Debug,
+    Copy,
+    Clone,
+    Hash,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+)]
 #[serde(rename_all = "kebab-case")]
-pub enum ConnectionType {
-    IncludeMessy,
-    IncludeElements,
-    Component,
-    Link,
-    Redirect,
+pub enum FetchDirection {
+    /// Retrieves items prior (earlier) to this one.
+    Before,
+
+    /// Retrieves items after (later than) this one.
+    After,
 }
 
-impl ConnectionType {
+impl FetchDirection {
+    #[cfg(test)]
     pub fn name(self) -> &'static str {
         match self {
-            ConnectionType::IncludeMessy => "include-messy",
-            ConnectionType::IncludeElements => "include-elements",
-            ConnectionType::Component => "component",
-            ConnectionType::Link => "link",
-            ConnectionType::Redirect => "redirect",
+            FetchDirection::Before => "before",
+            FetchDirection::After => "after",
         }
     }
 }
 
-impl FromStr for ConnectionType {
+impl FromStr for FetchDirection {
     type Err = ServiceError;
 
-    fn from_str(value: &str) -> Result<ConnectionType, ServiceError> {
+    fn from_str(value: &str) -> Result<FetchDirection, ServiceError> {
         match value {
-            "include-messy" => Ok(ConnectionType::IncludeMessy),
-            "include-elements" => Ok(ConnectionType::IncludeElements),
-            "component" => Ok(ConnectionType::Component),
-            "link" => Ok(ConnectionType::Link),
-            "redirect" => Ok(ConnectionType::Redirect),
+            "before" => Ok(FetchDirection::Before),
+            "after" => Ok(FetchDirection::After),
             _ => Err(ServiceError::InvalidEnumValue),
         }
     }
 }
 
-/// Ensure `ConnectionType::name()` produces the same output as serde.
+/// Ensure `FetchDirection::name()` produces the same output as serde.
 #[test]
 fn name_serde() {
     use strum::IntoEnumIterator;
 
-    for variant in ConnectionType::iter() {
+    for variant in FetchDirection::iter() {
         let output = serde_json::to_string(&variant).expect("Unable to serialize JSON");
         let serde_name: String =
             serde_json::from_str(&output).expect("Unable to deserialize JSON");
@@ -75,7 +82,7 @@ fn name_serde() {
             "Serde name does not match variant name",
         );
 
-        let converted: ConnectionType =
+        let converted: FetchDirection =
             serde_name.as_str().parse().expect("Could not convert item");
 
         assert_eq!(converted, variant, "Converted item does not match variant");

--- a/deepwell/src/types/file_details.rs
+++ b/deepwell/src/types/file_details.rs
@@ -1,5 +1,5 @@
 /*
- * web/file_details.rs
+ * types/file_details.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team

--- a/deepwell/src/types/maybe.rs
+++ b/deepwell/src/types/maybe.rs
@@ -1,5 +1,5 @@
 /*
- * types/provided_value.rs
+ * types/maybe.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team
@@ -30,7 +30,7 @@
 /// When serializing or deserializing a field using this enum, you must
 /// add the following:
 /// ```unchecked
-/// #[serde(default, skip_serializing_if = "ProvidedValue::is_unset")]
+/// #[serde(default, skip_serializing_if = "Maybe::is_unset")]
 /// ```
 ///
 /// (The `skip_serializing_if` attribute is optional if this is a
@@ -40,7 +40,7 @@
 /// to serialize.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Hash, PartialEq, Eq)]
 #[serde(untagged)]
-pub enum ProvidedValue<T> {
+pub enum Maybe<T> {
     Set(T),
 
     #[serde(skip)]
@@ -48,18 +48,18 @@ pub enum ProvidedValue<T> {
     Unset,
 }
 
-impl<T> ProvidedValue<T> {
+impl<T> Maybe<T> {
     pub fn to_option(&self) -> Option<&T> {
         match self {
-            ProvidedValue::Set(ref value) => Some(value),
-            ProvidedValue::Unset => None,
+            Maybe::Set(ref value) => Some(value),
+            Maybe::Unset => None,
         }
     }
 
     pub fn is_set(&self) -> bool {
         match self {
-            ProvidedValue::Set(_) => true,
-            ProvidedValue::Unset => false,
+            Maybe::Set(_) => true,
+            Maybe::Unset => false,
         }
     }
 
@@ -69,23 +69,23 @@ impl<T> ProvidedValue<T> {
     }
 }
 
-impl<T> ProvidedValue<T>
+impl<T> Maybe<T>
 where
     T: Into<sea_orm::Value>,
 {
     pub fn into_active_value(self) -> sea_orm::ActiveValue<T> {
         match self {
-            ProvidedValue::Set(value) => sea_orm::ActiveValue::Set(value),
-            ProvidedValue::Unset => sea_orm::ActiveValue::NotSet,
+            Maybe::Set(value) => sea_orm::ActiveValue::Set(value),
+            Maybe::Unset => sea_orm::ActiveValue::NotSet,
         }
     }
 }
 
-impl<T> From<ProvidedValue<T>> for Option<T> {
-    fn from(value: ProvidedValue<T>) -> Option<T> {
+impl<T> From<Maybe<T>> for Option<T> {
+    fn from(value: Maybe<T>) -> Option<T> {
         match value {
-            ProvidedValue::Set(value) => Some(value),
-            ProvidedValue::Unset => None,
+            Maybe::Set(value) => Some(value),
+            Maybe::Unset => None,
         }
     }
 }
@@ -96,8 +96,8 @@ fn serde() {
 
     #[derive(Serialize, Deserialize, Debug)]
     struct Object {
-        #[serde(default, skip_serializing_if = "ProvidedValue::is_unset")]
-        field: ProvidedValue<Option<String>>,
+        #[serde(default, skip_serializing_if = "Maybe::is_unset")]
+        field: Maybe<Option<String>>,
     }
 
     // Deserialization
@@ -114,12 +114,9 @@ fn serde() {
         }};
     }
 
-    check_deser!(json!({}), ProvidedValue::Unset);
-    check_deser!(json!({ "field": null }), ProvidedValue::Set(None));
-    check_deser!(
-        json!({"field": "apple"}),
-        ProvidedValue::Set(Some(str!("apple"))),
-    );
+    check_deser!(json!({}), Maybe::Unset);
+    check_deser!(json!({ "field": null }), Maybe::Set(None));
+    check_deser!(json!({"field": "apple"}), Maybe::Set(Some(str!("apple"))));
 
     // Serialization
 
@@ -135,10 +132,7 @@ fn serde() {
         }};
     }
 
-    check_ser!(ProvidedValue::Unset, "{}");
-    check_ser!(ProvidedValue::Set(None), r#"{"field":null}"#);
-    check_ser!(
-        ProvidedValue::Set(Some(str!("banana"))),
-        r#"{"field":"banana"}"#,
-    );
+    check_ser!(Maybe::Unset, "{}");
+    check_ser!(Maybe::Set(None), r#"{"field":null}"#);
+    check_ser!(Maybe::Set(Some(str!("banana"))), r#"{"field":"banana"}"#);
 }

--- a/deepwell/src/types/mod.rs
+++ b/deepwell/src/types/mod.rs
@@ -24,16 +24,16 @@ mod bytes;
 mod connection_type;
 mod fetch_direction;
 mod file_details;
+mod maybe;
 mod page_details;
 mod page_order;
-mod provided_value;
 mod reference;
 
 pub use self::bytes::Bytes;
 pub use self::connection_type::ConnectionType;
 pub use self::fetch_direction::FetchDirection;
 pub use self::file_details::FileDetails;
+pub use self::maybe::Maybe;
 pub use self::page_details::PageDetails;
 pub use self::page_order::{PageOrder, PageOrderColumn};
-pub use self::provided_value::ProvidedValue;
 pub use self::reference::Reference;

--- a/deepwell/src/types/mod.rs
+++ b/deepwell/src/types/mod.rs
@@ -1,5 +1,5 @@
 /*
- * web/page_details.rs
+ * types/mod.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team
@@ -18,13 +18,22 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, PartialEq, Eq)]
-#[serde(default)]
-pub struct PageDetails {
-    /// Include the wikitext in the page output.
-    pub wikitext: bool,
+#![allow(unused_imports)]
 
-    /// Include the compiled HTML in the page output.
-    #[serde(alias = "compiled")]
-    pub compiled_html: bool,
-}
+mod bytes;
+mod connection_type;
+mod fetch_direction;
+mod file_details;
+mod page_details;
+mod page_order;
+mod provided_value;
+mod reference;
+
+pub use self::bytes::Bytes;
+pub use self::connection_type::ConnectionType;
+pub use self::fetch_direction::FetchDirection;
+pub use self::file_details::FileDetails;
+pub use self::page_details::PageDetails;
+pub use self::page_order::{PageOrder, PageOrderColumn};
+pub use self::provided_value::ProvidedValue;
+pub use self::reference::Reference;

--- a/deepwell/src/types/page_details.rs
+++ b/deepwell/src/types/page_details.rs
@@ -1,5 +1,5 @@
 /*
- * web/mod.rs
+ * types/page_details.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team
@@ -18,22 +18,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#![allow(unused_imports)]
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[serde(default)]
+pub struct PageDetails {
+    /// Include the wikitext in the page output.
+    pub wikitext: bool,
 
-mod bytes;
-mod connection_type;
-mod fetch_direction;
-mod file_details;
-mod page_details;
-mod page_order;
-mod provided_value;
-mod reference;
-
-pub use self::bytes::Bytes;
-pub use self::connection_type::ConnectionType;
-pub use self::fetch_direction::FetchDirection;
-pub use self::file_details::FileDetails;
-pub use self::page_details::PageDetails;
-pub use self::page_order::{PageOrder, PageOrderColumn};
-pub use self::provided_value::ProvidedValue;
-pub use self::reference::Reference;
+    /// Include the compiled HTML in the page output.
+    #[serde(alias = "compiled")]
+    pub compiled_html: bool,
+}

--- a/deepwell/src/types/page_order.rs
+++ b/deepwell/src/types/page_order.rs
@@ -1,5 +1,5 @@
 /*
- * web/page_order.rs
+ * types/page_order.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team

--- a/deepwell/src/types/provided_value.rs
+++ b/deepwell/src/types/provided_value.rs
@@ -1,5 +1,5 @@
 /*
- * web/provided_value.rs
+ * types/provided_value.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team

--- a/deepwell/src/types/reference.rs
+++ b/deepwell/src/types/reference.rs
@@ -1,5 +1,5 @@
 /*
- * web/reference/id.rs
+ * types/reference/id.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2024 Wikijump Team


### PR DESCRIPTION
As described in [WJ-1284](https://scuttle.atlassian.net/browse/WJ-1284), we are renaming `crate::web` → `crate::types`, and `ProvidedValue` → `Maybe`.

[WJ-1284]: https://scuttle.atlassian.net/browse/WJ-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ