### PR TITLE
Upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -33,7 +33,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -116,7 +116,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -24,7 +24,7 @@ jobs:
           toolchain: stable
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -53,7 +53,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cargo Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Required by https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/