### PR TITLE
Always add newline to end of text blocks

### DIFF
--- a/wws/src/handler/text_block.rs
+++ b/wws/src/handler/text_block.rs
@@ -199,7 +199,14 @@ async fn handle_text_block(
     };
 
     let Headers { content_type, etag } = get_headers(s3_response.headers());
-    let body = Body::from(s3_response.to_vec());
+    let body = Body::from({
+        // Ensure text blocks always end in a newline.
+        // This doesn't make the additional conditional to
+        // avoid confusing behavior.
+        let mut bytes = s3_response.to_vec();
+        bytes.push(b'\n');
+        bytes
+    });
     let result = Response::builder()
         .header(header::CONTENT_TYPE, &content_type)
         .header(header::ETAG, &etag)


### PR DESCRIPTION
Text blocks are written out using syntax like:
```
[[code]]
thing here
foo
bar
[[/code]]
```
They do "end" in a newline already, and given the annoyance in having to add an extra blank line at the end to avoid issues with final newline-sensitive uses, here we can just add the newline ourselves, consistently.