### PR TITLE
[chore] Bump deepwell version to v2024.10.23

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2024.10.6"
+version = "2024.10.23"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2024.10.6"
+version = "2024.10.23"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
We've made several changes to deepwell since 2024.10.6, we should bump the version.