### PR TITLE
Add preferred domain to seeder

### DIFF
--- a/deepwell/seeder/sites.dev.patch
+++ b/deepwell/seeder/sites.dev.patch
@@ -1,0 +1,6 @@
+32,33c32,33
+<         "domains": ["scpwiki.dev", "scpwiki.localhost"],
+<         "preferred-domain": "scpwiki.localhost",
+---
+>         "domains": ["scpwiki.dev"],
+>         "preferred-domain": "scpwiki.dev",

--- a/deepwell/seeder/sites.json
+++ b/deepwell/seeder/sites.json
@@ -30,6 +30,7 @@
         "slug": "scp-wiki",
         "name": "SCP Wiki (test)",
         "domains": ["scpwiki.dev", "scpwiki.localhost"],
+        "preferred-domain": "scpwiki.localhost",
         "tagline": "Secure, Contain, Protect",
         "description": "Test site mimicking the SCP Wiki (EN)",
         "default-page": "main",

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -135,6 +135,9 @@ pub struct Site {
 
     #[serde(default)]
     pub domains: Vec<String>,
+
+    #[serde(default)]
+    pub preferred_domain: Option<String>,
     pub name: String,
     pub tagline: String,
     pub description: String,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -31,7 +31,7 @@ use crate::services::file::{
 };
 use crate::services::filter::{CreateFilter, FilterService};
 use crate::services::page::{CreatePage, PageService};
-use crate::services::site::{CreateSite, CreateSiteOutput, SiteService};
+use crate::services::site::{CreateSite, CreateSiteOutput, SiteService, UpdateSiteBody};
 use crate::services::user::{CreateUser, CreateUserOutput, UpdateUserBody, UserService};
 use crate::services::ServiceContext;
 use crate::types::{Maybe, Reference};
@@ -188,6 +188,17 @@ pub async fn seed(state: &ServerState) -> Result<()> {
             DomainService::create_custom(&ctx, CreateCustomDomain { site_id, domain })
                 .await?;
         }
+
+        SiteService::update(
+            &ctx,
+            Reference::Id(site_id),
+            UpdateSiteBody {
+                preferred_domain: Maybe::Set(site.preferred_domain),
+                ..Default::default()
+            },
+            SYSTEM_USER_ID,
+        )
+        .await?;
 
         site_ids.insert(slug, site_id);
     }

--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -138,6 +138,9 @@ pub enum Error {
     #[error("Custom domains may not be subdomains of the Wikijump main or file domains")]
     CustomDomainSubdomain,
 
+    #[error("Cannot use custom domain, as it belongs to a different site")]
+    CustomDomainWrongSite,
+
     #[error("The regular expression found in the database is invalid")]
     FilterRegexInvalid(regex::Error),
 
@@ -411,6 +414,7 @@ impl Error {
             Error::BlobCannotBlacklistExisting => 4029,
             Error::NotLatestRevisionId => 4030,
             Error::CustomDomainSubdomain => 4031,
+            Error::CustomDomainWrongSite => 4032,
 
             // 4100 -- Localization
             Error::LocaleInvalid(_) => 4100,

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -30,7 +30,7 @@ use crate::models::site::{self, Entity as Site, Model as SiteModel};
 use crate::services::alias::CreateAlias;
 use crate::services::relation::CreateSiteUser;
 use crate::services::user::{CreateUser, UpdateUserBody};
-use crate::services::{AliasService, Error, RelationService, UserService};
+use crate::services::{AliasService, DomainService, Error, RelationService, UserService};
 use crate::utils::validate_locale;
 use ftml::layout::Layout;
 use ref_map::*;
@@ -168,6 +168,37 @@ impl SiteService {
             validate_locale(&locale)?;
             model.locale = Set(locale.clone());
             site_user_body.locales = Maybe::Set(vec![locale]);
+        }
+
+        if let Maybe::Set(default_page) = input.default_page {
+            model.default_page = Set(default_page);
+        }
+
+        if let Maybe::Set(preferred_domain) = input.preferred_domain {
+            if let Some(domain) = &preferred_domain {
+                // Ensure that the custom domain exists and belongs to this site
+                match DomainService::site_from_custom_domain_optional(ctx, domain).await?
+                {
+                    Some(found_site) if found_site.site_id == site.site_id => (),
+                    Some(found_site) => {
+                        error!(
+                            "Attempting to set preferred domain for site ID {} '{}' to {}, but the custom domain belongs to site ID {} '{}'!",
+                            site.site_id,
+                            site.slug,
+                            domain,
+                            found_site.site_id,
+                            found_site.slug,
+                        );
+                        return Err(Error::CustomDomainWrongSite);
+                    }
+                    None => {
+                        error!("Attempting to set preferred domain to '{domain}', but this is not a known custom domain!");
+                        return Err(Error::CustomDomainNotFound);
+                    }
+                }
+            }
+
+            model.preferred_domain = Set(preferred_domain);
         }
 
         if let Maybe::Set(layout) = input.layout {

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -18,24 +18,21 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// TODO disallow preferred domains for default site (www)
-// TODO expire redis cache on change to domains
-
-use wikidot_normalize::normalize;
-
 use super::prelude::*;
 use crate::constants::SYSTEM_USER_ID;
 use crate::models::sea_orm_active_enums::{AliasType, UserType};
 use crate::models::site::{self, Entity as Site, Model as SiteModel};
 use crate::services::alias::CreateAlias;
+use crate::services::domain::{DomainService, DEFAULT_SITE_SLUG};
 use crate::services::relation::CreateSiteUser;
 use crate::services::user::{CreateUser, UpdateUserBody};
-use crate::services::{AliasService, DomainService, Error, RelationService, UserService};
+use crate::services::{AliasService, Error, RelationService, UserService};
 use crate::utils::validate_locale;
 use ftml::layout::Layout;
 use ref_map::*;
 use sea_orm::NotSet;
 use std::borrow::Cow;
+use wikidot_normalize::normalize;
 
 #[derive(Debug)]
 pub struct SiteService;
@@ -175,8 +172,16 @@ impl SiteService {
         }
 
         if let Maybe::Set(preferred_domain) = input.preferred_domain {
+            // Disallow preferred domains for the default site (www)
+            if site.slug == DEFAULT_SITE_SLUG {
+                error!("Cannot set a preferred domain for the default site");
+                return Err(Error::BadRequest);
+            }
+
+            // TODO expire redis cache on change to domains
+
+            // Ensure that the custom domain exists and belongs to this site
             if let Some(domain) = &preferred_domain {
-                // Ensure that the custom domain exists and belongs to this site
                 match DomainService::site_from_custom_domain_optional(ctx, domain).await?
                 {
                     Some(found_site) if found_site.site_id == site.site_id => (),

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -173,7 +173,7 @@ impl SiteService {
 
         if let Maybe::Set(preferred_domain) = input.preferred_domain {
             // Disallow preferred domains for the default site (www)
-            if site.slug == DEFAULT_SITE_SLUG {
+            if site.slug == DEFAULT_SITE_SLUG && preferred_domain.is_some() {
                 error!("Cannot set a preferred domain for the default site");
                 return Err(Error::BadRequest);
             }

--- a/deepwell/src/services/site/structs.rs
+++ b/deepwell/src/services/site/structs.rs
@@ -72,5 +72,7 @@ pub struct UpdateSiteBody {
     pub tagline: Maybe<String>,
     pub description: Maybe<String>,
     pub locale: Maybe<String>,
+    pub default_page: Maybe<String>,
+    pub preferred_domain: Maybe<Option<String>>,
     pub layout: Maybe<Option<Layout>>,
 }

--- a/install/dev/deepwell/Dockerfile
+++ b/install/dev/deepwell/Dockerfile
@@ -16,6 +16,9 @@ RUN mkdir /src
 COPY ./deepwell /src/deepwell
 WORKDIR /src/deepwell
 
+# Adjust seeder files for dev
+RUN patch /src/deepwell/seeder/sites.json /src/deepwell/seeder/sites.dev.patch
+
 # Cache rust dependencies
 RUN cargo vendor
 


### PR DESCRIPTION
This PR adds functionality to `SiteService` to enable updating a site's preferred domain, and then calls this in the seeder. Now, users can set `preferred-domain` in `sites.json` to configure this field. I also add a patch so that we can set the local preferred domain to be a `.localhost` site, whereas for dev it is a `.dev` site.

Running locally:
```
$ curl -Ik -H 'Host: scp-wiki.wikijump.localhost' https://localhost
HTTP/2 302 
alt-svc: h3=":443"; ma=2592000
location: https://scpwiki.localhost/
server: Caddy
date: Thu, 17 Apr 2025 08:54:29 GMT
```