### PR TITLE
Remove "licensing" column

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -39,7 +39,6 @@ use anyhow::Result;
 use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseTransaction, Statement, TransactionTrait,
 };
-use serde_json::Value as JsonValue;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
@@ -311,7 +310,6 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                             direct_upload: Some(data),
                             revision_comments: str!(),
                             user_id: SYSTEM_USER_ID,
-                            licensing: JsonValue::Null,
                             bypass_filter: true,
                         },
                     )
@@ -335,7 +333,6 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                                 bypass_filter: true,
                                 body: EditFileBody {
                                     name: Maybe::Unset,
-                                    licensing: Maybe::Unset,
                                     uploaded_blob_id: Maybe::Set(str!()),
                                     direct_upload: Maybe::Set(data),
                                 },

--- a/deepwell/src/endpoints/file.rs
+++ b/deepwell/src/endpoints/file.rs
@@ -166,7 +166,6 @@ async fn build_file_response(
         mime: revision.mime,
         size: revision.size,
         s3_hash: Bytes::from(revision.s3_hash),
-        licensing: revision.licensing,
         revision_comments: revision.comments,
         hidden_fields: revision.hidden,
     })

--- a/deepwell/src/endpoints/page.rs
+++ b/deepwell/src/endpoints/page.rs
@@ -346,7 +346,6 @@ async fn build_page_file_output(
         mime: revision.mime,
         size: revision.size,
         s3_hash: Bytes::from(revision.s3_hash),
-        licensing: revision.licensing,
         revision_comments: revision.comments,
         hidden_fields: revision.hidden,
     }))

--- a/deepwell/src/models/file_revision.rs
+++ b/deepwell/src/models/file_revision.rs
@@ -24,7 +24,6 @@ pub struct Model {
     #[sea_orm(column_type = "Text")]
     pub mime: String,
     pub size: i64,
-    pub licensing: Json,
     pub changes: Vec<String>,
     #[sea_orm(column_type = "Text")]
     pub comments: String,

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -64,7 +64,6 @@ impl FileService {
             direct_upload,
             revision_comments,
             user_id,
-            licensing,
             bypass_filter,
         }: CreateFile,
     ) -> Result<CreateFileOutput> {
@@ -123,7 +122,6 @@ impl FileService {
                 size,
                 mime,
                 blob_created,
-                licensing,
                 revision_comments,
             },
         )
@@ -154,7 +152,6 @@ impl FileService {
 
         let EditFileBody {
             mut name,
-            licensing,
             uploaded_blob_id,
             direct_upload,
         } = body;
@@ -229,7 +226,6 @@ impl FileService {
                 revision_type: FileRevisionType::Regular,
                 body: CreateFileRevisionBody {
                     name,
-                    licensing,
                     blob,
                     ..Default::default()
                 },
@@ -527,7 +523,6 @@ impl FileService {
             s3_hash,
             mime,
             size,
-            licensing,
             ..
         } = target_revision;
 
@@ -565,7 +560,6 @@ impl FileService {
             body: CreateFileRevisionBody {
                 name: Maybe::Set(name),
                 blob: Maybe::Set(blob),
-                licensing: Maybe::Set(licensing),
                 page_id: Maybe::Unset, // rollbacks should never move files
             },
         };

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -34,7 +34,6 @@ pub struct CreateFile {
     pub uploaded_blob_id: String,
     pub revision_comments: String,
     pub user_id: i64,
-    pub licensing: JsonValue, // TODO
 
     #[serde(default)]
     pub bypass_filter: bool,
@@ -90,7 +89,6 @@ pub struct GetFileOutput {
     pub mime: String,
     pub size: i64,
     pub s3_hash: Bytes<'static>,
-    pub licensing: JsonValue,
     pub revision_comments: String,
     pub hidden_fields: Vec<String>,
 }
@@ -122,7 +120,6 @@ pub struct EditFile {
 #[serde(default)]
 pub struct EditFileBody {
     pub name: Maybe<String>,
-    pub licensing: Maybe<serde_json::Value>,
     pub uploaded_blob_id: Maybe<String>,
 
     /// Allows internal users to upload directly.

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -35,15 +35,8 @@ use std::num::NonZeroI32;
 /// The first revision is always considered to have changed everything.
 ///
 /// See `services/page_revision/service.rs`.
-static ALL_CHANGES: Lazy<Vec<String>> = Lazy::new(|| {
-    vec![
-        str!("page"),
-        str!("name"),
-        str!("blob"),
-        str!("mime"),
-        str!("licensing"),
-    ]
-});
+static ALL_CHANGES: Lazy<Vec<String>> =
+    Lazy::new(|| vec![str!("page"), str!("name"), str!("blob"), str!("mime")]);
 
 #[derive(Debug)]
 pub struct FileRevisionService;
@@ -91,7 +84,6 @@ impl FileRevisionService {
             mut s3_hash,
             mut mime,
             mut size,
-            mut licensing,
             ..
         } = previous;
 
@@ -127,13 +119,6 @@ impl FileRevisionService {
             }
         }
 
-        if let Maybe::Set(new_licensing) = body.licensing {
-            if licensing != new_licensing {
-                changes.push(str!("licensing"));
-                licensing = new_licensing;
-            }
-        }
-
         // If nothing has changed, then don't create a new revision
         // Also don't rerender the page, this isn't an edit.
         if changes.is_empty() {
@@ -148,8 +133,6 @@ impl FileRevisionService {
             error!("MIME type is empty");
             return Err(Error::FileMimeEmpty);
         }
-
-        // TODO validate licensing field
 
         // Run outdater
         let page_slug = Self::get_page_slug(ctx, site_id, page_id).await?;
@@ -167,7 +150,6 @@ impl FileRevisionService {
             s3_hash: Set(s3_hash.to_vec()),
             size: Set(size),
             mime: Set(mime),
-            licensing: Set(licensing),
             changes: Set(changes),
             comments: Set(revision_comments),
             hidden: Set(vec![]),
@@ -197,7 +179,6 @@ impl FileRevisionService {
             size,
             mime,
             blob_created,
-            licensing,
             revision_comments,
         }: CreateFirstFileRevision,
     ) -> Result<CreateFirstFileRevisionOutput> {
@@ -220,7 +201,6 @@ impl FileRevisionService {
             s3_hash: Set(s3_hash.to_vec()),
             mime: Set(mime),
             size: Set(size),
-            licensing: Set(licensing),
             changes: Set(ALL_CHANGES.clone()),
             comments: Set(revision_comments),
             hidden: Set(vec![]),
@@ -265,7 +245,6 @@ impl FileRevisionService {
             mut s3_hash,
             mime,
             size,
-            licensing,
             ..
         } = previous;
 
@@ -293,7 +272,6 @@ impl FileRevisionService {
             s3_hash: Set(s3_hash),
             mime: Set(mime),
             size: Set(size),
-            licensing: Set(licensing),
             changes: Set(vec![]),
             comments: Set(revision_comments),
             hidden: Set(hidden),
@@ -346,7 +324,6 @@ impl FileRevisionService {
             s3_hash,
             mime,
             size,
-            licensing,
             ..
         } = previous;
 
@@ -381,7 +358,6 @@ impl FileRevisionService {
             s3_hash: Set(s3_hash),
             mime: Set(mime),
             size: Set(size),
-            licensing: Set(licensing),
             changes: Set(changes),
             comments: Set(revision_comments),
             hidden: Set(vec![]),

--- a/deepwell/src/services/file_revision/structs.rs
+++ b/deepwell/src/services/file_revision/structs.rs
@@ -39,7 +39,6 @@ pub struct CreateFileRevisionBody {
     pub page_id: Maybe<i64>, // for changing the page this file is on
     pub name: Maybe<String>,
     pub blob: Maybe<FileBlob>,
-    pub licensing: Maybe<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,7 +69,6 @@ pub struct CreateFirstFileRevision {
     pub size: i64,
     pub mime: String,
     pub blob_created: bool,
-    pub licensing: serde_json::Value,
     pub revision_comments: String,
 }
 

--- a/framerail/src/lib/server/deepwell/pageFile.ts
+++ b/framerail/src/lib/server/deepwell/pageFile.ts
@@ -38,7 +38,6 @@ export async function pageFileCreate(
   userId: number,
   name: Optional<string>,
   file: File,
-  licensing: any,
   revisionComments: Optional<string>
 ) {
   let presign = await startBlobUpload(userId, file.size)
@@ -49,7 +48,6 @@ export async function pageFileCreate(
     page_id: pageId,
     user_id: userId,
     name: name ?? file.name,
-    licensing,
     uploaded_blob_id: presign.pending_blob_id,
     revision_comments: revisionComments
   })
@@ -80,7 +78,6 @@ export async function pageFileEdit(
   fileId: string,
   name: string,
   file: Optional<File>,
-  licensing: Optional<any>,
   lastRevisionId: number,
   revisionComments: Optional<string>
 ) {
@@ -98,7 +95,6 @@ export async function pageFileEdit(
     file_id: fileId,
     last_revision_id: lastRevisionId,
     name,
-    licensing,
     uploaded_blob_id: presignId,
     revision_comments: revisionComments
   })

--- a/framerail/src/routes/[slug]/[...extra]/FilePane.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/FilePane.svelte
@@ -249,9 +249,6 @@
         <div class="file-attribute updated-at">
           {$page.data.internationalization?.["wiki-page-file.updated-at"]}
         </div>
-        <div class="file-attribute licensing">
-          {$page.data.internationalization?.["wiki-page-file.license"]}
-        </div>
         <div class="file-attribute mime">
           {$page.data.internationalization?.["wiki-page-file.mime"]}
         </div>
@@ -273,9 +270,6 @@
           </div>
           <div class="file-attribute updated-at">
             {file.file_updated_at ? new Date(file.file_updated_at).toLocaleString() : ""}
-          </div>
-          <div class="file-attribute licensing">
-            {file.licensing}
           </div>
           <div class="file-attribute mime">
             {file.mime}

--- a/locales/fluent/wiki-page/en.ftl
+++ b/locales/fluent/wiki-page/en.ftl
@@ -62,15 +62,12 @@ wiki-page-file-select = Select file:
 
 wiki-page-file-name = File name:
 
-wiki-page-file-license = File license:
-
 wiki-page-file-move-destination-page = Destination page
 
 wiki-page-file =
   .name = File name
   .created-at = Created at
   .updated-at = Updated at
-  .license = License
   .mime = File type
   .size = File size
   .page = Page

--- a/locales/fluent/wiki-page/zh_Hans.ftl
+++ b/locales/fluent/wiki-page/zh_Hans.ftl
@@ -62,15 +62,12 @@ wiki-page-file-select = 选择档案：
 
 wiki-page-file-name = 档案名：
 
-wiki-page-file-license = 授权协议：
-
 wiki-page-file-move-destination-page = 新页面网址
 
 wiki-page-file =
   .name = 档案名
   .created-at = 创建日期
   .updated-at = 最后编辑日期
-  .license = 授权协议
   .mime = 档案类型
   .size = 档案大小
   .page = 页面


### PR DESCRIPTION
A long time ago, I added a `licensing` column to the `file` table in anticipation of adding first-class licensing metadata. However, such a feature would require significant product design to work well, so in the mean time I just have it be a loose JSON column currently set to only `null`.

But this isn't very useful. In the future we can properly design and implement this feature, and having a dummy column doesn't help us with that. So for now, we should just remove it.