### PR TITLE
[chore] Bump deepwell version to v2024.12.30

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2024.11.30"
+version = "2024.12.30"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2024.11.30"
+version = "2024.12.30"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Since we updated the dependencies, including a change with a security vulnerability fix, we should bump the DEEPWELL version.