### PR TITLE
Upgrade redis and rsmq_async

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -255,6 +255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,11 +307,10 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bb8"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
+checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
 dependencies = [
- "async-trait",
  "futures-util",
  "parking_lot",
  "tokio",
@@ -778,7 +786,6 @@ dependencies = [
  "argon2",
  "arraystring",
  "async-trait",
- "bb8",
  "built",
  "bytes",
  "cfg-if",
@@ -3089,20 +3096,21 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
 dependencies = [
  "arc-swap",
- "async-trait",
+ "backon",
  "bytes",
  "combine",
- "futures",
+ "futures-channel",
  "futures-util",
  "itoa",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "rustls 0.23.27",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -3110,8 +3118,7 @@ dependencies = [
  "sha1_smol",
  "socket2 0.5.9",
  "tokio",
- "tokio-retry",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "url",
 ]
@@ -3283,17 +3290,16 @@ dependencies = [
 
 [[package]]
 name = "rsmq_async"
-version = "12.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2fcb95695cdf22792ce612c4ea6eaea9842edc70fc2ded285a48c3bee97254"
+checksum = "7a66d897e5e44ae806512a927a38a23e661cfc3d01befe496af8026089f4f8e0"
 dependencies = [
- "async-trait",
  "bb8",
  "lazy_static",
  "radix_fmt",
- "rand 0.8.5",
+ "rand 0.9.1",
  "redis",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -3422,20 +3428,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
@@ -3507,17 +3499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
  "untrusted",
 ]
 
@@ -4522,34 +4503,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
  "tokio",
 ]
 

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = "1"
 argon2 = "0.5"
 arraystring = "0.3"
 async-trait = "0.1"  # remove when trait async fn enhancements land
-bb8 = "0.8"
 bytes = "1"
 cfg-if = "1"
 clap = "4"
@@ -44,11 +43,11 @@ notify = { version = "8", optional = true }
 once_cell = "1"
 paste = "1"
 rand = "0.8"
-redis = { version = "0.25", features = ["aio", "connection-manager", "keep-alive", "tokio-comp", "tokio-rustls-comp"] }
+redis = { version = "0.28", features = ["aio", "connection-manager", "keep-alive", "tokio-comp", "tokio-rustls-comp"] }
 ref-map = "0.1"
 regex = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-rsmq_async = "12"
+rsmq_async = "15"
 rust-s3 = { version = "0.35", features = ["with-tokio", "tokio-rustls-tls"], default-features = false }
 rust-otp = "2"
 sea-orm = { version = "1", features = ["sqlx-postgres", "runtime-tokio-rustls", "postgres-array", "macros", "with-json", "with-time"], default-features = false }

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -41,7 +41,7 @@ use crate::utils::debug_pointer;
 use crate::{database, redis as redis_db};
 use jsonrpsee::server::{RpcModule, Server, ServerHandle};
 use jsonrpsee::types::error::ErrorObjectOwned;
-use rsmq_async::PooledRsmq;
+use rsmq_async::Rsmq;
 use s3::bucket::Bucket;
 use sea_orm::{DatabaseConnection, TransactionTrait};
 use std::fmt::{self, Debug};
@@ -56,7 +56,7 @@ pub struct ServerStateInner {
     pub config: Config,
     pub database: DatabaseConnection,
     pub redis: redis::Client,
-    pub rsmq: PooledRsmq,
+    pub rsmq: Rsmq,
     pub localizations: Localizations,
     pub mime_analyzer: MimeAnalyzer,
     pub s3_files_bucket: Box<Bucket>,

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -41,6 +41,7 @@ use crate::utils::debug_pointer;
 use crate::{database, redis as redis_db};
 use jsonrpsee::server::{RpcModule, Server, ServerHandle};
 use jsonrpsee::types::error::ErrorObjectOwned;
+use redis::aio::MultiplexedConnection as RedisMultiplexedConnection;
 use rsmq_async::Rsmq;
 use s3::bucket::Bucket;
 use sea_orm::{DatabaseConnection, TransactionTrait};
@@ -55,7 +56,7 @@ pub type ServerState = Arc<ServerStateInner>;
 pub struct ServerStateInner {
     pub config: Config,
     pub database: DatabaseConnection,
-    pub redis: redis::Client,
+    pub redis: RedisMultiplexedConnection,
     pub rsmq: Rsmq,
     pub localizations: Localizations,
     pub mime_analyzer: MimeAnalyzer,

--- a/deepwell/src/endpoints/misc.rs
+++ b/deepwell/src/endpoints/misc.rs
@@ -36,7 +36,7 @@ async fn postgres_check(ctx: &ServiceContext<'_>) -> Result<()> {
 }
 
 async fn redis_check(ctx: &ServiceContext<'_>) -> Result<()> {
-    let mut redis = ctx.redis_connect().await?;
+    let mut redis = ctx.redis();
 
     redis
         .send_packed_command(redis::Cmd::new().arg("PING"))

--- a/deepwell/src/redis.rs
+++ b/deepwell/src/redis.rs
@@ -22,16 +22,20 @@ use crate::services::job::{
     JOB_QUEUE_DELAY, JOB_QUEUE_MAXIMUM_SIZE, JOB_QUEUE_NAME, JOB_QUEUE_PROCESS_TIME,
 };
 use anyhow::Result;
-use redis::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo, RedisConnectionInfo};
-use rsmq_async::{Rsmq, RsmqConnection, RsmqOptions};
+use redis::aio::MultiplexedConnection;
+use rsmq_async::{Rsmq, RsmqConnection};
 
 const RSMQ_NAMESPACE: &str = "rsmq";
+const RSMQ_REALTIME: bool = false;
 
-pub async fn connect(redis_uri: &str) -> Result<(redis::Client, Rsmq)> {
-    // Parse redis connection URI
-    let redis = redis::Client::open(redis_uri)?;
-    let rsmq_options = get_rsmq_options(redis_uri)?;
-    let mut rsmq = Rsmq::new(rsmq_options).await?;
+pub async fn connect(redis_uri: &str) -> Result<(MultiplexedConnection, Rsmq)> {
+    let client = redis::Client::open(redis_uri)?;
+    let connection = client.get_multiplexed_async_connection().await?;
+    let mut rsmq = {
+        let connection2 = MultiplexedConnection::clone(&connection);
+        Rsmq::new_with_connection(connection2, RSMQ_REALTIME, Some(RSMQ_NAMESPACE))
+            .await?
+    };
 
     // Set up queue if it doesn't already exist
     if !job_queue_exists(&mut rsmq).await? {
@@ -49,41 +53,7 @@ pub async fn connect(redis_uri: &str) -> Result<(redis::Client, Rsmq)> {
         .await?;
     }
 
-    Ok((redis, rsmq))
-}
-
-fn get_rsmq_options(redis_uri: &str) -> Result<RsmqOptions> {
-    let ConnectionInfo {
-        addr,
-        redis:
-            RedisConnectionInfo {
-                db,
-                username,
-                password,
-                protocol,
-            },
-    } = redis_uri.into_connection_info()?;
-
-    let (host, port) = match addr {
-        ConnectionAddr::Tcp(host, port) => (host, port),
-        ConnectionAddr::TcpTls { .. } => {
-            panic!("Custom TLS connection not supported for Redis: {addr:#?}")
-        }
-        ConnectionAddr::Unix(path) => {
-            panic!("Unix socket not supported for Redis: {}", path.display())
-        }
-    };
-
-    Ok(RsmqOptions {
-        host,
-        port,
-        db: db.try_into().expect("DB int value too large for u8"),
-        username,
-        password,
-        protocol,
-        ns: str!(RSMQ_NAMESPACE),
-        realtime: false,
-    })
+    Ok((connection, rsmq))
 }
 
 async fn job_queue_exists(rsmq: &mut Rsmq) -> Result<bool> {

--- a/deepwell/src/redis.rs
+++ b/deepwell/src/redis.rs
@@ -22,29 +22,16 @@ use crate::services::job::{
     JOB_QUEUE_DELAY, JOB_QUEUE_MAXIMUM_SIZE, JOB_QUEUE_NAME, JOB_QUEUE_PROCESS_TIME,
 };
 use anyhow::Result;
-use bb8::{ErrorSink, Pool};
-use redis::{IntoConnectionInfo, RedisError};
-use rsmq_async::{PooledRsmq, RedisConnectionManager, RsmqConnection};
+use redis::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo, RedisConnectionInfo};
+use rsmq_async::{Rsmq, RsmqConnection, RsmqOptions};
 
-const REDIS_POOL_SIZE: u32 = 12;
+const RSMQ_NAMESPACE: &str = "rsmq";
 
-pub async fn connect(redis_uri: &str) -> Result<(redis::Client, PooledRsmq)> {
+pub async fn connect(redis_uri: &str) -> Result<(redis::Client, Rsmq)> {
     // Parse redis connection URI
     let redis = redis::Client::open(redis_uri)?;
-    let mut rsmq = {
-        let connection_info = redis_uri.into_connection_info()?;
-        let redis = redis::Client::open(connection_info)?;
-        let redis_conn = RedisConnectionManager::from_client(redis)?;
-        let pool = Pool::builder()
-            .max_size(REDIS_POOL_SIZE)
-            .error_sink(Box::new(RedisPoolErrorSink))
-            .test_on_check_out(true)
-            .build(redis_conn)
-            .await?;
-
-        // No redis pubsub (realtime=false)
-        PooledRsmq::new_with_pool(pool, false, None).await?
-    };
+    let rsmq_options = get_rsmq_options(redis_uri)?;
+    let mut rsmq = Rsmq::new(rsmq_options).await?;
 
     // Set up queue if it doesn't already exist
     if !job_queue_exists(&mut rsmq).await? {
@@ -65,20 +52,41 @@ pub async fn connect(redis_uri: &str) -> Result<(redis::Client, PooledRsmq)> {
     Ok((redis, rsmq))
 }
 
-#[derive(Debug)]
-struct RedisPoolErrorSink;
+fn get_rsmq_options(redis_uri: &str) -> Result<RsmqOptions> {
+    let ConnectionInfo {
+        addr,
+        redis:
+            RedisConnectionInfo {
+                db,
+                username,
+                password,
+                protocol,
+            },
+    } = redis_uri.into_connection_info()?;
 
-impl ErrorSink<RedisError> for RedisPoolErrorSink {
-    fn sink(&self, error: RedisError) {
-        error!("Redis connection pool error: {error}");
-    }
+    let (host, port) = match addr {
+        ConnectionAddr::Tcp(host, port) => (host, port),
+        ConnectionAddr::TcpTls { .. } => {
+            panic!("Custom TLS connection not supported for Redis: {addr:#?}")
+        }
+        ConnectionAddr::Unix(path) => {
+            panic!("Unix socket not supported for Redis: {}", path.display())
+        }
+    };
 
-    fn boxed_clone(&self) -> Box<dyn ErrorSink<RedisError>> {
-        Box::new(RedisPoolErrorSink)
-    }
+    Ok(RsmqOptions {
+        host,
+        port,
+        db: db.try_into().expect("DB int value too large for u8"),
+        username,
+        password,
+        protocol,
+        ns: str!(RSMQ_NAMESPACE),
+        realtime: false,
+    })
 }
 
-async fn job_queue_exists(rsmq: &mut PooledRsmq) -> Result<bool> {
+async fn job_queue_exists(rsmq: &mut Rsmq) -> Result<bool> {
     // NOTE: Effectively the same as rsmq.list_queues().await?.contains(JOB_QUEUE_NAME),
     //       except we don't have to deal with the "&String" type issue.
     let queues = rsmq.list_queues().await?;

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -59,17 +59,8 @@ impl<'txn> ServiceContext<'txn> {
     }
 
     #[inline]
-    pub fn redis_client(&self) -> &redis::Client {
-        &self.state.redis
-    }
-
-    pub async fn redis_connect(&self) -> Result<RedisMultiplexedConnection> {
-        let conn = self
-            .redis_client()
-            .get_multiplexed_tokio_connection()
-            .await?;
-
-        Ok(conn)
+    pub fn redis(&self) -> RedisMultiplexedConnection {
+        RedisMultiplexedConnection::clone(&self.state.redis)
     }
 
     #[inline]

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -24,7 +24,7 @@ use crate::locales::Localizations;
 use crate::services::blob::MimeAnalyzer;
 use crate::services::error::Result;
 use redis::aio::MultiplexedConnection as RedisMultiplexedConnection;
-use rsmq_async::PooledRsmq;
+use rsmq_async::Rsmq;
 use s3::bucket::Bucket;
 use sea_orm::DatabaseTransaction;
 use std::sync::Arc;
@@ -73,8 +73,8 @@ impl<'txn> ServiceContext<'txn> {
     }
 
     #[inline]
-    pub fn rsmq(&self) -> PooledRsmq {
-        PooledRsmq::clone(&self.state.rsmq)
+    pub fn rsmq(&self) -> Rsmq {
+        Rsmq::clone(&self.state.rsmq)
     }
 
     #[inline]

--- a/deepwell/src/services/job/worker.rs
+++ b/deepwell/src/services/job/worker.rs
@@ -24,7 +24,7 @@ use super::prelude::*;
 use crate::api::ServerState;
 use crate::services::{PageRevisionService, SessionService, TextService, UserService};
 use crate::utils::debug_pointer;
-use rsmq_async::{PooledRsmq, RsmqConnection, RsmqMessage};
+use rsmq_async::{Rsmq, RsmqConnection, RsmqMessage};
 use sea_orm::TransactionTrait;
 use std::convert::Infallible;
 use std::fmt::{self, Debug};
@@ -49,7 +49,7 @@ enum NextJob {
 #[derive(Clone)]
 pub struct JobWorker {
     state: ServerState,
-    rsmq: PooledRsmq,
+    rsmq: Rsmq,
     id: u16,
 }
 
@@ -72,7 +72,7 @@ impl JobWorker {
     fn spawn_one(state: &ServerState, id: u16) {
         info!("Spawning job worker ID {id}");
         let state = Arc::clone(state);
-        let rsmq = PooledRsmq::clone(&state.rsmq);
+        let rsmq = Rsmq::clone(&state.rsmq);
         let worker = JobWorker { state, rsmq, id };
         tokio::spawn(worker.main_loop());
     }


### PR DESCRIPTION
These two crates have been out-of-date for a while, causing some maintenance issues. Additionally, cargo has been emitting the following warning in builds. By upgrading, we eliminate these issues:
```
warning: the following packages contain code that will be rejected by a future version of Rust: redis v0.25.4, rsmq_async v12.0.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

Note that this PR requires #2453 to be merged first to bring in the build fixes from there.