### PR TITLE
Fix incorrect page view enum cases

### DIFF
--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -26,6 +26,9 @@ use crate::models::session::Model as SessionModel;
 use crate::models::site::Model as SiteModel;
 use crate::models::user::Model as UserModel;
 
+// NOTE: Any changes to the output structures here, including the variant names,
+//       MUST be reflected in framerail!
+
 // TODO replace with actual user permissions type
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub struct UserPermissions;
@@ -51,8 +54,7 @@ pub struct PageRoute {
     pub extra: String,
 }
 
-// NOTE: Any changes to the structure here, including the variant names,
-//       MUST be reflected in framerail! See src/lib/server/load/page.ts
+// See also framerail src/lib/server/load/page.ts and src/routes/+error.svelte
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum GetPageViewOutput {
@@ -94,6 +96,7 @@ pub struct GetUserView<'a> {
     pub locales: Vec<String>,
 }
 
+// See also framerail src/lib/server/load/admin.ts and src/routes/[x+2d]/admin/+error.svelte
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum GetUserViewOutput {
@@ -116,6 +119,7 @@ pub struct GetAdminView {
     pub locales: Vec<String>,
 }
 
+// See also framerail src/lib/server/load/admin.ts and src/routes/[x+2d]/user/+error.svelte
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum GetAdminViewOutput {

--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -51,6 +51,8 @@ pub struct PageRoute {
     pub extra: String,
 }
 
+// NOTE: Any changes to the structure here, including the variant names,
+//       MUST be reflected in framerail! See src/lib/server/load/page.ts
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
 pub enum GetPageViewOutput {

--- a/framerail/src/lib/server/load/admin.ts
+++ b/framerail/src/lib/server/load/admin.ts
@@ -32,6 +32,11 @@ export async function loadAdminPage(request, cookies) {
       break
     case "site_missing":
       errorStatus = 404
+      break
+    default:
+      // Unexpected response type!
+      // There is an inconsistency between here / DEEPWELL
+      errorStatus = 500
   }
 
   if (errorStatus !== null) {

--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -45,19 +45,15 @@ export async function loadPage(
   let errorStatus = null
 
   switch (response.type) {
-    case "page_found":
+    case "found":
       break
-    case "page_missing":
+    case "missing":
       viewData.page = null
       viewData.page_revision = null
       errorStatus = 404
       break
-    case "page_permissions":
+    case "permissions":
       errorStatus = 403
-      break
-    case "site_missing":
-      checkRedirect = false
-      errorStatus = 404
   }
 
   let translateKeys: TranslateKeys = {

--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -54,6 +54,11 @@ export async function loadPage(
       break
     case "permissions":
       errorStatus = 403
+      break
+    default:
+      // Unexpected response type!
+      // There is an inconsistency between here / DEEPWELL
+      errorStatus = 500
   }
 
   let translateKeys: TranslateKeys = {

--- a/framerail/src/lib/server/load/user.ts
+++ b/framerail/src/lib/server/load/user.ts
@@ -33,6 +33,11 @@ export async function loadUser(username?: string, request, cookies) {
       break
     case "site_missing":
       errorStatus = 404
+      break
+    default:
+      // Unexpected response type!
+      // There is an inconsistency between here / DEEPWELL
+      errorStatus = 500
   }
 
   if (errorStatus === null && username && viewData.user.slug !== username) {

--- a/framerail/src/routes/+error.svelte
+++ b/framerail/src/routes/+error.svelte
@@ -221,7 +221,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:No such site
   {@html $page.error.html}
 {:else}
-  UNTRANSLATED:Fallback error, something really went wrong
+  UNTRANSLATED:Fallback error, invalid view type from backend
 {/if}
 
 <style global lang="scss">

--- a/framerail/src/routes/+error.svelte
+++ b/framerail/src/routes/+error.svelte
@@ -218,7 +218,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:Lacks permissions for page
   {@html $page.error.compiled_html}
 {:else}
-  UNTRANSLATED:Fallback error, invalid view type from backend
+  UNTRANSLATED:Fatal error: Unable to display view
 {/if}
 
 <style global lang="scss">

--- a/framerail/src/routes/+error.svelte
+++ b/framerail/src/routes/+error.svelte
@@ -84,7 +84,7 @@
 Use svelte-switch-case package with {#switch data.view}
 as soon as we can figure out prettier support for it.
 -->
-{#if $page.error.view === "page_missing"}
+{#if $page.error.view === "missing"}
   UNTRANSLATED:Page not found
 
   {#if $page.error.options?.edit}
@@ -214,12 +214,9 @@ as soon as we can figure out prettier support for it.
       </form>
     {/if}
   {/if}
-{:else if $page.error.view === "page_permissions"}
+{:else if $page.error.view === "permissions"}
   UNTRANSLATED:Lacks permissions for page
   {@html $page.error.compiled_html}
-{:else if $page.error.view === "site_missing"}
-  UNTRANSLATED:No such site
-  {@html $page.error.html}
 {:else}
   UNTRANSLATED:Fallback error, invalid view type from backend
 {/if}

--- a/framerail/src/routes/[x+2d]/admin/+error.svelte
+++ b/framerail/src/routes/[x+2d]/admin/+error.svelte
@@ -17,7 +17,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:No such site
   {@html $page.error.html}
 {:else}
-  UNTRANSLATED:Fallback error, invalid view type from backend
+  UNTRANSLATED:Fatal error: Unable to display view
 {/if}
 
 <style global lang="scss">

--- a/framerail/src/routes/[x+2d]/admin/+error.svelte
+++ b/framerail/src/routes/[x+2d]/admin/+error.svelte
@@ -17,7 +17,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:No such site
   {@html $page.error.html}
 {:else}
-  UNTRANSLATED:Fallback error, something really went wrong
+  UNTRANSLATED:Fallback error, invalid view type from backend
 {/if}
 
 <style global lang="scss">

--- a/framerail/src/routes/[x+2d]/user/+error.svelte
+++ b/framerail/src/routes/[x+2d]/user/+error.svelte
@@ -17,7 +17,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:No such site
   {@html $page.error.html}
 {:else}
-  UNTRANSLATED:Fallback error, invalid view type from backend
+  UNTRANSLATED:Fatal error: Unable to display view
 {/if}
 
 <style global lang="scss">

--- a/framerail/src/routes/[x+2d]/user/+error.svelte
+++ b/framerail/src/routes/[x+2d]/user/+error.svelte
@@ -17,7 +17,7 @@ as soon as we can figure out prettier support for it.
   UNTRANSLATED:No such site
   {@html $page.error.html}
 {:else}
-  UNTRANSLATED:Fallback error, something really went wrong
+  UNTRANSLATED:Fallback error, invalid view type from backend
 {/if}
 
 <style global lang="scss">


### PR DESCRIPTION
As described in the first commit, this broke when the enum variant names in deepwell were modified but the corresponding code in framerail was not. This PR fixes that and adds an error case for if none of the variants match.