### PR TITLE
Rename two deepwell methods from 'delete -> 'remove'

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -257,13 +257,13 @@ async fn build_module(app_state: ServerState) -> anyhow::Result<RpcModule<Server
 
     // Site custom domain
     register!("custom_domain_create", site_custom_domain_create);
-    register!("custom_domain_delete", site_custom_domain_delete);
+    register!("custom_domain_remove", site_custom_domain_remove);
     register!("custom_domain_list", site_custom_domain_list);
 
     // Site membership
     register!("member_set", membership_set);
     register!("member_get", membership_get);
-    register!("member_delete", membership_delete);
+    register!("member_remove", membership_remove);
 
     // Category
     register!("category_get", category_get);

--- a/deepwell/src/endpoints/domain.rs
+++ b/deepwell/src/endpoints/domain.rs
@@ -43,7 +43,7 @@ pub async fn site_custom_domain_create(
 }
 
 // TODO rename
-pub async fn site_custom_domain_delete(
+pub async fn site_custom_domain_remove(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
 ) -> Result<()> {

--- a/deepwell/src/endpoints/site_member.rs
+++ b/deepwell/src/endpoints/site_member.rs
@@ -38,7 +38,7 @@ pub async fn membership_set(
     RelationService::create_site_member(ctx, input).await
 }
 
-pub async fn membership_delete(
+pub async fn membership_remove(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
 ) -> Result<RelationModel> {


### PR DESCRIPTION
For consistency with their service method names, this PR renames some API methods to be `remove_xxx` instead of `delete_xxx`.

I am keeping the "delete" verb for "non-fungible objects", like pages, users, files, etc., which are not smaller data objects which can be comparatively easily re-instated by creating a new instance (what I term "fungible objects", e.g. page votes, relations).