### PR TITLE
Update mininum name length: add separate check for chars

### DIFF
--- a/deepwell/config.example.toml
+++ b/deepwell/config.example.toml
@@ -337,17 +337,18 @@ default-name-changes = 2
 # a user will top out at this amount.
 maximum-name-changes = 3
 
-# The minimum length for a user's name in bytes.
+# The minimum length for a user's name in bytes and codepoints.
 # A user who attempts to register must have a slug which is at least this long.
 #
 # The intent is to prevent the proliferation of very short, unidentifiable usernames
-# such as single Latin letters (e.g. "N"). However, we check *bytes* specifically to
-# avoid Anglo-centricism, as many full names in other languages fit within two letters
-# (consider CJK for instance). Single characters outside of the main ASCII block
-# usually take up two or three bytes themselves, making it a non-issue for those languages.
+# such as single Latin letters (e.g. "N"). However, we want to avoid Anglo-centrism,
+# as full names in non-English languages can fit within two letters. So we have
+# one requirement which excludes short ASCII usernames but permits a more reasonable
+# restriction for say CJK languages.
 #
 # See WJ-1122.
-minimum-name-bytes = 3
+minimum-name-bytes = 4
+minimum-name-chars = 2
 
 # Every this many days, all users get another name change token (up to the cap).
 # See the "job" section above to configure how often this is checked.

--- a/deepwell/src/config/file.rs
+++ b/deepwell/src/config/file.rs
@@ -180,6 +180,7 @@ struct User {
     maximum_name_changes: u8,
     refill_name_change_days: u64,
     minimum_name_bytes: usize,
+    minimum_name_chars: usize,
 }
 
 // NOTE: Name conflict with std::fs::File
@@ -313,6 +314,7 @@ impl ConfigFile {
                     maximum_name_changes,
                     refill_name_change_days,
                     minimum_name_bytes,
+                    minimum_name_chars,
                 },
             file:
                 FileSection {
@@ -442,6 +444,7 @@ impl ConfigFile {
                 ))
             },
             minimum_name_bytes,
+            minimum_name_chars,
             presigned_path_length,
             presigned_expiry_secs: presigned_expiration_minutes * 60,
             maximum_blob_size: maximum_blob_size_kb * 1024,

--- a/deepwell/src/config/object.rs
+++ b/deepwell/src/config/object.rs
@@ -198,6 +198,9 @@ pub struct Config {
     /// Minimum length of bytes in a username.
     pub minimum_name_bytes: usize,
 
+    /// Minimum length of chars in a username.
+    pub minimum_name_chars: usize,
+
     /// Length of randomly-generated portion of S3 presigned URLs.
     pub presigned_path_length: usize,
 

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -126,7 +126,7 @@ impl AliasService {
                     error!(
                         "User's name is not long enough ({} < {} chars)",
                         slug.len(),
-                        ctx.config().minimum_name_bytes,
+                        ctx.config().minimum_name_chars,
                     );
                     return Err(Error::UserNameTooShort);
                 }

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -85,7 +85,6 @@ impl AliasService {
                     error!(
                         "No target site with ID {target_id} exists, cannot create alias",
                     );
-
                     return Err(Error::SiteNotFound);
                 }
 
@@ -94,7 +93,6 @@ impl AliasService {
                     error!(
                         "Site with conflicting slug '{slug}' already exists, cannot create alias",
                     );
-
                     return Err(Error::SiteExists);
                 }
             }
@@ -103,7 +101,6 @@ impl AliasService {
                     error!(
                         "No target user with ID {target_id} exists, cannot create alias",
                     );
-
                     return Err(Error::UserNotFound);
                 }
 

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -124,7 +124,7 @@ impl AliasService {
 
                 if slug.chars().count() < config.minimum_name_chars {
                     error!(
-                        "User's name is not long enough ({} < {} bytes)",
+                        "User's name is not long enough ({} < {} chars)",
                         slug.len(),
                         ctx.config().minimum_name_bytes,
                     );

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -78,7 +78,7 @@ impl AliasService {
         // it actually finds conflicts properly.
         //
         // If the alias is for a user, also ensures that it is at least
-        // the minimum name length in bytes.
+        // the minimum name length in bytes and chars.
         match alias_type {
             AliasType::Site => {
                 if !SiteService::exists(ctx, Reference::Id(target_id)).await? {
@@ -109,17 +109,25 @@ impl AliasService {
                     error!(
                         "User with conflicting slug '{slug}' already exists, cannot create alias",
                     );
-
                     return Err(Error::UserExists);
                 }
 
-                if slug.len() < ctx.config().minimum_name_bytes {
+                let config = ctx.config();
+                if slug.len() < config.minimum_name_bytes {
                     error!(
-                        "User's name is not long enough ({} < {})",
+                        "User's name is not long enough ({} < {} bytes)",
                         slug.len(),
                         ctx.config().minimum_name_bytes,
                     );
+                    return Err(Error::UserNameTooShort);
+                }
 
+                if slug.chars().count() < config.minimum_name_chars {
+                    error!(
+                        "User's name is not long enough ({} < {} bytes)",
+                        slug.len(),
+                        ctx.config().minimum_name_bytes,
+                    );
                     return Err(Error::UserNameTooShort);
                 }
             }

--- a/deepwell/src/services/caddy/test.rs
+++ b/deepwell/src/services/caddy/test.rs
@@ -87,6 +87,7 @@ fn build_config(main_domain: &str, files_domain: &str) -> Config {
         maximum_name_changes: 0,
         refill_name_change: None,
         minimum_name_bytes: 0,
+        minimum_name_chars: 0,
         presigned_path_length: 0,
         presigned_expiry_secs: 0,
         maximum_blob_size: 0,

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -65,14 +65,23 @@ impl UserService {
             return Err(Error::UserSlugEmpty);
         }
 
-        // Check if username contains the minimum amount of required bytes.
-        if name.len() < ctx.config().minimum_name_bytes {
+        // Check if username contains the minimum amount of required bytes and chars.
+        let config = ctx.config();
+        if name.len() < config.minimum_name_bytes {
             error!(
                 "User's name is not long enough ({} < {})",
                 slug.len(),
                 ctx.config().minimum_name_bytes,
             );
+            return Err(Error::UserNameTooShort);
+        }
 
+        if name.chars().count() < config.minimum_name_chars {
+            error!(
+                "User's name is not long enough ({} < {} bytes)",
+                slug.len(),
+                ctx.config().minimum_name_bytes,
+            );
             return Err(Error::UserNameTooShort);
         }
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -69,7 +69,7 @@ impl UserService {
         let config = ctx.config();
         if name.len() < config.minimum_name_bytes {
             error!(
-                "User's name is not long enough ({} < {})",
+                "User's name is not long enough ({} < {} bytes)",
                 slug.len(),
                 ctx.config().minimum_name_bytes,
             );
@@ -78,7 +78,7 @@ impl UserService {
 
         if name.chars().count() < config.minimum_name_chars {
             error!(
-                "User's name is not long enough ({} < {} bytes)",
+                "User's name is not long enough ({} < {} chars)",
                 slug.len(),
                 ctx.config().minimum_name_bytes,
             );

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -80,7 +80,7 @@ impl UserService {
             error!(
                 "User's name is not long enough ({} < {} chars)",
                 slug.len(),
-                ctx.config().minimum_name_bytes,
+                ctx.config().minimum_name_chars,
             );
             return Err(Error::UserNameTooShort);
         }

--- a/install/dev/deepwell/deepwell.toml
+++ b/install/dev/deepwell/deepwell.toml
@@ -64,7 +64,8 @@ banned = "_ban"
 [user]
 default-name-changes = 2
 maximum-name-changes = 3
-minimum-name-bytes = 3
+minimum-name-bytes = 4
+minimum-name-chars = 2
 refill-name-change-days = 90
 
 [file]

--- a/install/local/deepwell/deepwell.toml
+++ b/install/local/deepwell/deepwell.toml
@@ -64,7 +64,8 @@ banned = "_ban"
 [user]
 default-name-changes = 2
 maximum-name-changes = 3
-minimum-name-bytes = 3
+minimum-name-bytes = 4
+minimum-name-chars = 2
 refill-name-change-days = 90
 
 [file]

--- a/install/prod/deepwell/deepwell.toml
+++ b/install/prod/deepwell/deepwell.toml
@@ -64,7 +64,8 @@ banned = "_ban"
 [user]
 default-name-changes = 2
 maximum-name-changes = 3
-minimum-name-bytes = 3
+minimum-name-bytes = 4
+minimum-name-chars = 2
 refill-name-change-days = 90
 
 [file]


### PR DESCRIPTION
This adds a separate check for chars (codepoints) in addition to the one for bytes. This way, you can set a byte requirement that restricts short ASCII names but are more permissive for other scripts, like names using CJK characters.

https://scuttle.atlassian.net/browse/WJ-1122