### PR TITLE
[WJ-1285] Don't allow rollback to expose hidden fields

### DIFF
--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -508,9 +508,6 @@ impl FileService {
             FileRevisionService::get_latest(ctx, site_id, page_id, file_id),
         )?;
 
-        // TODO Handle hidden fields, see https://scuttle.atlassian.net/browse/WJ-1285
-        let _ = target_revision.hidden;
-
         // Check last revision ID
         check_last_revision(&last_revision, last_revision_id)?;
 
@@ -520,13 +517,19 @@ impl FileService {
             s3_hash,
             mime,
             size,
+            hidden,
             ..
         } = target_revision;
+
+        let hide_name = hidden.iter().any(|field| field == "name");
+        let hide_s3_hash = hidden.iter().any(|field| field == "s3_hash");
+        let hide_mime = hidden.iter().any(|field| field == "mime");
+        let hide_size = hidden.iter().any(|field| field == "size");
 
         let mut new_name = ActiveValue::NotSet;
 
         // Check name change
-        if last_revision.name != name {
+        if !hide_name && last_revision.name != name {
             Self::check_conflicts(ctx, page_id, &name, "rollback").await?;
             new_name = ActiveValue::Set(name.clone());
 
@@ -539,12 +542,22 @@ impl FileService {
         //
         // Copy the body of the target revision
 
-        let blob = FileBlob {
-            s3_hash: slice_to_blob_hash(&s3_hash),
-            mime,
-            size,
-            // in a rollback, by definition the blob was already uploaded
-            blob_created: false,
+        let blob = if hide_s3_hash || hide_mime || hide_size {
+            Maybe::Unset
+        } else {
+            Maybe::Set(FileBlob {
+                s3_hash: slice_to_blob_hash(&s3_hash),
+                mime,
+                size,
+                // in a rollback, by definition the blob was already uploaded
+                blob_created: false,
+            })
+        };
+
+        let name_body = if hide_name {
+            Maybe::Unset
+        } else {
+            Maybe::Set(name)
         };
 
         let revision_input = CreateFileRevision {
@@ -555,8 +568,8 @@ impl FileService {
             revision_comments,
             revision_type: FileRevisionType::Rollback,
             body: CreateFileRevisionBody {
-                name: Maybe::Set(name),
-                blob: Maybe::Set(blob),
+                name: name_body,
+                blob,
                 page_id: Maybe::Unset, // rollbacks should never move files
             },
         };

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -561,16 +561,31 @@ impl PageService {
             PageRevisionService::get_latest(ctx, site_id, page_id),
         )?;
 
-        // TODO Handle hidden fields, see https://scuttle.atlassian.net/browse/WJ-1285
-        let _ = target_revision.hidden;
-
         // Check last revision ID
         check_last_revision(Some(&last_revision), latest_revision_id, last_revision_id)?;
 
+        let PageRevisionModel {
+            wikitext_hash,
+            title,
+            alt_title,
+            tags,
+            hidden,
+            ..
+        } = target_revision;
+
+        let hide_wikitext = hidden.iter().any(|field| field == "wikitext");
+        let hide_title = hidden.iter().any(|field| field == "title");
+        let hide_alt_title = hidden.iter().any(|field| field == "alt_title");
+        let hide_tags = hidden.iter().any(|field| field == "tags");
+
         // NOTE: we can't just copy the wikitext_hash because we
-        //       need its actual value for rendering.
+        //       need its actual value for rendering unless it has been hidden.
         //       This isn't run here, but in PageRevisionService::create().
-        let wikitext = TextService::get(ctx, &target_revision.wikitext_hash).await?;
+        let wikitext = if hide_wikitext {
+            Maybe::Unset
+        } else {
+            Maybe::Set(TextService::get(ctx, &wikitext_hash).await?)
+        };
 
         // Create new revision
         //
@@ -581,10 +596,18 @@ impl PageService {
             revision_type: PageRevisionType::Rollback,
             comments,
             body: CreatePageRevisionBody {
-                wikitext: Maybe::Set(wikitext),
-                title: Maybe::Set(target_revision.title),
-                alt_title: Maybe::Set(target_revision.alt_title),
-                tags: Maybe::Set(target_revision.tags),
+                wikitext,
+                title: if hide_title { Maybe::Unset } else { Maybe::Set(title) },
+                alt_title: if hide_alt_title {
+                    Maybe::Unset
+                } else {
+                    Maybe::Set(alt_title)
+                },
+                tags: if hide_tags {
+                    Maybe::Unset
+                } else {
+                    Maybe::Set(tags)
+                },
                 slug: Maybe::Unset, // rollbacks should never move a page
             },
         };


### PR DESCRIPTION
[Fixes WJ-1285.](https://scuttle.atlassian.net/jira/software/c/projects/WJ/issues/?jql=project%20%3D%20%22WJ%22%20ORDER%20BY%20created%20DESC&selectedIssue=WJ-1285)

Rollbacks could rehydrate fields that moderators previously hid. This patch makes rollback respect revision.hidden for both pages and files.

Page rollback:
- Skip wikitext restore when 'wikitext' is hidden.
- Only restore title, alt_title, tags if they are not hidden.

File rollback:
- Only restore name, s3_hash, mime, size when they are not hidden.

Field names reflect the existing hidden contract used in page/file endpoints.

Prevents rollback from exposing suppressed content. No tests requested.