### PR TITLE
Change deepwell container health checks to avoid startup stalls

### DIFF
--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
     restart: always
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
-      interval: 120s
+      interval: 600s
       timeout: 2s
       retries: 3
     depends_on:
@@ -100,7 +100,7 @@ services:
       retries: 3
     depends_on:
       deepwell:
-        condition: service_healthy
+        condition: service_started
 
   wws:
     build:


### PR DESCRIPTION
In order to improve the development experience, we have deepwell (the container) build the source code for the service at runtime, using `cargo watch`. This way, instead of needing to rebuild the image every time you made a local code change, it instead gets reflected immediately without changing anything about your local deployment.

One downside with this, however, is that the build (at least initially) can take a while, and the health check configured for deepwell is when the service is built, running, and responding to pings. In some cases, the build can take so long that Docker decides that the container is "unhealthy" (since it's not ready yet) and then fail it, which is obnoxious since it requires you to manually restart it to let the build finish. However, if you increase the check time to allow the build to finish, then Docker _doesn't attempt_ to check if the container is ready until that time elapses, slowing down subsequent containers which depend on deepwell.

Ideally, we could set a separate "wait this long before doing health checks" value that allows for the initial build to happen but a short "do health checks this often" value, but unfortunately for Docker these two values are the same. So instead, we are configuring Docker to consider this container ready when it's _started_ rather than healthy, and giving a much longer health check duration (which now doesn't delay later containers trying to start up), allowing builds more time to finish their work.