### PR TITLE
Update .prettierignore for repo structure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,21 +1,12 @@
 # Artifacts, dependencies
 dist
-/web/public/files--built
 node_modules
 vendor
 
 # Legacy code
-/web/bin
-/web/lib
-/web/php
-/web/web
-/web/templates
-
-# PHP
-*.blade.php
-/web/bootstrap
-/web/storage
-/web/database/migrations
+/legacy
+/web
+*.php
 
 # Misc
 .gitignore


### PR DESCRIPTION
Last change to this file was 4 years ago, and the directory structure has changed a bit since then. This updates the file to better reflect the current state of the project structure.