### PR TITLE
Disable Caddy debug mode

### DIFF
--- a/install/dev/caddy/request.json
+++ b/install/dev/caddy/request.json
@@ -3,7 +3,7 @@
 	"method": "caddyfile",
 	"id": 0,
 	"params": {
-		"debug": true,
+		"debug": false,
 		"local": false,
 		"framerail_host": "framerail:3000",
 		"wws_host": "wws:7000"

--- a/install/local/caddy/request.json
+++ b/install/local/caddy/request.json
@@ -3,7 +3,7 @@
 	"method": "caddyfile",
 	"id": 0,
 	"params": {
-		"debug": true,
+		"debug": false,
 		"local": true,
 		"framerail_host": "framerail:3000",
 		"wws_host": "wws:7000"

--- a/install/prod/caddy/request.json
+++ b/install/prod/caddy/request.json
@@ -3,7 +3,7 @@
 	"method": "caddyfile",
 	"id": 0,
 	"params": {
-		"debug": true,
+		"debug": false,
 		"local": false,
 		"framerail_host": "framerail:3000",
 		"wws_host": "wws:7000"


### PR DESCRIPTION
It's rather noisy, giving a lot of specifics on connection and TLS details, which isn't useful in debugging issues experienced locally.