### PR TITLE
Use valkey image instead of redis

### DIFF
--- a/.github/workflows/docker-build-valkey.local.yaml
+++ b/.github/workflows/docker-build-valkey.local.yaml
@@ -1,10 +1,10 @@
-name: '[backend] Docker build Redis (local)'
+name: '[backend] Docker build Valkey (local)'
 
 on:
   pull_request:
     paths:
-      - 'install/local/redis/*'
-      - '.github/workflows/docker-build-redis.local.yaml'
+      - 'install/local/valkey/*'
+      - '.github/workflows/docker-build-valkey.local.yaml'
 
 jobs:
   build:
@@ -14,6 +14,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: cd install/local/redis && docker build .
+        run: cd install/local/valkey && docker build .
         env:
           DOCKER_BUILDKIT: 1

--- a/install/dev/redis/Dockerfile
+++ b/install/dev/redis/Dockerfile
@@ -1,5 +1,0 @@
-FROM redis:alpine
-
-EXPOSE 6379
-COPY ./redis.conf /usr/local/etc/redis.conf
-CMD ["redis-server", "/usr/local/etc/redis.conf"]

--- a/install/dev/valkey/Dockerfile
+++ b/install/dev/valkey/Dockerfile
@@ -1,0 +1,5 @@
+FROM valkey/valkey:alpine
+
+EXPOSE 6379
+COPY ./valkey.conf /usr/local/etc/valkey.conf
+CMD ["valkey-server", "/usr/local/etc/valkey.conf"]

--- a/install/dev/valkey/valkey.conf
+++ b/install/dev/valkey/valkey.conf
@@ -11,8 +11,6 @@ daemonize no
 loglevel notice
 logfile ""
 
-# see https://redis.io/docs/management/persistence/ for snapshotting vs WAL
-
 # daily backups
 # or hourly if >1 million changes
 save 86400 1 3600 1000000

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -37,11 +37,11 @@ services:
       - "9001:9001"
 
   cache:
-    build: redis
+    build: valkey
     restart: always
     # You can add a volume for /data if you wish
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/install/local/redis/Dockerfile
+++ b/install/local/redis/Dockerfile
@@ -1,5 +1,0 @@
-FROM redis:alpine
-
-EXPOSE 6379
-COPY ./redis.conf /usr/local/etc/redis.conf
-CMD ["redis-server", "/usr/local/etc/redis.conf"]

--- a/install/local/valkey/Dockerfile
+++ b/install/local/valkey/Dockerfile
@@ -1,0 +1,5 @@
+FROM valkey/valkey:alpine
+
+EXPOSE 6379
+COPY ./valkey.conf /usr/local/etc/valkey.conf
+CMD ["valkey-server", "/usr/local/etc/valkey.conf"]

--- a/install/local/valkey/valkey.conf
+++ b/install/local/valkey/valkey.conf
@@ -11,8 +11,6 @@ daemonize no
 loglevel notice
 logfile ""
 
-# see https://redis.io/docs/management/persistence/ for snapshotting vs WAL
-
 # daily backups
 # or hourly if >1 million changes
 save 86400 1 3600 1000000


### PR DESCRIPTION
Since March of 2024, Redis has been using a non-open source license. As a result, the project was forked into Valkey, and people have been slowly migrating to it. This PR implements that change for Wikijump, replacing Redis with Valkey.

Note that the name "redis" is still used in some places. We use the Rust crate `redis`, which of course Valkey is cross-compatible with, and we use `REDIS_URL` as the name of the cache instance variable for the same reason.