### PR TITLE
Refactor GitHub workflows for Rust

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -27,11 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -63,15 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Cargo Cache
         uses: actions/cache@v4
@@ -85,15 +78,9 @@ jobs:
       - name: System Dependencies
         run: sudo apt update && sudo apt install libmagic-dev
 
-      - name: Install Tarpaulin
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-tarpaulin
-          version: latest
-          use-tool-cache: true
-
       - name: Generate Coverage
-        run: cd deepwell && cargo tarpaulin
+        run: |
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
 
       - name: Export Coverage
         uses: codecov/codecov-action@v5
@@ -112,14 +99,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -132,8 +111,14 @@ jobs:
       - name: System Dependencies
         run: sudo apt update && sudo apt install libmagic-dev
 
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
+        with:
+          paths:
+            - deepwell
+
       - name: Rustfmt
         run: cd deepwell && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd deepwell && cargo clippy --no-deps
+        run: cd deepwell && cargo clippy --tests --no-deps

--- a/.github/workflows/locales.yaml
+++ b/.github/workflows/locales.yaml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -44,14 +39,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -65,4 +52,4 @@ jobs:
         run: cd locales/validator && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd locales/validator && cargo clippy --no-deps
+        run: cd locales/validator && cargo clippy --tests --no-deps

--- a/.github/workflows/wws.yaml
+++ b/.github/workflows/wws.yaml
@@ -22,11 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -51,14 +46,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Cargo Cache
         uses: actions/cache@v4
         with:
@@ -68,8 +55,14 @@ jobs:
             wws/target
           key: ${{ runner.os }}-wws-lint-${{ hashFiles('wws/**/Cargo.toml') }}
 
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
+        with:
+          paths:
+            - wws
+
       - name: Rustfmt
         run: cd wws && cargo fmt --all -- --check
 
       - name: Clippy
-        run: cd wws && cargo clippy --no-deps
+        run: cd wws && cargo clippy --tests --no-deps

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -27,7 +27,6 @@ color-backtrace = "0.7"
 cuid2 = "0.1"
 data-encoding = "2"
 dotenvy = "0.15"
-either = "1"
 femme = "2"
 filemagic = "0.13"
 fluent = "0.17"
@@ -76,7 +75,7 @@ pretty_assertions = "1"
 [build-dependencies]
 built = { version = "0.8", features = ["chrono", "git2"] }
 
-# Warnings and Errors
+# Lints
 
 [lints.rust]
 unsafe_code = "forbid"
@@ -84,6 +83,9 @@ missing_debug_implementations = "deny"
 
 [lints.clippy]
 large_enum_variant = "allow"
+
+[package.metadata.cargo-machete]
+ignored = ["rust-s3"]  # renamed to s3
 
 # Performance options
 

--- a/locales/validator/Cargo.toml
+++ b/locales/validator/Cargo.toml
@@ -10,8 +10,7 @@ exclude = [".gitignore"]
 
 version = "0.1.0"
 authors = ["Emmie Maeda <emmie.maeda@gmail.com>"]
-edition = "2021" # this is *not* the same as the current year
-rust-version = "1.56.0"
+edition = "2024"
 
 [dependencies]
 fluent-bundle = "0.15"

--- a/wws/Cargo.lock
+++ b/wws/Cargo.lock
@@ -3280,7 +3280,6 @@ dependencies = [
  "str-macro",
  "thiserror 2.0.17",
  "tokio",
- "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/wws/Cargo.toml
+++ b/wws/Cargo.toml
@@ -29,7 +29,6 @@ serde = { version = "1", features = ["derive"] }
 str-macro = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tower = "0.5"
 tower-http = { version = "0.6.6", features = ["add-extension", "compression-br", "compression-deflate", "compression-gzip", "compression-zstd", "normalize-path", "set-header", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -37,3 +36,8 @@ wikidot-normalize = "0.12"
 
 [build-dependencies]
 built = { version = "0.8", features = ["git2"] }
+
+# Lints
+
+[package.metadata.cargo-machete]
+ignored = ["rust-s3"]  # renamed to s3

--- a/wws/Cargo.toml
+++ b/wws/Cargo.toml
@@ -39,5 +39,9 @@ built = { version = "0.8", features = ["git2"] }
 
 # Lints
 
+[lints.rust]
+unsafe_code = "forbid"
+missing_debug_implementations = "deny"
+
 [package.metadata.cargo-machete]
 ignored = ["rust-s3"]  # renamed to s3


### PR DESCRIPTION
See https://github.com/scpwiki/ftml/pull/92. This PR takes the same basic changes to remove the deprecated `actions-rs` org and use native actions instead.