### PR TITLE
Hotfix: Add missing libmagic.so for deploy

### DIFF
--- a/install/aws/prod/docker/api/Dockerfile
+++ b/install/aws/prod/docker/api/Dockerfile
@@ -28,7 +28,7 @@ FROM debian:latest
 ENV LOCALIZATION_PATH="/opt/locales"
 
 RUN apt update
-RUN apt install -y curl libmagic-mgc
+RUN apt install -y curl libmagic1 libmagic-mgc
 COPY --from=rust /src/deepwell/target/release/deepwell /usr/local/bin/deepwell
 COPY ./install/files/api/health-check.sh /bin/wikijump-health-check
 COPY ./install/files/prod/deepwell.toml /etc/deepwell.toml

--- a/install/dev/digitalocean/api/Dockerfile
+++ b/install/dev/digitalocean/api/Dockerfile
@@ -33,7 +33,7 @@ ENV LOCALIZATION_PATH="/opt/locales"
 # Install system dependencies
 RUN mkdir /opt/database
 RUN apt update
-RUN apt install -y curl libmagic-mgc postgresql-client
+RUN apt install -y curl libmagic1 libmagic-mgc postgresql-client
 
 # Install files
 COPY --from=rust /usr/local/cargo/bin/sqlx /usr/local/cargo/bin/sqlx


### PR DESCRIPTION
In #2137, one of the dependabot dependency update PRs, I changed our dev/prod docker images for deepwell to use Debian instead of Alpine due to repeated issues with libraries. However, while I added the dependency for the magic _files_, I didn't add the actual magic library itself, so the binary cannot launch because it lacks `libmagic.so.1`.

Deploy error:
```
[2024-10-23 02:59:52] wikijump-dev-db-do-user-2151029-0.g.db.ondigitalocean.com:25060 - accepting connections
[2024-10-23 02:59:52] DROP OWNED
[2024-10-23 02:59:52] Applied 20211211080753/migrate initial (8.899015ms)
[2024-10-23 02:59:52] Applied 20220906090721/migrate wikidot (305.065878ms)
[2024-10-23 02:59:52] Applied 20220906090722/migrate wikidot seed (15.764554ms)
[2024-10-23 02:59:52] Applied 20220906090723/migrate wikidot drop (75.21557ms)
[2024-10-23 02:59:53] Applied 20220906103252/migrate deepwell (176.911041ms)
[2024-10-23 02:59:53] /usr/local/bin/deepwell: error while loading shared libraries: libmagic.so.1: cannot open shared object file: No such file or directory
```

And [here are the contents of the `libmagic1` package on Debian](https://packages.debian.org/bookworm/amd64/libmagic1/filelist):
```
/etc/magic
/etc/magic.mime
/usr/lib/x86_64-linux-gnu/libmagic.so.1
/usr/lib/x86_64-linux-gnu/libmagic.so.1.0.0
/usr/share/bug/libmagic1/control
/usr/share/bug/libmagic1/presubj
/usr/share/doc/libmagic1/changelog.Debian.gz
/usr/share/doc/libmagic1/changelog.gz
/usr/share/doc/libmagic1/copyright
/usr/share/man/man5/magic.5.gz
/usr/share/misc/magic
```

So adding this dependency should resolve the deployment issue.