### PR TITLE
[chore] Fix ending commas in macros

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -455,7 +455,7 @@ async fn restart_sequence_with(
     sequence_name: &'static str,
     new_start_value: i64,
 ) -> Result<()> {
-    debug!("Restarting sequence {sequence_name} to start with {new_start_value}",);
+    debug!("Restarting sequence {sequence_name} to start with {new_start_value}");
     assert!(
         new_start_value > 0,
         "New sequence start value {new_start_value} is not positive",

--- a/deepwell/src/endpoints/auth.rs
+++ b/deepwell/src/endpoints/auth.rs
@@ -181,7 +181,7 @@ pub async fn auth_mfa_verify(
         user_agent,
     } = params.parse()?;
 
-    info!("Verifying user's MFA for login (temporary session token {session_token})",);
+    info!("Verifying user's MFA for login (temporary session token {session_token})");
 
     let user = AuthenticationService::auth_mfa(
         ctx,

--- a/deepwell/src/endpoints/file_revision.rs
+++ b/deepwell/src/endpoints/file_revision.rs
@@ -35,7 +35,7 @@ pub async fn file_revision_count(
         file: file_reference,
     } = params.parse()?;
 
-    info!("Getting latest revision for file ID {page_id} in site ID {site_id}",);
+    info!("Getting latest revision for file ID {page_id} in site ID {site_id}");
 
     let file_id = FileService::get_id(ctx, site_id, file_reference).await?;
     let revision_count = FileRevisionService::count(ctx, page_id, file_id).await?;

--- a/deepwell/src/endpoints/link.rs
+++ b/deepwell/src/endpoints/link.rs
@@ -58,7 +58,7 @@ pub async fn page_links_to_missing_get(
     params: Params<'static>,
 ) -> Result<GetLinksToMissingOutput> {
     let GetLinksToMissing { site_id, page_slug } = params.parse()?;
-    info!("Getting missing page links from page slug {page_slug} in site ID {site_id}",);
+    info!("Getting missing page links from page slug {page_slug} in site ID {site_id}");
 
     LinkService::get_to_missing(ctx, site_id, &page_slug, None).await
 }
@@ -72,7 +72,7 @@ pub async fn page_links_external_from(
         page: reference,
     } = params.parse()?;
 
-    info!("Getting external links from page {reference:?} in site ID {site_id}",);
+    info!("Getting external links from page {reference:?} in site ID {site_id}");
 
     let page_id = PageService::get_id(ctx, site_id, reference).await?;
     LinkService::get_external_from(ctx, page_id).await

--- a/deepwell/src/endpoints/page_revision.rs
+++ b/deepwell/src/endpoints/page_revision.rs
@@ -37,7 +37,7 @@ pub async fn page_revision_count(
         page: reference,
     } = params.parse()?;
 
-    info!("Getting latest revision for page {reference:?} in site ID {site_id}",);
+    info!("Getting latest revision for page {reference:?} in site ID {site_id}");
 
     let page_id = PageService::get_id(ctx, site_id, reference).await?;
     let revision_count = PageRevisionService::count(ctx, site_id, page_id).await?;

--- a/deepwell/src/endpoints/user_bot.rs
+++ b/deepwell/src/endpoints/user_bot.rs
@@ -148,6 +148,6 @@ pub async fn bot_user_owner_remove(
     params: Params<'static>,
 ) -> Result<RemoveBotOwnerOutput> {
     let input: RemoveBotOwner = params.parse()?;
-    info!("Remove bot owner ({:?} <- {:?})", input.bot, input.human,);
+    info!("Remove bot owner ({:?} <- {:?})", input.bot, input.human);
     UserBotOwnerService::remove(ctx, input).await
 }

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -278,7 +278,7 @@ impl AliasService {
         alias_type: AliasType,
         slug: &str,
     ) -> Result<()> {
-        info!("Verifying target and alias table consistency for slug '{slug}'",);
+        info!("Verifying target and alias table consistency for slug '{slug}'");
 
         let txn = ctx.transaction();
         let alias_fut = Alias::find()

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -47,7 +47,7 @@ impl FilterService {
 
         // Ensure the regular expression is valid
         if let Err(error) = Regex::new(&regex) {
-            error!("Passed regular expression '{regex}' pattern is invalid: {error}",);
+            error!("Passed regular expression '{regex}' pattern is invalid: {error}");
             return Err(Error::FilterRegexInvalid(error));
         }
 
@@ -308,7 +308,7 @@ impl FilterService {
         }
 
         let regex_set = RegexSet::new(regexes).map_err(|error| {
-            error!("Invalid regular expression found in the database: {error}",);
+            error!("Invalid regular expression found in the database: {error}");
             Error::FilterRegexInvalid(error)
         })?;
 

--- a/deepwell/src/services/message/service.rs
+++ b/deepwell/src/services/message/service.rs
@@ -408,7 +408,7 @@ impl MessageService {
         user_id: i64,
         value: bool,
     ) -> Result<()> {
-        info!("Setting message read status for {record_id} / {user_id}: {value}",);
+        info!("Setting message read status for {record_id} / {user_id}: {value}");
 
         let txn = ctx.transaction();
         let message = Self::get_message(ctx, record_id, user_id).await?;
@@ -501,7 +501,7 @@ impl MessageService {
                 continue;
             }
 
-            debug!("Adding message recipient {recipient_type:?} with ID {user_id}",);
+            debug!("Adding message recipient {recipient_type:?} with ID {user_id}");
 
             let model = message_recipient::ActiveModel {
                 record_id: Set(str!(record_id)),
@@ -534,7 +534,7 @@ impl MessageService {
         let record = match Self::get_record_optional(ctx, record_id).await? {
             Some(record) => record,
             None => {
-                error!("The {purpose} message record does not exist: {record_id}",);
+                error!("The {purpose} message record does not exist: {record_id}");
 
                 return Err(Error::MessageNotFound);
             }
@@ -545,7 +545,7 @@ impl MessageService {
         if record.sender_id != user_id
             && Self::any_recipient_exists(ctx, record_id, user_id).await?
         {
-            error!("User ID {user_id} is not a sender or recipient of the {purpose}",);
+            error!("User ID {user_id} is not a sender or recipient of the {purpose}");
 
             // To protect privacy, if the user doesn't have access to a message with a
             // given ID, we pretend it does not exist for the purposes of returning errors.
@@ -561,7 +561,7 @@ impl MessageService {
         record_id: &str,
         user_id: i64,
     ) -> Result<bool> {
-        info!("Checking if user ID {user_id} is a recipient of record ID {record_id}",);
+        info!("Checking if user ID {user_id} is a recipient of record ID {record_id}");
 
         let txn = ctx.transaction();
         let model = MessageRecipient::find()

--- a/deepwell/src/services/mfa/service.rs
+++ b/deepwell/src/services/mfa/service.rs
@@ -175,7 +175,7 @@ impl MfaService {
         let recovery_code_hashes = match &user.multi_factor_recovery_codes {
             Some(codes) => codes,
             None => {
-                warn!("User has no MFA recovery codes, but wants to verify recovery",);
+                warn!("User has no MFA recovery codes, but wants to verify recovery");
 
                 return Err(Error::InvalidAuthentication);
             }

--- a/deepwell/src/services/page_query/service.rs
+++ b/deepwell/src/services/page_query/service.rs
@@ -222,7 +222,7 @@ impl PageQueryService {
             // Pages which are not siblings of the current page,
             // i.e., they do not share any parents with the current page.
             PageParentSelector::DifferentParents => {
-                debug!("Selecting pages which are not siblings under the given parents",);
+                debug!("Selecting pages which are not siblings under the given parents");
 
                 let parents = ParentService::get_parents(
                     ctx,
@@ -246,7 +246,7 @@ impl PageQueryService {
 
             // Pages which are children of the current page.
             PageParentSelector::ChildOf => {
-                debug!("Selecting pages which are children of the current page",);
+                debug!("Selecting pages which are children of the current page");
 
                 page::Column::PageId.in_subquery(
                     Query::select()
@@ -261,7 +261,7 @@ impl PageQueryService {
             // TODO: Possibly allow either *any* or *all* of specified parents
             //       rather than only any, in the future.
             PageParentSelector::HasParents(parents) => {
-                debug!("Selecting on pages which have one of the given as parents",);
+                debug!("Selecting on pages which have one of the given as parents");
 
                 let parent_ids = PageService::get_pages(ctx, queried_site_id, parents)
                     .await?
@@ -352,7 +352,7 @@ impl PageQueryService {
                 OrderProperty::PageSlug => {
                     // idk how to do this, we need to strip off the category part somehow
                     // PgExpr::matches?
-                    error!("Ordering by page slug (no category), not yet implemented",);
+                    error!("Ordering by page slug (no category), not yet implemented");
                     todo!() // TODO
                 }
                 OrderProperty::FullSlug => {

--- a/deepwell/src/services/password.rs
+++ b/deepwell/src/services/password.rs
@@ -88,7 +88,7 @@ impl PasswordService {
 
                     // Some kind of server error
                     _ => {
-                        error!("Unexpected error while verifying password: {error}",);
+                        error!("Unexpected error while verifying password: {error}");
                     }
                 }
 

--- a/deepwell/src/services/relation/mod.rs
+++ b/deepwell/src/services/relation/mod.rs
@@ -83,7 +83,7 @@ impl RelationService {
         created_by: i64,
         metadata: &M,
     ) -> Result<RelationModel> {
-        debug!("Create relation for {dest:?} ← {relation_type:?} ← {from:?}",);
+        debug!("Create relation for {dest:?} ← {relation_type:?} ← {from:?}");
 
         // Get previous relation, if present
         let txn = ctx.transaction();
@@ -234,7 +234,7 @@ impl RelationService {
         object: RelationObject,
         direction: RelationDirection,
     ) -> Result<Vec<RelationModel>> {
-        info!("Getting {direction:?} relations for {object:?} / {relation_type:?}",);
+        info!("Getting {direction:?} relations for {object:?} / {relation_type:?}");
 
         let (object_type, object_id) = object.into();
         let (object_type_column, object_id_column) = match direction {

--- a/deepwell/src/services/relation/site_user.rs
+++ b/deepwell/src/services/relation/site_user.rs
@@ -31,7 +31,7 @@ use super::prelude::*;
 use crate::models::sea_orm_active_enums::UserType;
 use crate::services::UserService;
 
-impl_relation!(SiteUser, Site, site_id, User, user_id, (), NO_CREATE_IMPL,);
+impl_relation!(SiteUser, Site, site_id, User, user_id, (), NO_CREATE_IMPL);
 
 impl RelationService {
     pub async fn create_site_user(

--- a/deepwell/src/services/session/service.rs
+++ b/deepwell/src/services/session/service.rs
@@ -54,7 +54,7 @@ impl SessionService {
             restricted,
         }: CreateSession,
     ) -> Result<String> {
-        info!("Creating new session for user ID {user_id} (restricted: {restricted})",);
+        info!("Creating new session for user ID {user_id} (restricted: {restricted})");
 
         let txn = ctx.transaction();
         let config = ctx.config();
@@ -281,7 +281,7 @@ impl SessionService {
             .exec(txn)
             .await?;
 
-        debug!("User ID {user_id}: {rows_affected} other sessions were invalidated",);
+        debug!("User ID {user_id}: {rows_affected} other sessions were invalidated");
         Ok(rows_affected)
     }
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -184,7 +184,7 @@ impl UserService {
                 }
 
                 EmailClassification::Alias => {
-                    info!("User {slug}'s email was verified successfully (as an alias)",);
+                    info!("User {slug}'s email was verified successfully (as an alias)");
                     Some(true)
                 }
 

--- a/deepwell/src/services/view/options.rs
+++ b/deepwell/src/services/view/options.rs
@@ -138,7 +138,7 @@ impl PageOptions {
         // Now go through anything remaining and emitting warnings for them
 
         for (key, (value, raw)) in arguments {
-            warn!("Unused argument in page path: {key} -> {value:?} ('{raw}')",);
+            warn!("Unused argument in page path: {key} -> {value:?} ('{raw}')");
         }
 
         options

--- a/deepwell/src/watch.rs
+++ b/deepwell/src/watch.rs
@@ -67,7 +67,7 @@ pub fn setup_autorestart(config: &Config) -> Result<RecommendedWatcher> {
                 error!("Unable to receive filesystem events: {error}");
             }
             Ok(event) => {
-                debug!("Received filesystem event ({} paths)", event.paths.len(),);
+                debug!("Received filesystem event ({} paths)", event.paths.len());
 
                 if event_is_applicable(&watched_paths, event) {
                     restart_self();
@@ -117,7 +117,7 @@ fn path_is_applicable(watched_paths: &WatchedPaths, path: &Path) -> bool {
     let path = match fs::canonicalize(path) {
         Ok(path) => path,
         Err(error) => {
-            error!("Error finding canonical path for event processing: {error}",);
+            error!("Error finding canonical path for event processing: {error}");
             return false;
         }
     };


### PR DESCRIPTION
`rustfmt` by its nature does not attempt to significantly format macros (since it doesn't know if certain pieces of punctuation are meaningful), so we need to remove the trailing commas here where they're inappropriate.