### PR TITLE
Fix redis Dockerfile build

### DIFF
--- a/install/dev/redis/Dockerfile
+++ b/install/dev/redis/Dockerfile
@@ -1,5 +1,5 @@
 FROM redis:alpine
 
 EXPOSE 6379
-COPY ./install/dev/redis/redis.conf /usr/local/etc/redis.conf
+COPY ./redis.conf /usr/local/etc/redis.conf
 CMD ["redis-server", "/usr/local/etc/redis.conf"]


### PR DESCRIPTION
Minor issue in the build process here. Compare with the `local` redis Dockerfile.