### PR TITLE
[chore] Upgrade ftml version

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "ftml"
-version = "1.34.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226e3053393955786b12ea0a37b0cdbf43145a0a66bdc1131254e731aba3f8c1"
+checksum = "6a62fbbfaea430617de5f347ec332d8b28032195b3cfa7c9be7d00e959d9523b"
 dependencies = [
  "built",
  "cfg-if",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -32,7 +32,7 @@ femme = "2"
 filemagic = "0.13"
 fluent = "0.17"
 fluent-syntax = "0"
-ftml = { version = "1.33", features = ["mathml"] }
+ftml = { version = "1.36" }
 futures = { version = "0.3", features = ["async-await"], default-features = false }
 hex = { version = "0.4", features = ["serde"] }
 hostname = "0.4"


### PR DESCRIPTION
This takes us from 1.33 -> 1.36, capturing several fixes and improvements made between these two versions.

I also remove the features since both `html` and `mathml` are enabled by default.