### PR TITLE
Use LazyLock instead of once_cell

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -808,7 +808,6 @@ dependencies = [
  "log",
  "maplit",
  "notify",
- "once_cell",
  "paste",
  "pretty_assertions",
  "rand 0.8.5",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -40,7 +40,6 @@ intl-memoizer = "0.5"
 jsonrpsee = { version = "0.24", features = ["macros", "server"] }
 log = "0.4"
 notify = { version = "8", optional = true }
-once_cell = "1"
 paste = "1"
 rand = "0.8"
 redis = { version = "0.28", features = ["aio", "connection-manager", "keep-alive", "tokio-comp", "tokio-rustls-comp"] }

--- a/deepwell/src/info.rs
+++ b/deepwell/src/info.rs
@@ -22,7 +22,7 @@ mod build {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use time::format_description::well_known::Rfc2822;
 use time::OffsetDateTime;
 
@@ -33,12 +33,12 @@ pub use self::build::{
     RUSTC_VERSION, TARGET,
 };
 
-pub static BUILT_TIME_UTC: Lazy<OffsetDateTime> = Lazy::new(|| {
+pub static BUILT_TIME_UTC: LazyLock<OffsetDateTime> = LazyLock::new(|| {
     OffsetDateTime::parse(BUILT_TIME_UTC_STR, &Rfc2822)
         .expect("Unable to parse built time string")
 });
 
-pub static VERSION_INFO: Lazy<String> = Lazy::new(|| {
+pub static VERSION_INFO: LazyLock<String> = LazyLock::new(|| {
     let mut version = format!("v{PKG_VERSION}");
 
     if let Some(commit_hash) = *GIT_COMMIT_HASH_SHORT {
@@ -48,7 +48,7 @@ pub static VERSION_INFO: Lazy<String> = Lazy::new(|| {
     version
 });
 
-pub static COMPILE_INFO: Lazy<String> = Lazy::new(|| {
+pub static COMPILE_INFO: LazyLock<String> = LazyLock::new(|| {
     let mut info = str!("Compile info:\n");
     str_writeln!(&mut info, "* on {BUILT_TIME_UTC_STR}");
     str_writeln!(&mut info, "* by {RUSTC_VERSION}");
@@ -57,15 +57,16 @@ pub static COMPILE_INFO: Lazy<String> = Lazy::new(|| {
     info
 });
 
-pub static VERSION: Lazy<String> = Lazy::new(|| format!("{PKG_NAME} {}", *VERSION_INFO));
+pub static VERSION: LazyLock<String> =
+    LazyLock::new(|| format!("{PKG_NAME} {}", *VERSION_INFO));
 
-pub static FULL_VERSION: Lazy<String> =
-    Lazy::new(|| format!("{}\n\n{}", *VERSION, *COMPILE_INFO));
+pub static FULL_VERSION: LazyLock<String> =
+    LazyLock::new(|| format!("{}\n\n{}", *VERSION, *COMPILE_INFO));
 
-pub static GIT_COMMIT_HASH_SHORT: Lazy<Option<&'static str>> =
-    Lazy::new(|| build::GIT_COMMIT_HASH.map(|s| &s[..8]));
+pub static GIT_COMMIT_HASH_SHORT: LazyLock<Option<&'static str>> =
+    LazyLock::new(|| build::GIT_COMMIT_HASH.map(|s| &s[..8]));
 
-pub static HOSTNAME: Lazy<String> = Lazy::new(|| {
+pub static HOSTNAME: LazyLock<String> = LazyLock::new(|| {
     // According to the gethostname(3p) man page,
     // there don't seem to be any errors possible.
     //

--- a/deepwell/src/services/blob/mime.rs
+++ b/deepwell/src/services/blob/mime.rs
@@ -21,7 +21,7 @@
 //! Evaluates MIME types using libmagic.
 //!
 //! Because it is a binding to a C library, it cannot be shared among threads.
-//! So we cannot use `once_cell::Lazy` and we can't have it in a coroutine.
+//! So we cannot use `LazyLock` and we can't have it in a coroutine.
 //! We don't load the `Magic` instance locally because it's an expensive operation
 //! and it would be inefficient to load it for each invocation.
 //!

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -35,14 +35,14 @@ use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{BlobService, FileRevisionService, FilterService, PageService};
 use crate::types::FileOrder;
 use crate::utils::regex_replace_in_place;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use sea_orm::ActiveValue;
+use std::sync::LazyLock;
 
 pub const MAXIMUM_FILE_NAME_LENGTH: usize = 256;
 
-static LEADING_TRAILING_SPACES: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(^\s+)|(\s+$)").unwrap());
+static LEADING_TRAILING_SPACES: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^\s+)|(\s+$)").unwrap());
 
 #[derive(Debug)]
 pub struct FileService;

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -27,16 +27,16 @@ use crate::models::{file, page, site};
 use crate::services::blob::{FinalizeBlobUploadOutput, EMPTY_BLOB_HASH, EMPTY_BLOB_MIME};
 use crate::services::{BlobService, OutdateService, PageService};
 use crate::types::{Bytes, FetchDirection};
-use once_cell::sync::Lazy;
 use sea_orm::{prelude::*, FromQueryResult};
 use std::num::NonZeroI32;
+use std::sync::LazyLock;
 
 /// The changes for the first revision.
 /// The first revision is always considered to have changed everything.
 ///
 /// See `services/page_revision/service.rs`.
-static ALL_CHANGES: Lazy<Vec<String>> =
-    Lazy::new(|| vec![str!("page"), str!("name"), str!("blob"), str!("mime")]);
+static ALL_CHANGES: LazyLock<Vec<String>> =
+    LazyLock::new(|| vec![str!("page"), str!("name"), str!("blob"), str!("mime")]);
 
 #[derive(Debug)]
 pub struct FileRevisionService;

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -34,15 +34,15 @@ use crate::utils::{split_category, split_category_name};
 use ftml::data::PageInfo;
 use ftml::layout::Layout;
 use ftml::settings::{WikitextMode, WikitextSettings};
-use once_cell::sync::Lazy;
 use ref_map::*;
 use std::num::NonZeroI32;
+use std::sync::LazyLock;
 
 /// The changes for the first revision.
 /// The first revision is always considered to have changed everything.
 ///
 /// See `services/file_revision/service.rs`.
-static ALL_CHANGES: Lazy<Vec<String>> = Lazy::new(|| {
+static ALL_CHANGES: LazyLock<Vec<String>> = LazyLock::new(|| {
     vec![
         str!("wikitext"),
         str!("title"),

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -27,13 +27,13 @@ use crate::services::email::{EmailClassification, EmailService};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{AliasService, FilterService, PasswordService};
 use crate::utils::regex_replace_in_place;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use sea_orm::ActiveValue;
 use std::cmp;
+use std::sync::LazyLock;
 
-static LEADING_TRAILING_CHARS: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(^[\-\s]+)|([\-\s+]$)").unwrap());
+static LEADING_TRAILING_CHARS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(^[\-\s]+)|([\-\s+]$)").unwrap());
 
 #[derive(Debug)]
 pub struct UserService;


### PR DESCRIPTION
Since rust 1.80.0, [`LazyLock`](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html) has been added to the standard library, which does basically what `once_cell::sync::Lazy` and `lazy_static!` did. This means we can use the standard library version instead and shed a dependency. (Well kind of, some of our dependencies still use it, but at least we can avoid it at the top level).