### PR TITLE
Fix new warnings in rust build

### DIFF
--- a/deepwell/README.md
+++ b/deepwell/README.md
@@ -52,7 +52,7 @@ The routes are defined in `api/`, with their implementations in `methods/`, and 
 
 ### Compilation
 
-This executable targets the latest stable Rust. At time of writing, that is `1.77.0`.
+This executable targets the latest stable Rust. At time of writing, that is `1.89.0`.
 
 At present the crate has one feature:
 * `notify` &mdash; Enables a feature to track the locale directory and configuration file, reloading the server if they are modified. This should be used in local builds only, not in production.

--- a/deepwell/src/locales/fluent.rs
+++ b/deepwell/src/locales/fluent.rs
@@ -116,7 +116,7 @@ impl Localizations {
         &self,
         locale: &LanguageIdentifier,
         path: &str,
-    ) -> Result<(&FluentBundle, FluentMessage), ServiceError> {
+    ) -> Result<(&'_ FluentBundle, FluentMessage<'_>), ServiceError> {
         match self.bundles.get(locale) {
             None => Err(ServiceError::LocaleMissing),
             Some(bundle) => match bundle.get_message(path) {

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -145,7 +145,7 @@ impl DomainService {
     /// it should instead redirect to just `wikijump.com`. The use of the `www`
     /// slug is an internal detail.
     #[inline]
-    fn www_domain(config: &Config) -> Cow<str> {
+    fn www_domain(config: &Config) -> Cow<'_, str> {
         Cow::Borrowed(&config.main_domain_no_dot)
     }
 

--- a/deepwell/src/services/score/impls/mod.rs
+++ b/deepwell/src/services/score/impls/mod.rs
@@ -18,6 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// TEMP
+#![allow(dead_code)]
+
 use super::prelude;
 
 mod mean;


### PR DESCRIPTION
There are new warnings in rustc, which this PR addresses:

* Reports structures in the scorer implementations as unused. (For the moment, they are, so suppress this)
* Implicit lifetimes in the output are no longer acceptable.