### PR TITLE
[WJ-964] Amend compatibility ID data

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -271,7 +271,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     //
     // See https://scuttle.atlassian.net/browse/WJ-964
 
-    restart_sequence_with(&txn, "user_user_id_seq", 10000000).await?;
+    restart_sequence_with(&txn, "user_user_id_seq", 20000000).await?;
     restart_sequence_with(&txn, "site_site_id_seq", 6000000).await?;
     restart_sequence_with(&txn, "page_page_id_seq", 3000000000).await?;
     restart_sequence_with(&txn, "page_revision_revision_id_seq", 3000000000).await?;

--- a/docs/compatibility-ids.md
+++ b/docs/compatibility-ids.md
@@ -7,13 +7,14 @@ This is important because Wikidot exposes IDs in several places, such as forum U
 The approach used here is to set the starting ID value to be higher than Wikidot in production will ever conceivably reach (at least before Wikijump is deployed). We did this by finding a recent ID value for that kind of object, and increasing its most significant digit by at least one value. For the most populous objects (pages and revisions), the produced value is higher than Wikidot could ever achieve, since they use only 32-bit integers for IDs.
 
 ```
-- Page           -- 3000000000 (sample       1331370625)
-- Revision       -- 3000000000 (sample       1388179085)
-- Page Category  --  100000000 (sample         43202888)
-- Forum Post     --    7000000 (sample          5174477)
-- Forum Thread   --   30000000 (sample         14447612)
+- Page           -- 3000000000 (sample       1457417979)
+- Revision       -- 3000000000 (sample       1525918930)
+- Page Category  --  100000000 (sample         44073660)
+- Forum Post     --    7000000 (sample          6734911)
+- Forum Thread   --   30000000 (sample         16988888)
 - Forum Category --    9000000 (sample          7412040)
-- User           --   10000000 (sample          7840760)
+- User           --   20000000 (sample          9475151)
+- Site           --    6000000 (sample          4573998)
 ```
 
 (Note that forum groups are not included, as their IDs are not exposed by Wikidot.)

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -8,8 +8,8 @@ To understand the limits for Wikidot-imported items, see [Compatibility IDs](com
 | Item                             | Upper limit               | Comment |
 |----------------------------------|---------------------------|---------|
 | Users (total)                    | 9223372036854775807       |         |
-| Users (new)                      | 9223372036844775807       | Any new user accounts registered on Wikijump. |
-| Users (compatibility)            | 10000000                  | Any user accounts imported from Wikidot. |
+| Users (new)                      | 9223372036834775807       | Any new user accounts registered on Wikijump. |
+| Users (compatibility)            | 20000000                  | Any user accounts imported from Wikidot. |
 | Sites                            | 9223372036854775807       |         |
 | Pages (total)                    | 9223372036854775807       |         |
 | Pages (new)                      | 9223372033854775807       | Any new pages created on Wikijump. |


### PR DESCRIPTION
After re-reviewing recent Wikidot IDs, I have made one modification due to the growth in user account creations since the last sample.

See the edits to [WJ-964](https://scuttle.atlassian.net/browse/WJ-964).

[WJ-964]: https://scuttle.atlassian.net/browse/WJ-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ