### PR TITLE
Fix file revision move bugs

### DIFF
--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -71,11 +71,12 @@ impl FileRevisionService {
         let txn = ctx.transaction();
         let revision_number = next_revision_number(&previous, page_id, file_id);
 
-        // Replace with debug_assert_matches! when stablized
+        // Replace with debug_assert_matches! when stablized.
+        // This should correspond to each use of FileRevisionService::create() in FileService.
         debug_assert!(
             matches!(
                 revision_type,
-                FileRevisionType::Regular | FileRevisionType::Rollback,
+                FileRevisionType::Regular | FileRevisionType::Move | FileRevisionType::Rollback,
             ),
             "Invalid revision type for standard revision creation",
         );

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -542,7 +542,6 @@ impl FileRevisionService {
     pub async fn get_range(
         ctx: &ServiceContext<'_>,
         GetFileRevisionRange {
-            page_id,
             file_id,
             revision_number,
             revision_direction,
@@ -571,7 +570,6 @@ impl FileRevisionService {
         let revisions = FileRevision::find()
             .filter(
                 Condition::all()
-                    .add(file_revision::Column::PageId.eq(page_id))
                     .add(file_revision::Column::FileId.eq(file_id))
                     .add(revision_condition),
             )

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -76,7 +76,9 @@ impl FileRevisionService {
         debug_assert!(
             matches!(
                 revision_type,
-                FileRevisionType::Regular | FileRevisionType::Move | FileRevisionType::Rollback,
+                FileRevisionType::Regular
+                    | FileRevisionType::Move
+                    | FileRevisionType::Rollback,
             ),
             "Invalid revision type for standard revision creation",
         );

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -122,7 +122,6 @@ pub struct UpdateFileRevision {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct GetFileRevisionRange {
-    pub page_id: i64,
     pub file_id: i64,
     pub revision_number: i32,
     pub revision_direction: FetchDirection,


### PR DESCRIPTION
Two bugs were raised in chat related to moving files between pages:
1. The actual function to create a `move`-type file revision fails because that type wasn't permitted in the assertion. I also left a comment noting under what conditions enums should be present there.
2. The `page_id` requirement in the `file_revision` query means we can only see file revisions that happened when the file was on that specific page. Since files can exist historically across multiple pages, we shouldn't add that condition here like we have for `site_id` in pages.