### PR TITLE
Remove licensing column from database schema

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -491,8 +491,7 @@ CREATE TYPE file_revision_type AS ENUM (
 CREATE TYPE file_revision_change AS ENUM (
     'name',
     'blob',
-    'mime',
-    'licensing'
+    'mime'
 );
 
 CREATE TABLE file (
@@ -521,7 +520,6 @@ CREATE TABLE file_revision (
     s3_hash BYTEA NOT NULL,
     mime TEXT NOT NULL,
     size BIGINT NOT NULL,
-    licensing JSON NOT NULL,
     changes TEXT[] NOT NULL DEFAULT '{}', -- List of changes in this revision
     comments TEXT NOT NULL,
     hidden TEXT[] NOT NULL DEFAULT '{}', -- List of fields to be hidden/suppressed
@@ -536,8 +534,7 @@ CREATE TABLE file_revision (
         page,
         name,
         blob,
-        mime,
-        licensing
+        mime
     }'),
 
     -- Ensure first revision reports all changes
@@ -551,8 +548,7 @@ CREATE TABLE file_revision (
             page,
             name,
             blob,
-            mime,
-            licensing
+            mime
         }'
     ),
 


### PR DESCRIPTION
Follow-up to #2434 

Embarrassing thing to miss. This removes the `licensing` column from the database schema, which obviously causes issues if you remake your database container.