### PR TITLE
[WJ-1032] Add file_rollback

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -446,12 +446,12 @@ CREATE TYPE file_revision_type AS ENUM (
     -- standard
     'regular',
     'rollback',
-    'undo',
 
     -- special
     'create',
     'delete',
-    'undelete'
+    'undelete',
+    'move'
 );
 
 CREATE TYPE file_revision_change AS ENUM (
@@ -523,7 +523,7 @@ CREATE TABLE file_revision (
     ),
 
     -- Ensure array is not empty for regular revisions
-    CHECK (revision_type NOT IN ('regular', 'rollback', 'undo') OR changes != '{}'),
+    CHECK (revision_type NOT IN ('regular', 'rollback') OR changes != '{}'),
 
     -- Ensure page creations are always the first revision
     CHECK (revision_number != 0 OR revision_type = 'create'),

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -438,8 +438,8 @@ CREATE TABLE blob_pending (
 
 -- Enum types for file_revision
 CREATE TYPE file_revision_type AS ENUM (
+    'regular',
     'create',
-    'update',
     'delete',
     'undelete'
 );
@@ -512,8 +512,8 @@ CREATE TABLE file_revision (
         }'
     ),
 
-    -- Ensure array is not empty for update revisions
-    CHECK (revision_type != 'update' OR changes != '{}'),
+    -- Ensure array is not empty for regular revisions
+    CHECK (revision_type != 'regular' OR changes != '{}'),
 
     -- Ensure page creations are always the first revision
     CHECK (revision_number != 0 OR revision_type = 'create'),

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -215,7 +215,12 @@ CREATE TABLE page (
 
 -- Enum types for page_revision
 CREATE TYPE page_revision_type AS ENUM (
+    -- standard
     'regular',
+    'rollback',
+    'undo',
+
+    -- special
     'create',
     'delete',
     'undelete',
@@ -293,7 +298,7 @@ CREATE TABLE page_revision (
     ),
 
     -- Ensure array is not empty for regular revisions
-    CHECK (revision_type != 'regular' OR changes != '{}'),
+    CHECK (revision_type NOT IN ('regular', 'rollback', 'undo') OR changes != '{}'),
 
     -- Ensure page creations are always the first revision
     CHECK (revision_number != 0 OR revision_type = 'create'),
@@ -438,7 +443,12 @@ CREATE TABLE blob_pending (
 
 -- Enum types for file_revision
 CREATE TYPE file_revision_type AS ENUM (
+    -- standard
     'regular',
+    'rollback',
+    'undo',
+
+    -- special
     'create',
     'delete',
     'undelete'
@@ -513,7 +523,7 @@ CREATE TABLE file_revision (
     ),
 
     -- Ensure array is not empty for regular revisions
-    CHECK (revision_type != 'regular' OR changes != '{}'),
+    CHECK (revision_type NOT IN ('regular', 'rollback', 'undo') OR changes != '{}'),
 
     -- Ensure page creations are always the first revision
     CHECK (revision_number != 0 OR revision_type = 'create'),

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -270,6 +270,7 @@ async fn build_module(app_state: ServerState) -> anyhow::Result<RpcModule<Server
     register!("file_delete", file_delete);
     register!("file_move", file_move);
     register!("file_restore", file_restore);
+    register!("file_rollback", file_rollback);
     register!("file_hard_delete", file_hard_delete);
 
     // File revisions

--- a/deepwell/src/endpoints/file.rs
+++ b/deepwell/src/endpoints/file.rs
@@ -25,7 +25,7 @@ use crate::services::blob::BlobService;
 use crate::services::file::{
     CreateFile, CreateFileOutput, DeleteFile, DeleteFileOutput, EditFile, EditFileOutput,
     GetFileDetails, GetFileOutput, MoveFile, MoveFileOutput, RestoreFile,
-    RestoreFileOutput,
+    RestoreFileOutput, RollbackFile,
 };
 use crate::services::Result;
 use crate::types::{Bytes, FileDetails};
@@ -113,6 +113,20 @@ pub async fn file_restore(
     );
 
     FileService::restore(ctx, input).await
+}
+
+pub async fn file_rollback(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<Option<EditFileOutput>> {
+    let input: RollbackFile = params.parse()?;
+
+    info!(
+        "Rolling back file {:?} in page ID {} in site ID {} to revision number {}",
+        input.file, input.page_id, input.site_id, input.revision_number,
+    );
+
+    FileService::rollback(ctx, input).await
 }
 
 pub async fn file_move(

--- a/deepwell/src/hash/blob.rs
+++ b/deepwell/src/hash/blob.rs
@@ -42,11 +42,17 @@ pub fn sha512_hash(data: &[u8]) -> BlobHash {
     let mut hasher = Sha512::new();
     hasher.update(data);
     let result = hasher.finalize();
+    slice_to_blob_hash(&result)
+}
 
-    // Copy data into regular Rust array
-    let mut bytes = [0; 64];
-    bytes.copy_from_slice(&result);
-    bytes
+/// Convert a slice into a hash array.
+///
+/// # Panics
+/// Panics if the input slice is not the appropriate size.
+pub fn slice_to_blob_hash(slice: &[u8]) -> BlobHash {
+    let mut hash = [0; 64];
+    hash.copy_from_slice(slice);
+    hash
 }
 
 /// Converts the given SHA-512 hash into a hex array string.

--- a/deepwell/src/models/blob_pending.rs
+++ b/deepwell/src/models/blob_pending.rs
@@ -16,7 +16,7 @@ pub struct Model {
     pub expected_length: i64,
     #[sea_orm(column_type = "Text")]
     pub s3_path: String,
-    #[sea_orm(column_type = "VarBinary(StringLen::None)")]
+    #[sea_orm(column_type = "VarBinary(StringLen::None)", nullable)]
     pub s3_hash: Option<Vec<u8>>,
     #[sea_orm(column_type = "Text")]
     pub presign_url: String,

--- a/deepwell/src/models/page_category.rs
+++ b/deepwell/src/models/page_category.rs
@@ -15,6 +15,7 @@ pub struct Model {
     pub site_id: i64,
     #[sea_orm(column_type = "Text")]
     pub slug: String,
+    #[sea_orm(column_type = "Text", nullable)]
     pub layout: Option<String>,
 }
 

--- a/deepwell/src/models/sea_orm_active_enums.rs
+++ b/deepwell/src/models/sea_orm_active_enums.rs
@@ -20,14 +20,18 @@ pub enum AliasType {
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "file_revision_type")]
 #[serde(rename_all = "kebab-case")]
 pub enum FileRevisionType {
-    #[sea_orm(string_value = "regular")]
-    Regular,
     #[sea_orm(string_value = "create")]
     Create,
     #[sea_orm(string_value = "delete")]
     Delete,
+    #[sea_orm(string_value = "regular")]
+    Regular,
+    #[sea_orm(string_value = "rollback")]
+    Rollback,
     #[sea_orm(string_value = "undelete")]
     Undelete,
+    #[sea_orm(string_value = "undo")]
+    Undo,
 }
 #[derive(
     Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, Serialize, Deserialize,
@@ -60,8 +64,12 @@ pub enum PageRevisionType {
     Move,
     #[sea_orm(string_value = "regular")]
     Regular,
+    #[sea_orm(string_value = "rollback")]
+    Rollback,
     #[sea_orm(string_value = "undelete")]
     Undelete,
+    #[sea_orm(string_value = "undo")]
+    Undo,
 }
 #[derive(
     Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, Serialize, Deserialize,

--- a/deepwell/src/models/sea_orm_active_enums.rs
+++ b/deepwell/src/models/sea_orm_active_enums.rs
@@ -20,14 +20,14 @@ pub enum AliasType {
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "file_revision_type")]
 #[serde(rename_all = "kebab-case")]
 pub enum FileRevisionType {
+    #[sea_orm(string_value = "regular")]
+    Regular,
     #[sea_orm(string_value = "create")]
     Create,
     #[sea_orm(string_value = "delete")]
     Delete,
     #[sea_orm(string_value = "undelete")]
     Undelete,
-    #[sea_orm(string_value = "update")]
-    Update,
 }
 #[derive(
     Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, Serialize, Deserialize,

--- a/deepwell/src/models/sea_orm_active_enums.rs
+++ b/deepwell/src/models/sea_orm_active_enums.rs
@@ -24,14 +24,14 @@ pub enum FileRevisionType {
     Create,
     #[sea_orm(string_value = "delete")]
     Delete,
+    #[sea_orm(string_value = "move")]
+    Move,
     #[sea_orm(string_value = "regular")]
     Regular,
     #[sea_orm(string_value = "rollback")]
     Rollback,
     #[sea_orm(string_value = "undelete")]
     Undelete,
-    #[sea_orm(string_value = "undo")]
-    Undo,
 }
 #[derive(
     Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Copy, Serialize, Deserialize,

--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -19,6 +19,7 @@
  */
 
 use super::prelude::*;
+use crate::hash::slice_to_blob_hash;
 use crate::models::blob_pending::{
     self, Entity as BlobPending, Model as BlobPendingModel,
 };
@@ -371,11 +372,8 @@ impl BlobService {
 
                 debug_assert_eq!(expected_length, size);
 
-                let mut hash = [0; 64];
-                hash.copy_from_slice(&hash_vec);
-
                 FinalizeBlobUploadOutput {
-                    hash,
+                    hash: slice_to_blob_hash(&hash_vec),
                     mime,
                     size,
                     created: false,

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -189,6 +189,7 @@ impl FileService {
                 file_id,
                 user_id,
                 revision_comments,
+                revision_type: FileRevisionType::Regular,
                 body: CreateFileRevisionBody {
                     name,
                     licensing,
@@ -254,6 +255,7 @@ impl FileService {
                 file_id,
                 user_id,
                 revision_comments,
+                revision_type: FileRevisionType::Move,
                 body: CreateFileRevisionBody {
                     page_id: Maybe::Set(destination_page_id),
                     ..Default::default()
@@ -492,6 +494,7 @@ impl FileService {
             file_id,
             user_id,
             revision_comments,
+            revision_type: FileRevisionType::Rollback,
             body: CreateFileRevisionBody {
                 name: Maybe::Set(name),
                 blob: Maybe::Set(blob),

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -19,6 +19,7 @@
  */
 
 use super::prelude::*;
+use crate::hash::slice_to_blob_hash;
 use crate::models::file::{self, Entity as File, Model as FileModel};
 use crate::models::file_revision::{
     self, Entity as FileRevision, Model as FileRevisionModel,
@@ -470,11 +471,7 @@ impl FileService {
         // Copy the body of the target revision
 
         let blob = FileBlob {
-            s3_hash: {
-                let mut hash = [0; 64];
-                hash.copy_from_slice(&s3_hash);
-                hash
-            },
+            s3_hash: slice_to_blob_hash(&s3_hash),
             mime_hint,
             size_hint,
             // in a rollback, by definition the blob was already uploaded

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -485,10 +485,10 @@ impl FileService {
             user_id,
             revision_comments,
             body: CreateFileRevisionBody {
-                name: ProvidedValue::Set(name),
-                blob: ProvidedValue::Set(blob),
-                licensing: ProvidedValue::Set(licensing),
-                page_id: ProvidedValue::Unset, // rollbacks should never move files
+                name: Maybe::Set(name),
+                blob: Maybe::Set(blob),
+                licensing: Maybe::Set(licensing),
+                page_id: Maybe::Unset, // rollbacks should never move files
             },
         };
 

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -137,6 +137,13 @@ pub struct DeleteFile<'a> {
     pub user_id: i64,
 }
 
+#[derive(Serialize, Debug, Clone)]
+pub struct DeleteFileOutput {
+    pub file_id: i64,
+    pub file_revision_id: i64,
+    pub file_revision_number: i32,
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct RestoreFile {
     pub revision_comments: String,
@@ -146,13 +153,6 @@ pub struct RestoreFile {
     pub page_id: i64,
     pub file_id: i64,
     pub user_id: i64,
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct DeleteFileOutput {
-    pub file_id: i64,
-    pub file_revision_id: i64,
-    pub file_revision_number: i32,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -165,12 +165,15 @@ pub struct RestoreFileOutput {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct RollbackFile {
+pub struct RollbackFile<'a> {
     pub site_id: i64,
     pub page_id: i64,
-    pub file_id: i64,
+    pub file: Reference<'a>,
     pub last_revision_id: i64,
     pub revision_number: i32,
     pub revision_comments: String,
     pub user_id: i64,
+
+    #[serde(default)]
+    pub bypass_filter: bool,
 }

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -163,3 +163,14 @@ pub struct RestoreFileOutput {
     pub file_revision_id: i64,
     pub file_revision_number: i32,
 }
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct RollbackFile {
+    pub site_id: i64,
+    pub page_id: i64,
+    pub file_id: i64,
+    pub last_revision_id: i64,
+    pub revision_number: i32,
+    pub revision_comments: String,
+    pub user_id: i64,
+}

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -155,7 +155,7 @@ impl FileRevisionService {
 
         // Insert the new revision into the table
         let model = file_revision::ActiveModel {
-            revision_type: Set(FileRevisionType::Update),
+            revision_type: Set(FileRevisionType::Regular),
             revision_number: Set(revision_number),
             file_id: Set(file_id),
             page_id: Set(page_id),

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -62,12 +62,22 @@ impl FileRevisionService {
             file_id,
             user_id,
             revision_comments,
+            revision_type,
             body,
         }: CreateFileRevision,
         previous: FileRevisionModel,
     ) -> Result<Option<CreateFileRevisionOutput>> {
         let txn = ctx.transaction();
         let revision_number = next_revision_number(&previous, page_id, file_id);
+
+        // Replace with debug_assert_matches! when stablized
+        debug_assert!(
+            matches!(
+                revision_type,
+                FileRevisionType::Regular | FileRevisionType::Rollback,
+            ),
+            "Invalid revision type for standard revision creation",
+        );
 
         // Fields to create in the revision
         let mut changes = Vec::new();
@@ -155,7 +165,7 @@ impl FileRevisionService {
 
         // Insert the new revision into the table
         let model = file_revision::ActiveModel {
-            revision_type: Set(FileRevisionType::Regular),
+            revision_type: Set(revision_type),
             revision_number: Set(revision_number),
             file_id: Set(file_id),
             page_id: Set(page_id),

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::hash::BlobHash;
+use crate::models::sea_orm_active_enums::FileRevisionType;
 use crate::services::page_revision::PageRevisionCountOutput;
 use crate::types::{Bytes, FetchDirection};
 
@@ -30,6 +31,7 @@ pub struct CreateFileRevision {
     pub file_id: i64,
     pub user_id: i64,
     pub revision_comments: String,
+    pub revision_type: FileRevisionType,
     pub body: CreateFileRevisionBody,
 }
 

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -468,6 +468,9 @@ impl PageService {
             PageRevisionService::get_latest(ctx, site_id, page_id),
         )?;
 
+        // TODO Handle hidden fields, see https://scuttle.atlassian.net/browse/WJ-1285
+        let _ = target_revision.hidden;
+
         // Check last revision ID
         check_last_revision(Some(&last_revision), latest_revision_id, last_revision_id)?;
 

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -22,6 +22,7 @@ use super::prelude::*;
 use crate::models::page::{self, Entity as Page, Model as PageModel};
 use crate::models::page_category::Model as PageCategoryModel;
 use crate::models::page_revision::Model as PageRevisionModel;
+use crate::models::sea_orm_active_enums::PageRevisionType;
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::page_revision::{
     CreateFirstPageRevision, CreateFirstPageRevisionOutput, CreatePageRevision,
@@ -174,6 +175,7 @@ impl PageService {
         let revision_input = CreatePageRevision {
             user_id,
             comments,
+            revision_type: PageRevisionType::Regular,
             body: CreatePageRevisionBody {
                 wikitext,
                 title,
@@ -260,6 +262,7 @@ impl PageService {
         let revision_input = CreatePageRevision {
             user_id,
             comments,
+            revision_type: PageRevisionType::Move,
             body: CreatePageRevisionBody {
                 slug: Maybe::Set(new_slug.clone()),
                 ..Default::default()
@@ -485,6 +488,7 @@ impl PageService {
 
         let revision_input = CreatePageRevision {
             user_id,
+            revision_type: PageRevisionType::Rollback,
             comments,
             body: CreatePageRevisionBody {
                 wikitext: Maybe::Set(wikitext),

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -108,6 +108,18 @@ impl PageRevisionService {
         let txn = ctx.transaction();
         let revision_number = next_revision_number(&previous, site_id, page_id);
 
+        // Replace with debug_assert_matches! when stablized
+        debug_assert!(
+            matches!(
+                revision_type,
+                PageRevisionType::Regular
+                    | PageRevisionType::Move
+                    | PageRevisionType::Rollback
+                    | PageRevisionType::Undo,
+            ),
+            "Invalid revision type for standard revision creation",
+        );
+
         // Fields to create in the revision
         let mut parser_errors = None;
         let mut old_slug = None;

--- a/deepwell/src/services/page_revision/structs.rs
+++ b/deepwell/src/services/page_revision/structs.rs
@@ -30,6 +30,7 @@ use time::OffsetDateTime;
 pub struct CreatePageRevision {
     pub user_id: i64,
     pub comments: String,
+    pub revision_type: PageRevisionType,
 
     #[serde(flatten)]
     pub body: CreatePageRevisionBody,


### PR DESCRIPTION
This adds rollback capability to files, which like for page rollbacks, changes a file to have the same state it had earlier. (This cannot be used to move a file to a different page). While working on this, I discovered a bug in file moves where it wasn't properly updating the name.

Example output after local tests:
```
 revision_id | revision_type |          created_at           | revision_number | file_id | page_id | site_id | user_i>
-------------+---------------+-------------------------------+-----------------+---------+---------+---------+------->
           1 | create        | 2024-10-10 08:52:01.028316+00 |               0 |       1 |       1 |       1 |       >
           2 | regular       | 2024-10-10 08:52:13.901203+00 |               1 |       1 |       1 |       1 |       >
           3 | rollback      | 2024-10-10 08:52:21.541878+00 |               2 |       1 |       1 |       1 |       >
(3 rows)
```