### PR TITLE
Add page delete pane

### DIFF
--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -102,6 +102,7 @@ export async function loadPage(
       "layout": {},
       "parents": {},
       "options": {},
+      "confirm": {},
 
       // Page history
       "wiki-page-revision": {
@@ -163,6 +164,7 @@ export async function loadPage(
       // Misc
       "wiki-page-edit": {},
       "wiki-page-parent": {},
+      "wiki-page-delete": {},
       "wiki-page-move": {},
       "wiki-page-move-new-slug": {},
       "wiki-page-no-render": {},

--- a/framerail/src/lib/types.ts
+++ b/framerail/src/lib/types.ts
@@ -13,5 +13,6 @@ export enum PagePane {
   Layout,
   Move,
   Parent,
-  Vote
+  Vote,
+  Delete
 }

--- a/framerail/src/routes/[slug]/[...extra]/DeletePane.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/DeletePane.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { page } from "$app/stores"
+  import { goto, invalidateAll } from "$app/navigation"
+  import { useErrorPopup, usePageLayoutState, usePagePaneState } from "$lib/stores"
+  import { Layout, PagePane } from "$lib/types"
+  let showErrorPopup = useErrorPopup()
+  let pagePaneState = usePagePaneState()
+  let pageLayout = usePageLayoutState()
+  let moveInputNewSlugElem: HTMLInputElement
+  enum DeleteOptions {
+    Move = "move",
+    Delete = "delete"
+  }
+  let delOption = DeleteOptions.Move
+
+  async function handleDelete() {
+    let fdata = new FormData()
+    fdata.set("site-id", $page.data.site.site_id)
+    fdata.set("page-id", $page.data.page.page_id)
+    fdata.set("last-revision-id", $page.data.page_revision.revision_id)
+    let res = await fetch(`/${$page.data.page.slug}`, {
+      method: "DELETE",
+      body: fdata
+    }).then((res) => res.json())
+    if (res?.message) {
+      showErrorPopup.set({
+        state: true,
+        message: res.message,
+        data: res.data
+      })
+    } else {
+      pagePaneState.set(PagePane.None)
+      invalidateAll()
+    }
+  }
+
+  async function handleMove() {
+    let form = document.getElementById("page-delete")
+    let fdata = new FormData(form)
+    let newSlug = fdata.get("new-slug")
+    if (!newSlug) {
+      moveInputNewSlugElem.classList.add("error")
+      return
+    } else {
+      moveInputNewSlugElem.classList.remove("error")
+    }
+    fdata.set("site-id", $page.data.site.site_id)
+    fdata.set("page-id", $page.data.page.page_id)
+    fdata.set("last-revision-id", $page.data.page_revision.revision_id)
+    let res = await fetch(`/${$page.data.page.slug}/move`, {
+      method: "POST",
+      body: fdata
+    }).then((res) => res.json())
+    if (res?.message) {
+      showErrorPopup.set({
+        state: true,
+        message: res.message,
+        data: res.data
+      })
+    } else {
+      goto(`/${newSlug}`, {
+        noScroll: true
+      })
+      pagePaneState.set(PagePane.None)
+    }
+  }
+</script>
+
+{#if $pageLayout === Layout.WIKIDOT}
+  <h1 class="page-delete-header">
+    {$page.data.internationalization?.["wiki-page-delete"]}
+  </h1>
+{:else}
+  <h2 class="page-delete-header">
+    {$page.data.internationalization?.["wiki-page-delete"]}
+  </h2>
+{/if}
+
+<form
+  id="page-delete"
+  class="page-delete"
+  method="POST"
+  on:submit|preventDefault={() => {
+    if (delOption === DeleteOptions.Move) handleMove()
+    else handleDelete()
+  }}
+>
+  <input
+    id="page-delete-option-move"
+    name="page-delete-option"
+    type="radio"
+    value={DeleteOptions.Move}
+    bind:group={delOption}
+  /><label class="page-delete-option option-move" for="page-delete-option-move"
+    >{$page.data.internationalization?.["wiki-page-move"]}</label
+  >
+  <input
+    id="page-delete-option-delete"
+    name="page-delete-option"
+    type="radio"
+    value={DeleteOptions.Delete}
+    bind:group={delOption}
+  /><label class="page-delete-option option-delete" for="page-delete-option-delete"
+    >{$page.data.internationalization?.["wiki-page-delete"]}</label
+  >
+  {#if delOption === DeleteOptions.Move}
+    <input
+      bind:this={moveInputNewSlugElem}
+      name="new-slug"
+      class="page-move-new-slug"
+      placeholder={$page.data.internationalization?.["wiki-page-move-new-slug"]}
+      type="text"
+      value={`deleted:${$page.data.page.slug}`}
+    />
+    <textarea
+      name="comments"
+      class="page-move-comments"
+      placeholder={$page.data.internationalization?.["wiki-page-revision-comments"]}
+    />
+  {/if}
+  {#if $pageLayout === Layout.WIKIDOT}
+    <div class="buttons">
+      <input
+        class="btn btn-danger"
+        type="button"
+        value={$page.data.internationalization?.cancel}
+        on:click|stopPropagation={() => {
+          pagePaneState.set(PagePane.None)
+        }}
+      />
+      <input
+        class="btn btn-primary"
+        type="submit"
+        value={$page.data.internationalization?.confirm}
+        on:click|stopPropagation
+      />
+    </div>
+  {:else}
+    <div class="action-row page-delete-actions">
+      <button
+        class="action-button page-delete-button button-cancel clickable"
+        type="button"
+        on:click|stopPropagation={() => {
+          pagePaneState.set(PagePane.None)
+        }}
+      >
+        {$page.data.internationalization?.cancel}
+      </button>
+      <button
+        class="action-button page-delete-button button-confirm clickable"
+        type="submit"
+        on:click|stopPropagation
+      >
+        {$page.data.internationalization?.confirm}
+      </button>
+    </div>
+  {/if}
+</form>
+
+<style lang="scss">
+  .page-delete {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+    justify-content: stretch;
+    width: 100%;
+    padding: 0 0 2em;
+  }
+</style>

--- a/framerail/src/routes/[slug]/[...extra]/index.ts
+++ b/framerail/src/routes/[slug]/[...extra]/index.ts
@@ -1,3 +1,4 @@
+export { default as DeletePane } from "./DeletePane.svelte"
 export { default as EditorPane } from "./EditorPane.svelte"
 export { default as FilePane } from "./FilePane.svelte"
 export { default as HistoryPane } from "./HistoryPane.svelte"

--- a/framerail/src/routes/[slug]/[...extra]/page.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { page } from "$app/stores"
-  import { goto, invalidateAll } from "$app/navigation"
+  import { goto } from "$app/navigation"
   import { onMount } from "svelte"
-  import { useErrorPopup, usePageLayoutState, usePagePaneState } from "$lib/stores"
+  import { usePageLayoutState, usePagePaneState } from "$lib/stores"
   import { Layout, PagePane } from "$lib/types"
   import {
     EditorPane,
@@ -11,9 +11,9 @@
     LayoutPane,
     MovePane,
     ParentPane,
-    VotePane
+    VotePane,
+    DeletePane
   } from "."
-  let showErrorPopup = useErrorPopup()
   let pagePaneState = usePagePaneState()
   let pageLayout = usePageLayoutState()
 
@@ -21,24 +21,6 @@
   let showPageOptions = false
   let showRevision = false
   let revision: Record<string, any> = {}
-
-  async function handleDelete() {
-    let fdata = new FormData()
-    fdata.set("site-id", $page.data.site.site_id)
-    fdata.set("page-id", $page.data.page.page_id)
-    fdata.set("last-revision-id", $page.data.page_revision.revision_id)
-    let res = await fetch(`/${$page.data.page.slug}`, {
-      method: "DELETE",
-      body: fdata
-    }).then((res) => res.json())
-    if (res?.message) {
-      showErrorPopup.set({
-        state: true,
-        message: res.message,
-        data: res.data
-      })
-    } else invalidateAll()
-  }
 
   function navigateEdit() {
     let options: string[] = []
@@ -256,7 +238,10 @@
           class="btn btn-default"
           href="javascript:;"
           type="button"
-          on:click={handleDelete}
+          on:click={() => {
+            showSource = false
+            pagePaneState.set(PagePane.Delete)
+          }}
         >
           {$page.data.internationalization?.delete}
         </a>
@@ -296,6 +281,8 @@
         <FilePane />
       {:else if $pagePaneState === PagePane.History}
         <HistoryPane {setRevision} {setShowRevision} />
+      {:else if $pagePaneState === PagePane.Delete}
+        <DeletePane />
       {/if}
     </div>
   {/if}
@@ -385,7 +372,9 @@
       <button
         class="action-button editor-button button-delete clickable"
         type="button"
-        on:click={handleDelete}
+        on:click={() => {
+          pagePaneState.set(PagePane.Delete)
+        }}
       >
         {$page.data.internationalization?.delete}
       </button>
@@ -454,6 +443,8 @@
     <FilePane />
   {:else if $pagePaneState === PagePane.History}
     <HistoryPane {setRevision} {setShowRevision} />
+  {:else if $pagePaneState === PagePane.Delete}
+    <DeletePane />
   {/if}
 {/if}
 

--- a/locales/fluent/base/en.ftl
+++ b/locales/fluent/base/en.ftl
@@ -31,6 +31,7 @@ cancel = Cancel
 change = Change
 clear = clear
 close = Close
+confirm = Confirm
 dashboard = Dashboard
 delete = Delete
 docs = Docs

--- a/locales/fluent/base/zh_Hans.ftl
+++ b/locales/fluent/base/zh_Hans.ftl
@@ -30,6 +30,7 @@ cancel = 取消
 change = 修改
 clear = 清空
 close = 关闭
+confirm = 确认
 dashboard = 仪表盘
 delete = 删除
 docs = 文档

--- a/locales/fluent/wiki-page/en.ftl
+++ b/locales/fluent/wiki-page/en.ftl
@@ -62,6 +62,8 @@ wiki-page-layout = Page layout
   .wikidot = Wikidot (Legacy)
   .wikijump = Wikijump
 
+wiki-page-delete = Delete page
+
 wiki-page-restore = Restore page
 
 wiki-page-restore-select = Select page to restore

--- a/locales/fluent/wiki-page/zh_Hans.ftl
+++ b/locales/fluent/wiki-page/zh_Hans.ftl
@@ -62,6 +62,8 @@ wiki-page-layout = 页面布局
   .wikidot = Wikidot（旧）
   .wikijump = Wikijump
 
+wiki-page-delete = 删除页面
+
 wiki-page-restore = 恢复页面
 
 wiki-page-restore-select = 选择需恢复的页面


### PR DESCRIPTION
This adds a pane for page options > delete, giving the operator the options of moving the page to `deleted` category or deleting it entirely. Currently no second confirmation is done for deleting the page.