### PR TITLE
Fix seeder

### DIFF
--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -35,7 +35,6 @@
         "biography": "Wikijump system user",
         "user_page": "https://wikijump.org/",
         "aliases": [
-            "sys",
             "auto",
             "automatic",
             "wikidot",

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -182,6 +182,13 @@ pub async fn seed(state: &ServerState) -> Result<()> {
             .await?;
         }
 
+        if let Some(preferred_domain) = &site.preferred_domain {
+            assert!(
+                site.domains.contains(preferred_domain),
+                "The site's preferred domain must be a listed custom domain",
+            );
+        }
+
         for domain in site.domains {
             info!("Creating site domain '{domain}'");
 

--- a/deepwell/src/models/site.rs
+++ b/deepwell/src/models/site.rs
@@ -51,6 +51,8 @@ pub enum Relation {
     PageConnectionMissing,
     #[sea_orm(has_many = "super::page_revision::Entity")]
     PageRevision,
+    #[sea_orm(has_many = "super::site_domain::Entity")]
+    SiteDomain,
     #[sea_orm(
         belongs_to = "super::site_domain::Entity",
         from = "Column::PreferredDomain",
@@ -58,7 +60,7 @@ pub enum Relation {
         on_update = "NoAction",
         on_delete = "NoAction"
     )]
-    SiteDomain,
+    SiteDomainPreferredDomain,
 }
 
 impl Related<super::file::Entity> for Entity {


### PR DESCRIPTION
There were a couple bugs introduced with recent changes:
* The Sea-ORM `site_domain` relation bug was reintroduced, since that manual change to the entity file was reset.
* I removed a user alias which is now too short by our rules.
* I added a check to ensure that the preferred domain for a site is actually one of the site's custom domains.