### PR TITLE
Fix in-place string substitution functions

### DIFF
--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -182,7 +182,7 @@ impl SpecialPageService {
         //
         // See https://fluent-compiler.readthedocs.io/en/latest/usage.html#:~:text=You%20will%20notice%20the%20extra%20characters%20\u2068%20and%20\u2069%20in%20the%20output.
         static CONTROL_CHAR_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new("[\u{2068}|\u{2069}]").unwrap());
+            LazyLock::new(|| Regex::new("[\u{2068}\u{2069}]").unwrap());
 
         regex_replace_in_place(&mut wikitext, &CONTROL_CHAR_REGEX, "");
 

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -22,11 +22,13 @@ use super::prelude::*;
 use crate::models::site::Model as SiteModel;
 use crate::services::{PageRevisionService, PageService, RenderService, TextService};
 use crate::types::Reference;
-use crate::utils::{char_replace_in_place, split_category};
+use crate::utils::{regex_replace_in_place, split_category};
 use fluent::{FluentArgs, FluentValue};
 use ftml::prelude::*;
 use ref_map::*;
+use regex::Regex;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 use unic_langid::LanguageIdentifier;
 
 #[derive(Debug)]
@@ -179,7 +181,10 @@ impl SpecialPageService {
         // a desired localization property of Fluent.
         //
         // See https://fluent-compiler.readthedocs.io/en/latest/usage.html#:~:text=You%20will%20notice%20the%20extra%20characters%20\u2068%20and%20\u2069%20in%20the%20output.
-        char_replace_in_place(&mut wikitext, &['\u{2068}', '\u{2069}'], "");
+        static CONTROL_CHAR_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new("[\u{2068}|\u{2069}]").unwrap());
+
+        regex_replace_in_place(&mut wikitext, &CONTROL_CHAR_REGEX, "");
 
         Ok(wikitext)
     }

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -34,7 +34,10 @@ static LEADING_TRAILING_SPACES: LazyLock<Regex> =
 /// # Panics
 /// Panics if `pattern` is an empty string.
 pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
-    assert!(!pattern.is_empty(), "Cannot call replace_in_place() with an empty string");
+    assert!(
+        !pattern.is_empty(),
+        "Cannot call replace_in_place() with an empty string"
+    );
 
     // Resume each iteration of search after the last replacement.
     // Avoids issues with infinite loops if the replacement contains the pattern.

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -125,6 +125,7 @@ fn test_regex_replace_in_place() {
         "After 12.5 years, he could only achieve a high score of -5000 in 2 games" => "After $NUMBER years, he could only achieve a high score of $NUMBER in $NUMBER games",
         r"-?[0-9]+(\.[0-9])?" => "$NUMBER",
     );
+    test!("猫の手も借りたい" => "猫手借", "[\u{3042}-\u{3094}]+" => "");
 }
 
 #[test]
@@ -141,6 +142,7 @@ fn test_trim_start_matches_in_place() {
     test!("_foo_" => "foo_", "_");
     test!(">>> foo" => "foo", ">>> ");
     test!("[foo]" => "[foo]", ">>> ");
+    test!("悪い🥭!" => "🥭!", "悪い");
 }
 
 #[test]
@@ -157,6 +159,7 @@ fn test_trim_end_matches_in_place() {
     test!("_foo_" => "_foo", "_");
     test!(">>> foo" => ">>> foo", ">>> ");
     test!("foo <<<" => "foo", " <<<");
+    test!("🥭 腐った" => "🥭 ", "腐った");
 }
 
 #[test]
@@ -181,4 +184,5 @@ fn test_trim_spaces_in_place() {
     test!("\t apple\n\n" => "apple");
     test!("banana         " => "banana");
     test!("\r\t  cherry" => "cherry");
+    test!(" 🥭  " => "🥭");
 }

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -68,8 +68,8 @@ pub fn trim_start_matches_in_place(string: &mut String, pattern: &str) {
 /// Removes the given suffix in the buffer, if it exists, in-place.
 #[allow(dead_code)]
 pub fn trim_end_matches_in_place(string: &mut String, pattern: &str) {
-    if string.starts_with(pattern) {
-        string.drain(pattern.len() - 1..);
+    if string.ends_with(pattern) {
+        string.drain(string.len() - pattern.len()..);
     }
 }
 

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -27,7 +27,7 @@ static LEADING_TRAILING_SPACES: LazyLock<Regex> =
 // General replacement
 
 // TODO: When https://doc.rust-lang.org/stable/std/str/pattern/trait.Pattern.html is stabilized,
-//       replace all the non-regex cases with one function that uses the Pattern trait!
+//       use it in the definition of replace_in_place() if possible.
 
 /// Replaces all instances of the given fixed string in the buffer, in-place.
 ///
@@ -44,18 +44,6 @@ pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
         let end = index + pattern.len();
         string.replace_range(index..end, replacement);
         start_index = end;
-    }
-}
-
-/// Replaces all instances of the given character(s) in the buffer, in-place.
-///
-/// This is distinct from a substring search, as any _individual_ instances of the characters
-/// are replaced. For instance, with an input string of `"foo/bar.xyz"` and a pattern of
-/// `&['/', '.']` being replaced with `"_"`, then the output will be `"foo_bar_xyz"`.
-pub fn char_replace_in_place(string: &mut String, pattern: &[char], replacement: &str) {
-    while let Some(index) = string.find(pattern) {
-        let end = index + replacement.len();
-        string.replace_range(index..end, replacement);
     }
 }
 

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -37,7 +37,7 @@ pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
     assert!(!pattern.is_empty(), "Cannot call replace_in_place() with an empty string");
 
     while let Some(index) = string.find(pattern) {
-        let end = index + replacement.len();
+        let end = index + pattern.len();
         string.replace_range(index..end, replacement);
     }
 }

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -46,7 +46,7 @@ pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
         let index = start_index + substr_index;
         let end = index + pattern.len();
         string.replace_range(index..end, replacement);
-        start_index = end;
+        start_index = end + replacement.len() - 1;
     }
 }
 

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -77,3 +77,41 @@ pub fn trim_end_matches_in_place(string: &mut String, pattern: &str) {
 pub fn trim_spaces_in_place(string: &mut String) {
     regex_replace_in_place(string, &LEADING_TRAILING_SPACES, "");
 }
+
+// Tests
+
+#[test]
+fn test_replace_in_place() {
+    macro_rules! test {
+        ($input:expr => $output:expr, $pattern:expr => $replacement:expr $(,)?) => {{
+            let mut string = str!($input);
+            replace_in_place(&mut string, $pattern, $replacement);
+            assert_eq!(string, $output, "Replaced contents did not match expected");
+        }};
+    }
+
+    test!("" => "", "/" => "_");
+    test!("foo/bar" => "foo + bar", "/" => " + ");
+    test!("apple banana cherry" => "pple bnn cherry", "a" => "");
+    test!("apple banana cherry" => "applexi banana chexirry", "e" => "exi");
+    test!("class pass hassle dash" => "cly py hyle dash", "ass" => "y");
+}
+
+#[test]
+fn test_regex_replace_in_place() {
+    macro_rules! test {
+        ($input:expr => $output:expr, $regex:expr => $replacement:expr $(,)?) => {{
+            let mut string = str!($input);
+            let regex = Regex::new($regex).expect("Unable to compile regex");
+            regex_replace_in_place(&mut string, &regex, $replacement);
+            assert_eq!(string, $output, "Replaced contents did not match expected");
+        }};
+    }
+
+    test!("apple banana cherry" => "axle banana chexy", r"p{2}|r{2}|n{2}" => "x");
+    test!("apple banana cherry" => "_ b_ cherry", r"a\w+" => "_");
+    test!(
+        "After 12.5 years, he could only achieve a high score of -5000 in 2 games" => "After $NUMBER years, he could only achieve a high score of $NUMBER in $NUMBER games",
+        r"-?[0-9]+(\.[0-9])?" => "$NUMBER",
+    );
+}

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -126,3 +126,59 @@ fn test_regex_replace_in_place() {
         r"-?[0-9]+(\.[0-9])?" => "$NUMBER",
     );
 }
+
+#[test]
+fn test_trim_start_matches_in_place() {
+    macro_rules! test {
+        ($input:expr => $output:expr, $pattern:expr $(,)?) => {{
+            let mut string = str!($input);
+            trim_start_matches_in_place(&mut string, $pattern);
+            assert_eq!(string, $output, "Trimmed contents did not match expected");
+        }};
+    }
+
+    test!("" => "", "_");
+    test!("_foo_" => "foo_", "_");
+    test!(">>> foo" => "foo", ">>> ");
+    test!("[foo]" => "[foo]", ">>> ");
+}
+
+#[test]
+fn test_trim_end_matches_in_place() {
+    macro_rules! test {
+        ($input:expr => $output:expr, $pattern:expr $(,)?) => {{
+            let mut string = str!($input);
+            trim_end_matches_in_place(&mut string, $pattern);
+            assert_eq!(string, $output, "Trimmed contents did not match expected");
+        }};
+    }
+
+    test!("" => "", "_");
+    test!("_foo_" => "_foo", "_");
+    test!(">>> foo" => ">>> foo", ">>> ");
+    test!("foo <<<" => "foo", " <<<");
+}
+
+#[test]
+fn test_trim_spaces_in_place() {
+    macro_rules! test {
+        ($input:expr => $output:expr $(,)?) => {{
+            let mut string = str!($input);
+            trim_spaces_in_place(&mut string);
+            assert_eq!(string, $output, "Trimmed contents did not match expected");
+        }};
+
+        // Unmodified case, where no substition occurs
+        ($input:expr $(,)?) => {
+            test!($input => $input)
+        };
+    }
+
+    test!("");
+    test!("foo");
+    test!(" foo" => "foo");
+    test!("foo " => "foo");
+    test!("\t apple\n\n" => "apple");
+    test!("banana         " => "banana");
+    test!("\r\t  cherry" => "cherry");
+}

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -30,7 +30,12 @@ static LEADING_TRAILING_SPACES: LazyLock<Regex> =
 //       replace all the non-regex cases with one function that uses the Pattern trait!
 
 /// Replaces all instances of the given fixed string in the buffer, in-place.
+///
+/// # Panics
+/// Panics if `pattern` is an empty string.
 pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
+    assert!(!pattern.is_empty(), "Cannot call replace_in_place() with an empty string");
+
     while let Some(index) = string.find(pattern) {
         let end = index + replacement.len();
         string.replace_range(index..end, replacement);
@@ -95,6 +100,13 @@ fn test_replace_in_place() {
     test!("apple banana cherry" => "pple bnn cherry", "a" => "");
     test!("apple banana cherry" => "applexi banana chexirry", "e" => "exi");
     test!("class pass hassle dash" => "cly py hyle dash", "ass" => "y");
+}
+
+#[test]
+#[should_panic]
+fn test_replace_in_place_empty() {
+    let mut string = str!("apple banana");
+    replace_in_place(&mut string, "", "cherry");
 }
 
 #[test]

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -36,9 +36,14 @@ static LEADING_TRAILING_SPACES: LazyLock<Regex> =
 pub fn replace_in_place(string: &mut String, pattern: &str, replacement: &str) {
     assert!(!pattern.is_empty(), "Cannot call replace_in_place() with an empty string");
 
-    while let Some(index) = string.find(pattern) {
+    // Resume each iteration of search after the last replacement.
+    // Avoids issues with infinite loops if the replacement contains the pattern.
+    let mut start_index = 0;
+    while let Some(substr_index) = &string[start_index..].find(pattern) {
+        let index = start_index + substr_index;
         let end = index + pattern.len();
         string.replace_range(index..end, replacement);
+        start_index = end;
     }
 }
 
@@ -98,8 +103,11 @@ fn test_replace_in_place() {
     test!("" => "", "/" => "_");
     test!("foo/bar" => "foo + bar", "/" => " + ");
     test!("apple banana cherry" => "pple bnn cherry", "a" => "");
-    test!("apple banana cherry" => "applexi banana chexirry", "e" => "exi");
+    test!("apple banana cherry" => "appluxi banana chuxirry", "e" => "uxi");
     test!("class pass hassle dash" => "cly py hyle dash", "ass" => "y");
+    // should terminate despite replacement value
+    test!("apple banana cherry" => "applexi banana chexirry", "e" => "exi");
+    test!("e ee eee" => "eye eyeeye eyeeyeeye", "e" => "eye");
 }
 
 #[test]


### PR DESCRIPTION
These were implemented quickly and only used for a few simple cases. Because no unit tests were put in place, some of these had some bugs. This PR fixes these issues and adds test cases to catch regressions.

Due to some of the complexity required to fix `char_replace_in_place()`, I scrapped it and am just using `regex_replace_in_place()` instead. This was meant to be a quick function definition, if that wasn't working then it's not worth it.