### PR TITLE
Remove U+2608/2609 characters from Fluent strings as wikitext

### DIFF
--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::site::Model as SiteModel;
 use crate::services::{PageRevisionService, PageService, RenderService, TextService};
 use crate::types::Reference;
-use crate::utils::split_category;
+use crate::utils::{char_replace_in_place, split_category};
 use fluent::{FluentArgs, FluentValue};
 use ftml::prelude::*;
 use ref_map::*;
@@ -164,10 +164,23 @@ impl SpecialPageService {
         args.set("category", fluent_str!(category));
         args.set("domain", fluent_str!(ctx.config().main_domain_no_dot));
 
-        let wikitext = ctx
+        let mut wikitext = ctx
             .localization()
-            .translate(locales, translate_key, &args)?;
+            .translate(locales, translate_key, &args)?
+            .into_owned();
 
-        Ok(wikitext.into_owned())
+        // Fluent adds U+2068 and U+2069 characters to assist text layout engines
+        // when dealing with LTR / RTL text. However, this causes parsing issues
+        // for us in wikitext, since these characters can gum up string concatenation
+        // cases like URL construction.
+        //
+        // So as a special case here, we strip out any of these characters.
+        // We don't remove these characters from other locale strings since they are
+        // a desired localization property of Fluent.
+        //
+        // See https://fluent-compiler.readthedocs.io/en/latest/usage.html#:~:text=You%20will%20notice%20the%20extra%20characters%20\u2068%20and%20\u2069%20in%20the%20output.
+        char_replace_in_place(&mut wikitext, &['\u{2068}', '\u{2069}'], "");
+
+        Ok(wikitext)
     }
 }

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -26,8 +26,23 @@ static LEADING_TRAILING_SPACES: LazyLock<Regex> =
 
 // General replacement
 
+// TODO: When https://doc.rust-lang.org/stable/std/str/pattern/trait.Pattern.html is stabilized,
+//       replace all the non-regex cases with one function that uses the Pattern trait!
+
 /// Replaces all instances of the given fixed string in the buffer, in-place.
 pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
+    while let Some(index) = string.find(pattern) {
+        let end = index + replacement.len();
+        string.replace_range(index..end, replacement);
+    }
+}
+
+/// Replaces all instances of the given character(s) in the buffer, in-place.
+///
+/// This is distinct from a substring search, as any _individual_ instances of the characters
+/// are replaced. For instance, with an input string of `"foo/bar.xyz"` and a pattern of
+/// `&['/', '.']` being replaced with `"_"`, then the output will be `"foo_bar_xyz"`.
+pub fn char_replace_in_place(string: &mut String, pattern: &[char], replacement: &str) {
     while let Some(index) = string.find(pattern) {
         let end = index + replacement.len();
         string.replace_range(index..end, replacement);


### PR DESCRIPTION
There was a discussion in chat concerning an issue with our use of Fluent for constructing localized wikitext. The issue is that the U+2068 and U+2069 characters that Fluent adds for text layout reasons messes up our string creation in cases like URLs. These characters should not be present _only_ in the case wikitext case. (In normal text contexts they are important for internationalization).

So the solution is to strip these characters out only in `SpecialPageService::get_wikitext()`.