### PR TITLE
Add domains endpoint

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -28,10 +28,10 @@
 
 use crate::config::{Config, Secrets};
 use crate::endpoints::{
-    auth::*, blob::*, caddy::*, category::*, domain::*, email::*, file::*,
-    file_revision::*, info::*, link::*, locale::*, message::*, misc::*, page::*,
-    page_revision::*, parent::*, site::*, site_member::*, special_error::*, text::*,
-    user::*, user_bot::*, view::*, vote::*,
+    auth::*, blob::*, category::*, domain::*, email::*, file::*, file_revision::*,
+    info::*, link::*, locale::*, message::*, misc::*, page::*, page_revision::*,
+    parent::*, routing::*, site::*, site_member::*, special_error::*, text::*, user::*,
+    user_bot::*, view::*, vote::*,
 };
 use crate::locales::Localizations;
 use crate::services::blob::MimeAnalyzer;
@@ -190,6 +190,7 @@ async fn build_module(app_state: ServerState) -> anyhow::Result<RpcModule<Server
     register!("translate", translate_strings);
 
     // Web routing
+    register!("domains", platform_domains);
     register!("caddyfile", generate_caddyfile);
 
     // Web server

--- a/deepwell/src/endpoints/mod.rs
+++ b/deepwell/src/endpoints/mod.rs
@@ -44,7 +44,6 @@ mod prelude {
 
 pub mod auth;
 pub mod blob;
-pub mod caddy;
 pub mod category;
 pub mod domain;
 pub mod email;
@@ -58,6 +57,7 @@ pub mod misc;
 pub mod page;
 pub mod page_revision;
 pub mod parent;
+pub mod routing;
 pub mod site;
 pub mod site_member;
 pub mod special_error;

--- a/deepwell/src/endpoints/routing.rs
+++ b/deepwell/src/endpoints/routing.rs
@@ -1,5 +1,5 @@
 /*
- * endpoints/caddy.rs
+ * endpoints/routing.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2025 Wikijump Team
@@ -20,6 +20,28 @@
 
 use super::prelude::*;
 use crate::services::caddy::CaddyfileOptions;
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Domains {
+    main_domain: String,
+    main_domain_no_dot: String,
+    files_domain: String,
+    files_domain_no_dot: String,
+}
+
+pub async fn platform_domains<'a>(
+    ctx: &ServiceContext<'a>,
+    _params: Params<'static>,
+) -> Result<Domains> {
+    let config = ctx.config();
+
+    Ok(Domains {
+        main_domain: config.main_domain.clone(),
+        main_domain_no_dot: config.main_domain_no_dot.clone(),
+        files_domain: config.files_domain.clone(),
+        files_domain_no_dot: config.files_domain_no_dot.clone(),
+    })
+}
 
 pub async fn generate_caddyfile(
     ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/routing.rs
+++ b/deepwell/src/endpoints/routing.rs
@@ -29,8 +29,8 @@ pub struct Domains {
     files_domain_no_dot: String,
 }
 
-pub async fn platform_domains<'a>(
-    ctx: &ServiceContext<'a>,
+pub async fn platform_domains(
+    ctx: &ServiceContext<'_>,
     _params: Params<'static>,
 ) -> Result<Domains> {
     let config = ctx.config();


### PR DESCRIPTION
This adds the `domains` JSONRPC endpoint, which returns:
```json
{
    "main_domain": ".wikijump.com",
    "main_domain_no_dot": "wikijump.com",
    "files_domain": ".wjfiles.com",
    "files_domain_no_dot": "wjfiles.com"
}
```

This way it can be used by downstream services like framerail or wws.