### PR TITLE
[WJ-1291] Update ftml dependency to 1.28.0

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -127,6 +127,9 @@ jobs:
             deepwell/target
           key: ${{ runner.os }}-deepwell-lint-${{ hashFiles('deepwell/**/Cargo.toml') }}
 
+      - name: System Dependencies
+        run: sudo apt update && sudo apt install libmagic-dev
+
       - name: Rustfmt
         run: cd deepwell && cargo fmt --all -- --check
 

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1152,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9e7d928f9c118863c143c3d3f84b8a726ce556acf105cb3d44f6c7f8b9a5b5"
+checksum = "495d6a8bccff636c0498bcfc7aeb1f8aeb20f8c9519b8f51c84266c3eaa3e8aa"
 dependencies = [
  "built",
  "cfg-if",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -33,7 +33,7 @@ femme = "2"
 filemagic = "0.13"
 fluent = "0.16"
 fluent-syntax = "0"
-ftml = { version = "1.27", features = ["mathml"] }
+ftml = { version = "1.28", features = ["mathml"] }
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 hex = { version = "0.4", features = ["serde"] }
 hostname = "0.4"


### PR DESCRIPTION
See https://github.com/scpwiki/ftml/pull/28. Also add a missing step causing CI failure.