### PR TITLE
Upgrade codecov-action to v5

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -100,7 +100,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: deepwell/target/coverage/cobertura.xml
-          flags: deepwell
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -96,10 +96,13 @@ jobs:
         run: cd deepwell && cargo tarpaulin
 
       - name: Export Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          directory: deepwell/target/coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: deepwell/target/coverage/cobertura.xml
           flags: deepwell
+          fail_ci_if_error: true
+          verbose: true
 
   clippy_lint:
     name: Lint


### PR DESCRIPTION
Apparently this has been quite out-of-date. This PR upgrades the coverage step. The @codecov comment below shows that the step works as expected (naturally, with an extremely outdated prior coverage report to compare against).

See also https://github.com/scpwiki/ftml/pull/75.