### PR TITLE
Renumber all error cases in new system

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2025.9.5"
+version = "2025.9.6"
 dependencies = [
  "anyhow",
  "argon2",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2025.9.5"
+version = "2025.9.6"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2021"
 

--- a/deepwell/src/services/error.rs
+++ b/deepwell/src/services/error.rs
@@ -39,11 +39,14 @@ pub enum Error {
     #[error("{0}")]
     Raw(#[from] ErrorObjectOwned),
 
-    #[error("Cryptography error: {0}")]
-    Cryptography(argon2::password_hash::Error),
+    #[error("Serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
 
     #[error("Database error: {0}")]
     Database(DbErr),
+
+    #[error("Cryptography error: {0}")]
+    Cryptography(argon2::password_hash::Error),
 
     #[error("Redis error: {0}")]
     Redis(#[from] redis::RedisError),
@@ -51,155 +54,29 @@ pub enum Error {
     #[error("Redis Simple Message Queue (RSMQ) error: {0}")]
     Rsmq(#[from] rsmq_async::RsmqError),
 
-    #[error("Invalid locale: {0}")]
-    LocaleInvalid(#[from] LanguageIdentifierError),
-
-    #[error("No messages are available for this locale")]
-    LocaleMissing,
-
-    #[error("Message key not found for this locale")]
-    LocaleMessageMissing,
-
-    #[error("Message key was found, but has no value")]
-    LocaleMessageValueMissing,
-
-    #[error("Message key was found, but does not have this attribute")]
-    LocaleMessageAttributeMissing,
-
-    #[error("No locales were specified in the request")]
-    NoLocalesSpecified,
-
     #[error("Magic library error: {0}")]
     Magic(#[from] FileMagicError),
 
     #[error("One-time password error: {0}")]
     Otp(#[from] rust_otp::Error),
 
-    #[error("Serialization error: {0}")]
-    Serde(#[from] serde_json::Error),
+    #[error("The rate limit for an external API has been reached")]
+    RateLimited,
+
+    #[error("Web request error: {0}")]
+    WebRequest(#[from] ReqwestError),
+
+    #[error("Attempting to perform a wikitext parse and render has timed out")]
+    RenderTimeout,
+
+    #[error("Email verification error: {}", .0.as_ref().unwrap_or(&str!("<unspecified>")))]
+    EmailVerification(Option<String>),
 
     #[error("S3 service returned error: {0}")]
     S3Service(#[from] S3Error),
 
     #[error("S3 service failed to respond properly")]
     S3Response,
-
-    #[error("Email verification error: {}", .0.as_ref().unwrap_or(&str!("<unspecified>")))]
-    EmailVerification(Option<String>),
-
-    #[error("Web request error: {0}")]
-    WebRequest(#[from] ReqwestError),
-
-    #[error("Invalid enum serialization value")]
-    InvalidEnumValue,
-
-    #[error("Attempting to perform a wikitext parse and render has timed out")]
-    RenderTimeout,
-
-    #[error("The user cannot rename as they do not have enough name change tokens")]
-    InsufficientNameChanges,
-
-    #[error("Invalid username, password, or TOTP code")]
-    InvalidAuthentication,
-
-    #[error("Backend error while trying to authenticate")]
-    AuthenticationBackend(Box<Error>),
-
-    #[error("Invalid session token, cannot be used for authentication")]
-    InvalidSessionToken,
-
-    #[error("User ID {session_user_id} associated with session does not match active user ID {active_user_id}")]
-    SessionUserId {
-        active_user_id: i64,
-        session_user_id: i64,
-    },
-
-    #[error("A password is required")]
-    EmptyPassword,
-
-    #[error("The user's email is disallowed")]
-    DisallowedEmail,
-
-    #[error("The user's email is invalid")]
-    InvalidEmail,
-
-    #[error("The request is in some way malformed or incorrect")]
-    BadRequest,
-
-    #[error("The request violates a configured content filter")]
-    FilterViolation,
-
-    #[error("Cannot hide the wikitext for the latest page revision")]
-    CannotHideLatestRevision,
-
-    #[error("Revision ID passed for this operation is not the latest")]
-    NotLatestRevisionId,
-
-    #[error("Custom domains may not be subdomains of the Wikijump main or file domains")]
-    CustomDomainSubdomain,
-
-    #[error("Cannot use custom domain, as it belongs to a different site")]
-    CustomDomainWrongSite,
-
-    #[error("The regular expression found in the database is invalid")]
-    FilterRegexInvalid(regex::Error),
-
-    #[error("Cannot restore a non-deleted filter")]
-    FilterNotDeleted,
-
-    #[error("File name cannot be empty")]
-    FileNameEmpty,
-
-    #[error("File name too long")]
-    FileNameTooLong { length: usize, maximum: usize },
-
-    #[error("File name contains invalid characters (control chars or slashes)")]
-    FileNameInvalidCharacters,
-
-    #[error("File MIME type cannot be empty")]
-    FileMimeEmpty,
-
-    #[error("Cannot restore a non-deleted file")]
-    FileNotDeleted,
-
-    #[error("Cannot restore a non-deleted page")]
-    PageNotDeleted,
-
-    #[error("Page slug cannot be empty")]
-    PageSlugEmpty,
-
-    #[error("Site slug cannot be empty")]
-    SiteSlugEmpty,
-
-    #[error("User name is too short")]
-    UserNameTooShort,
-
-    #[error("User slug cannot be empty")]
-    UserSlugEmpty,
-
-    #[error("User email cannot be empty")]
-    UserEmailEmpty,
-
-    #[error("User wrong type for this operation")]
-    UserWrongType,
-
-    #[error("Message subject cannot be empty")]
-    MessageSubjectEmpty,
-
-    #[error("Message subject too long")]
-    MessageSubjectTooLong,
-
-    #[error("Message body cannot be empty")]
-    MessageBodyEmpty,
-
-    #[error("Message body too long")]
-    MessageBodyTooLong,
-
-    #[error("Message cannot have no recipients")]
-    MessageNoRecipients,
-
-    #[error("Message has too many recipients")]
-    MessageTooManyRecipients,
 
     #[error("Unspecified entity not found")]
     GeneralNotFound,
@@ -252,26 +129,6 @@ pub enum Error {
     #[error("Blob item does not exist")]
     BlobNotFound,
 
-    #[error("Blob not uploaded")]
-    BlobNotUploaded,
-
-    #[error("Cannot use blob uploaded by different user")]
-    BlobWrongUser,
-
-    #[error("Uploaded blob is too big for this operation")]
-    BlobTooBig,
-
-    #[error("Uploaded blob does not match expected length")]
-    BlobSizeMismatch { expected: usize, actual: usize },
-
-    #[error("Uploaded blob content is blacklisted")]
-    BlobBlacklisted(BlobHash),
-
-    #[error(
-        "Cannot blacklist a blob which is already in use, you must do a hard deletion"
-    )]
-    BlobCannotBlacklistExisting,
-
     #[error("Text item does not exist")]
     TextNotFound,
 
@@ -302,14 +159,157 @@ pub enum Error {
     #[error("Cannot perform, custom domain already exists")]
     CustomDomainExists,
 
+    #[error("Invalid username, password, or TOTP code")]
+    InvalidAuthentication,
+
+    #[error("Backend error while trying to authenticate")]
+    AuthenticationBackend(Box<Error>),
+
+    #[error("Invalid session token, cannot be used for authentication")]
+    InvalidSessionToken,
+
+    #[error("User ID {session_user_id} associated with session does not match active user ID {active_user_id}")]
+    SessionUserId {
+        active_user_id: i64,
+        session_user_id: i64,
+    },
+
+    #[error("A password is required")]
+    EmptyPassword,
+
+    #[error("The request is in some way malformed or incorrect")]
+    BadRequest,
+
+    #[error("Invalid enum serialization value")]
+    InvalidEnumValue,
+
+    #[error("User name is too short")]
+    UserNameTooShort,
+
+    #[error("User slug cannot be empty")]
+    UserSlugEmpty,
+
+    #[error("User email cannot be empty")]
+    UserEmailEmpty,
+
+    #[error("Wrong user type for this operation")]
+    UserWrongType,
+
+    #[error("The user cannot rename as they do not have enough name change tokens")]
+    InsufficientNameChanges,
+
+    #[error("The user's email is disallowed")]
+    DisallowedEmail,
+
+    #[error("The user's email is invalid")]
+    InvalidEmail,
+
+    #[error("Site slug cannot be empty")]
+    SiteSlugEmpty,
+
+    #[error("Page slug cannot be empty")]
+    PageSlugEmpty,
+
+    #[error("Cannot restore a non-deleted page")]
+    PageNotDeleted,
+
+    #[error("Cannot hide the wikitext for the latest page revision")]
+    CannotHideLatestRevision,
+
+    #[error("Revision ID passed for this operation is not the latest")]
+    NotLatestRevisionId,
+
+    #[error("File name cannot be empty")]
+    FileNameEmpty,
+
+    #[error("File name too long")]
+    FileNameTooLong { length: usize, maximum: usize },
+
+    #[error("File name contains invalid characters (control chars or slashes)")]
+    FileNameInvalidCharacters,
+
+    #[error("File MIME type cannot be empty")]
+    FileMimeEmpty,
+
+    #[error("Cannot restore a non-deleted file")]
+    FileNotDeleted,
+
+    #[error("Invalid locale: {0}")]
+    LocaleInvalid(#[from] LanguageIdentifierError),
+
+    #[error("No messages are available for this locale")]
+    LocaleMissing,
+
+    #[error("Message key not found for this locale")]
+    LocaleMessageMissing,
+
+    #[error("Message key was found, but has no value")]
+    LocaleMessageValueMissing,
+
+    #[error("Message key was found, but does not have this attribute")]
+    LocaleMessageAttributeMissing,
+
+    #[error("No locales were specified in the request")]
+    NoLocalesSpecified,
+
+    #[error("The request violates a configured content filter")]
+    FilterViolation,
+
+    #[error("The regular expression found in the database is invalid")]
+    FilterRegexInvalid(regex::Error),
+
+    #[error("Cannot restore a non-deleted filter")]
+    FilterNotDeleted,
+
+    #[error("Blob not uploaded")]
+    BlobNotUploaded,
+
+    #[error("Cannot use blob uploaded by different user")]
+    BlobWrongUser,
+
+    #[error("Uploaded blob is too big for this operation")]
+    BlobTooBig,
+
+    #[error("Uploaded blob does not match expected length")]
+    BlobSizeMismatch { expected: usize, actual: usize },
+
+    #[error("Uploaded blob content is blacklisted")]
+    BlobBlacklisted(BlobHash),
+
+    #[error(
+        "Cannot blacklist a blob which is already in use, you must do a hard deletion"
+    )]
+    BlobCannotBlacklistExisting,
+
+    #[error("Message subject cannot be empty")]
+    MessageSubjectEmpty,
+
+    #[error("Message subject too long")]
+    MessageSubjectTooLong,
+
+    #[error("Message body cannot be empty")]
+    MessageBodyEmpty,
+
+    #[error("Message body too long")]
+    MessageBodyTooLong,
+
+    #[error("Message cannot have no recipients")]
+    MessageNoRecipients,
+
+    #[error("Message has too many recipients")]
+    MessageTooManyRecipients,
+
+    #[error("Custom domains may not be subdomains of the Wikijump main or file domains")]
+    CustomDomainSubdomain,
+
+    #[error("Cannot use custom domain, as it belongs to a different site")]
+    CustomDomainWrongSite,
+
     #[error("Cannot perform this action because you are blocked by the user")]
     UserBlockedUser,
 
     #[error("Cannot perform this action because you are blocked by the site")]
     SiteBlockedUser,
-
-    #[error("The rate limit for an external API has been reached")]
-    RateLimited,
 }
 
 impl Error {
@@ -327,12 +327,36 @@ impl Error {
     /// accordingly when error codes are added or removed.
     pub fn code(&self) -> i32 {
         match self {
-            // 1000 - Miscellaneous, general errors
-            //        Avoid putting stuff here, prefer other categories instead
-            Error::Raw(_) => 1000,
+            //
+            // 1000 -- General Process Handling
+            //
 
-            // 2000 - Database conflicts
-            //        Missing data
+            // 1000 - Miscellaneous / Technical
+            Error::Raw(_) => 1000,
+            Error::AuthenticationBackend(_) => 1001,
+
+            // 1100 - Rust Errors
+            Error::Serde(_) => 1100,
+            Error::Database(_) => 1101,
+            Error::Cryptography(_) => 1102,
+            Error::Magic(_) => 1103,
+            Error::Otp(_) => 1104,
+            Error::Redis(_) => 1105,
+            Error::Rsmq(_) => 1106,
+
+            // 1200 - Service Errors
+            Error::RateLimited => 1200,
+            Error::WebRequest(_) => 1201,
+            Error::RenderTimeout => 1202,
+            Error::EmailVerification(_) => 1203,
+            Error::S3Service(_) => 1204,
+            Error::S3Response => 1205,
+
+            //
+            // 2000 -- Data Consistency
+            //
+
+            // 2000 - Not Found
             Error::GeneralNotFound => 2000,
             Error::AliasNotFound => 2001,
             Error::RelationNotFound => 2002,
@@ -352,7 +376,7 @@ impl Error {
             Error::BlobNotFound => 2016,
             Error::TextNotFound => 2017,
 
-            // 2100 -- Existing data
+            // 2100 - Already Exists
             Error::UserExists => 2100,
             Error::UserMfaExists => 2101,
             Error::SiteExists => 2102,
@@ -363,85 +387,104 @@ impl Error {
             Error::FilterExists => 2107,
             Error::CustomDomainExists => 2108,
 
-            // 3000 - Server errors, unexpected
-            Error::RateLimited => 3000,
-            Error::WebRequest(_) => 3001,
-            Error::AuthenticationBackend(_) => 3002,
+            //
+            // 3000 -- Client / Protocol Errors
+            //
 
-            // 3100 -- Remote services
-            Error::RenderTimeout => 3100,
-            Error::EmailVerification(_) => 3101,
-            Error::S3Service(_) => 3102,
-            Error::S3Response => 3103,
+            // 3000 - Authentication
+            Error::InvalidAuthentication => 3000,
+            Error::InvalidSessionToken => 3001,
+            Error::SessionUserId { .. } => 3002,
+            Error::EmptyPassword => 3003,
 
-            // 3200 -- Backend issues
-            Error::Serde(_) => 3200,
-            Error::Database(_) => 3201,
-            Error::Cryptography(_) => 3202,
-            Error::Magic(_) => 3204,
-            Error::Otp(_) => 3205,
-            Error::Redis(_) => 3206,
-            Error::Rsmq(_) => 3207,
+            // 3100 - Permission
+            // TODO
 
-            // 4000 - Client, request errors
-            //        BadRequest is pretty general, avoid it except for rare weird cases
+            //
+            // 4000, 5000, 6000 -- Client / Request Errors
+            //
+
+            //
+            // 4000 -- Client / Request Errors - Core Data Objects
+            //
+
+            // 4000 - General
+            //
+            // Some of these requests are pretty general, unless it is a rare edge case,
+            // consider adding a new error case when code to handle new fail states are
+            // introduced.
             Error::BadRequest => 4000,
             Error::InvalidEnumValue => 4001,
-            Error::FilterViolation => 4002,
-            Error::InsufficientNameChanges => 4003,
-            Error::CannotHideLatestRevision => 4004,
-            Error::FilterRegexInvalid(_) => 4005,
-            Error::FilterNotDeleted => 4006,
-            Error::FileNameEmpty => 4007,
-            Error::FileNameTooLong { .. } => 4008,
-            Error::FileNameInvalidCharacters => 4009,
-            Error::FileMimeEmpty => 4010,
-            Error::FileNotDeleted => 4011,
-            Error::PageNotDeleted => 4012,
-            Error::PageSlugEmpty => 4013,
-            Error::SiteSlugEmpty => 4014,
-            Error::UserNameTooShort => 4015,
-            Error::UserSlugEmpty => 4016,
-            Error::UserEmailEmpty => 4017,
-            Error::UserWrongType => 4033, // new
-            Error::MessageSubjectEmpty => 4018,
-            Error::MessageSubjectTooLong => 4019,
-            Error::MessageBodyEmpty => 4020,
-            Error::MessageBodyTooLong => 4021,
-            Error::MessageNoRecipients => 4022,
-            Error::MessageTooManyRecipients => 4023,
-            Error::BlobWrongUser => 4024,
-            Error::BlobTooBig => 4025,
-            Error::BlobNotUploaded => 4026,
-            Error::BlobSizeMismatch { .. } => 4027,
-            Error::BlobBlacklisted(_) => 4028,
-            Error::BlobCannotBlacklistExisting => 4029,
-            Error::NotLatestRevisionId => 4030,
-            Error::CustomDomainSubdomain => 4031,
-            Error::CustomDomainWrongSite => 4032,
 
-            // 4100 -- Localization
-            Error::LocaleInvalid(_) => 4100,
-            Error::LocaleMissing => 4101,
-            Error::LocaleMessageMissing => 4102,
-            Error::LocaleMessageValueMissing => 4103,
-            Error::LocaleMessageAttributeMissing => 4104,
-            Error::NoLocalesSpecified => 4105,
+            // 4100 - User
+            Error::UserNameTooShort => 4100,
+            Error::UserSlugEmpty => 4101,
+            Error::UserEmailEmpty => 4102,
+            Error::UserWrongType => 4103,
+            Error::InsufficientNameChanges => 4104,
+            Error::InvalidEmail => 4105,
+            Error::DisallowedEmail => 4106,
 
-            // 4200 -- Login errors
-            Error::EmptyPassword => 4200,
-            Error::InvalidEmail => 4201,
-            Error::DisallowedEmail => 4202,
+            // 4200 - Site
+            Error::SiteSlugEmpty => 4200,
 
-            // 4300 -- Relationship conflicts
-            Error::SiteBlockedUser => 4300,
-            Error::UserBlockedUser => 4301,
+            // 4300 - Page
+            Error::PageSlugEmpty => 4300,
+            Error::PageNotDeleted => 4301,
+            Error::CannotHideLatestRevision => 4302,
+            Error::NotLatestRevisionId => 4303,
 
-            // 5000 - Authentication, permission, or role errors
-            Error::InvalidAuthentication => 5000,
-            Error::InvalidSessionToken => 5001,
-            Error::SessionUserId { .. } => 5002,
-            // TODO: permission errors (e.g. locked page, cannot apply bans)
+            // 4400 - File
+            Error::FileNameEmpty => 4400,
+            Error::FileNameTooLong { .. } => 4401,
+            Error::FileNameInvalidCharacters => 4402,
+            Error::FileMimeEmpty => 4403,
+            Error::FileNotDeleted => 4404,
+
+            //
+            // 5000 -- Client / Request Errors - Ancillary Data Objects
+            //
+
+            // 5000 - Locale
+            Error::LocaleInvalid(_) => 5000,
+            Error::LocaleMissing => 5001,
+            Error::LocaleMessageMissing => 5002,
+            Error::LocaleMessageValueMissing => 5003,
+            Error::LocaleMessageAttributeMissing => 5004,
+            Error::NoLocalesSpecified => 5005,
+
+            // 5100 - Filter
+            Error::FilterViolation => 5100,
+            Error::FilterRegexInvalid(_) => 5101,
+            Error::FilterNotDeleted => 5102,
+
+            // 5200 - Blob
+            Error::BlobNotUploaded => 5200,
+            Error::BlobWrongUser => 5201,
+            Error::BlobTooBig => 5202,
+            Error::BlobSizeMismatch { .. } => 5204,
+            Error::BlobBlacklisted(_) => 5205,
+            Error::BlobCannotBlacklistExisting => 5206,
+
+            // 5300 - Message
+            Error::MessageSubjectEmpty => 5300,
+            Error::MessageSubjectTooLong => 5301,
+            Error::MessageBodyEmpty => 5302,
+            Error::MessageBodyTooLong => 5303,
+            Error::MessageNoRecipients => 5304,
+            Error::MessageTooManyRecipients => 5305,
+
+            // 5400 - Domains
+            Error::CustomDomainWrongSite => 5400,
+            Error::CustomDomainSubdomain => 5401,
+
+            //
+            // 6000 -- Client / Request Errors - Composite Data
+            //
+
+            // 6000 - Relations
+            Error::SiteBlockedUser => 6000,
+            Error::UserBlockedUser => 6001,
         }
     }
 


### PR DESCRIPTION
This redoes the numbering system used for error cases within DEEPWELL.

One issue has become clear in the existing system: client or request errors are by far the most common type of error for DEEPWELL to return. Previous X000 groups were far too big for their type, while the 4000 group for request errors was too small and did not afford flexibility to add new errors for differing sub-types/relevant objects.

This re-organizes the error numbering system:

* `1XXX` are errors for generally unexpected issues at runtime.
  * `11XX` are wrappers for Rust error objects not otherwise handled.
  * `12XX` are errors for services or libraries which did not respond in an expected way.
* `2XXX` are for issues with basic data consistency:
  * `20XX` are for missing objects (e.g. cannot ban a user that doesn't exist).
  * `21XX` are for existing objects (e.g. cannot create a page if one already exists at that location).
* `3XXX` are for issues with the user making this particular request.
  * `30XX` are for authentication errors.
    * Note that `InvalidAuthentication` is intentionally broad to limit giving attackers useful information when attempting to bypass authentication controls.
  * `31XX` are for permissions errors (e.g. cannot edit a locked page).
* `4XXX`, `5XXX`, and `6XXX` are all for client / request errors. These are errors which result from the data being passed into the request being incorrect in some way. Naturally, errors for "not found" and "exists" are in the 2000s, not here.
  * `4XXX` is for "core objects". These are concepts that are high-level or central to Wikijump's data model.
    * `40XX` are for general errors. These error cases should be avoided when writing code and only used for situations where adding new error cases would be overkill.
    * `41XX` are for errors related to user data or state.
    * `42XX` are for errors related to sites.
    * `43XX` are for errors related to pages.
    * `44XX` are for errors related to files.
  * `5XXX` are for "ancillary objects".
    * `50XX` are for errors related to locales.
    * `51XX` are for errors related to filters.
    * `52XX` are for errors related to blobs.
    * `53XX` are for errors related to messages.
    * `54XX` are for errors related to domains.
  * `6XXX` are for "composite data objects". These are groups of existing kinds of data objects which are linked together, associated, or grouped in some manner.
    * `60XX` are for errors related to relations. (See `RelationService` for more information)

This should make it easier to add new error cases in the future since new entries can be appended to their respective sublist. For instance, a new case involving something to do with file operations can go under the next 44XX number.

Note that we have not yet stabilized the error code system, so backwards-incompatible changes are acceptable. Once officially marked as stable, future changes need to be compatible. Removed error cases need to have their error code left unused, and new error codes should be added with the next-highest value in its group.
