### PR TITLE
WJ-1290: convert page attribution to relation

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -202,7 +202,6 @@ CREATE TABLE relation (
     deleted_by BIGINT REFERENCES "user"(user_id),
     deleted_at TIMESTAMP WITH TIME ZONE,
 
-    UNIQUE (relation_type, dest_type, dest_id, from_type, from_id, overwritten_at, deleted_at),
     CHECK ((overwritten_by IS NULL) = (overwritten_at IS NULL)),  -- ensure overwritten field consistency
     CHECK ((deleted_by IS NULL) = (deleted_at IS NULL)),          -- ensure deleted field consistency
     CHECK (
@@ -210,6 +209,24 @@ CREATE TABLE relation (
         ((overwritten_by IS NULL) != (deleted_at IS NULL))        -- or they are overwritten XOR deleted
     )
 );
+
+CREATE UNIQUE INDEX relation_unique_general_active
+    ON relation (relation_type, dest_type, dest_id, from_type, from_id, overwritten_at, deleted_at)
+    WHERE relation_type <> 'page-attribution';
+
+CREATE UNIQUE INDEX relation_unique_page_attribution_active
+    ON relation (
+        relation_type,
+        dest_type,
+        dest_id,
+        from_type,
+        from_id,
+        (metadata ->> 'attribution_type'),
+        (metadata ->> 'attribution_date'),
+        coalesce(overwritten_at, 'infinity'),
+        coalesce(deleted_at, 'infinity')
+    )
+    WHERE relation_type = 'page-attribution';
 
 --
 -- Session
@@ -368,18 +385,6 @@ CREATE TABLE page_parent (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 
     PRIMARY KEY (parent_page_id, child_page_id)
-);
-
-CREATE TABLE page_attribution (
-    page_id BIGINT REFERENCES page(page_id),
-    user_id BIGINT REFERENCES "user"(user_id),
-    -- Text enum describing the kind of attribution
-    -- Currently synced to Crom: 'author', 'rewrite', 'translator', 'maintainer'
-    attribution_type TEXT NOT NULL,
-    attribution_date DATE NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-
-    PRIMARY KEY (page_id, user_id, attribution_type, attribution_date)
 );
 
 CREATE TABLE page_lock (

--- a/deepwell/src/models/mod.rs
+++ b/deepwell/src/models/mod.rs
@@ -15,7 +15,6 @@ pub mod message_recipient;
 pub mod message_record;
 pub mod message_report;
 pub mod page;
-pub mod page_attribution;
 pub mod page_category;
 pub mod page_connection;
 pub mod page_connection_missing;

--- a/deepwell/src/models/page.rs
+++ b/deepwell/src/models/page.rs
@@ -31,8 +31,6 @@ pub enum Relation {
     File,
     #[sea_orm(has_many = "super::file_revision::Entity")]
     FileRevision,
-    #[sea_orm(has_many = "super::page_attribution::Entity")]
-    PageAttribution,
     #[sea_orm(
         belongs_to = "super::page_category::Entity",
         from = "Column::PageCategoryId",
@@ -78,12 +76,6 @@ impl Related<super::file::Entity> for Entity {
 impl Related<super::file_revision::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::FileRevision.def()
-    }
-}
-
-impl Related<super::page_attribution::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::PageAttribution.def()
     }
 }
 

--- a/deepwell/src/models/prelude.rs
+++ b/deepwell/src/models/prelude.rs
@@ -12,7 +12,6 @@ pub use super::message_recipient::Entity as MessageRecipient;
 pub use super::message_record::Entity as MessageRecord;
 pub use super::message_report::Entity as MessageReport;
 pub use super::page::Entity as Page;
-pub use super::page_attribution::Entity as PageAttribution;
 pub use super::page_category::Entity as PageCategory;
 pub use super::page_connection::Entity as PageConnection;
 pub use super::page_connection_missing::Entity as PageConnectionMissing;

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -70,8 +70,6 @@ pub enum Relation {
     MessageRecipient,
     #[sea_orm(has_many = "super::message_record::Entity")]
     MessageRecord,
-    #[sea_orm(has_many = "super::page_attribution::Entity")]
-    PageAttribution,
     #[sea_orm(has_many = "super::page_lock::Entity")]
     PageLock,
     #[sea_orm(has_many = "super::page_revision::Entity")]
@@ -125,12 +123,6 @@ impl Related<super::message_recipient::Entity> for Entity {
 impl Related<super::message_record::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::MessageRecord.def()
-    }
-}
-
-impl Related<super::page_attribution::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::PageAttribution.def()
     }
 }
 

--- a/deepwell/src/services/mod.rs
+++ b/deepwell/src/services/mod.rs
@@ -111,7 +111,6 @@ pub use self::message_report::MessageReportService;
 pub use self::mfa::MfaService;
 pub use self::outdate::OutdateService;
 pub use self::page::PageService;
-// TODO convert page attribution to a type of relation
 pub use self::page_query::PageQueryService;
 pub use self::page_revision::PageRevisionService;
 pub use self::parent::ParentService;

--- a/deepwell/src/services/relation/mod.rs
+++ b/deepwell/src/services/relation/mod.rs
@@ -43,6 +43,7 @@ mod prelude {
 #[macro_use]
 mod macros;
 
+mod page_attribution;
 mod page_star;
 mod page_watch;
 mod site_ban;
@@ -54,6 +55,7 @@ mod user_bot_owner;
 mod user_contact;
 mod user_follow;
 
+pub use self::page_attribution::*;
 pub use self::page_star::*;
 pub use self::page_watch::*;
 pub use self::site_ban::*;

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -21,7 +21,7 @@
 use super::prelude::*;
 use time::Date;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PageAttributionKind {
     Author,
@@ -30,7 +30,7 @@ pub enum PageAttributionKind {
     Maintainer,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PageAttributionMetadata {
     pub attribution_type: PageAttributionKind,
     pub attribution_date: Date,
@@ -80,8 +80,17 @@ impl RelationService {
             .is_some();
 
         if already_exists {
+            debug!(
+                "Page attribution already exists for page {} user {} ({:?} @ {})",
+                page_id, user_id, metadata.attribution_type, metadata.attribution_date,
+            );
             return Ok(());
         }
+
+        debug!(
+            "Creating page attribution for page {} user {} ({:?} @ {})",
+            page_id, user_id, metadata.attribution_type, metadata.attribution_date,
+        );
 
         RelationType::PageAttribution
             .types()

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -1,0 +1,134 @@
+/*
+ * services/relation/page_attribution.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2025 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use time::Date;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PageAttributionKind {
+    Author,
+    Rewrite,
+    Translator,
+    Maintainer,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PageAttributionMetadata {
+    pub attribution_type: PageAttributionKind,
+    pub attribution_date: Date,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CreatePageAttribution {
+    pub page_id: i64,
+    pub user_id: i64,
+    pub metadata: PageAttributionMetadata,
+    pub created_by: i64,
+}
+
+impl RelationService {
+    /// Creates a page attribution relation without overwriting other attributions
+    /// for the same page / user combination. This mirrors the legacy uniqueness of
+    /// (page_id, user_id, attribution_type, attribution_date).
+    #[allow(dead_code)] // TEMP
+    pub async fn create_page_attribution(
+        ctx: &ServiceContext<'_>,
+        CreatePageAttribution {
+            page_id,
+            user_id,
+            metadata,
+            created_by,
+        }: CreatePageAttribution,
+    ) -> Result<()> {
+        let txn = ctx.transaction();
+
+        let metadata_json = serde_json::to_value(&metadata)?;
+        let already_exists = Relation::find()
+            .filter(
+                Condition::all()
+                    .add(relation::Column::RelationType.eq(
+                        RelationType::PageAttribution.value(),
+                    ))
+                    .add(relation::Column::DestType.eq(RelationObjectType::Page))
+                    .add(relation::Column::DestId.eq(page_id))
+                    .add(relation::Column::FromType.eq(RelationObjectType::User))
+                    .add(relation::Column::FromId.eq(user_id))
+                    .add(relation::Column::Metadata.eq(metadata_json.clone()))
+                    .add(relation::Column::OverwrittenAt.is_null())
+                    .add(relation::Column::DeletedAt.is_null()),
+            )
+            .one(txn)
+            .await?
+            .is_some();
+
+        if already_exists {
+            return Ok(());
+        }
+
+        RelationType::PageAttribution
+            .types()
+            .check(RelationObjectType::Page, RelationObjectType::User);
+
+        let model = relation::ActiveModel {
+            relation_type: Set(str!(RelationType::PageAttribution.value())),
+            dest_type: Set(RelationObjectType::Page),
+            dest_id: Set(page_id),
+            from_type: Set(RelationObjectType::User),
+            from_id: Set(user_id),
+            metadata: Set(metadata_json),
+            created_by: Set(created_by),
+            ..Default::default()
+        };
+
+        model.insert(txn).await?;
+        Ok(())
+    }
+
+    #[allow(dead_code)] // TEMP
+    pub async fn page_attribution_exists(
+        ctx: &ServiceContext<'_>,
+        page_id: i64,
+        user_id: i64,
+        metadata: &PageAttributionMetadata,
+    ) -> Result<bool> {
+        let txn = ctx.transaction();
+        let metadata_json = serde_json::to_value(metadata)?;
+        let exists = Relation::find()
+            .filter(
+                Condition::all()
+                    .add(relation::Column::RelationType.eq(
+                        RelationType::PageAttribution.value(),
+                    ))
+                    .add(relation::Column::DestType.eq(RelationObjectType::Page))
+                    .add(relation::Column::DestId.eq(page_id))
+                    .add(relation::Column::FromType.eq(RelationObjectType::User))
+                    .add(relation::Column::FromId.eq(user_id))
+                    .add(relation::Column::Metadata.eq(metadata_json))
+                    .add(relation::Column::OverwrittenAt.is_null())
+                    .add(relation::Column::DeletedAt.is_null()),
+            )
+            .one(txn)
+            .await?
+            .is_some();
+
+        Ok(exists)
+    }
+}

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -46,8 +46,9 @@ pub struct CreatePageAttribution {
 
 impl RelationService {
     /// Creates a page attribution relation without overwriting other attributions
-    /// for the same page / user combination. This mirrors the legacy uniqueness of
-    /// (page_id, user_id, attribution_type, attribution_date).
+    /// for the same page / user combination. This mirrors the unique constraint of
+    /// (page_id, user_id, attribution_type, attribution_date) from the former
+    /// dedicated table.
     #[allow(dead_code)] // TEMP
     pub async fn create_page_attribution(
         ctx: &ServiceContext<'_>,

--- a/deepwell/src/services/relation/structs.rs
+++ b/deepwell/src/services/relation/structs.rs
@@ -133,6 +133,7 @@ pub enum RelationType {
     SiteMember,
     PageStar,
     PageWatch,
+    PageAttribution,
     UserFollow,
     #[allow(dead_code)] // TEMP
     UserContact,
@@ -155,6 +156,7 @@ impl RelationType {
             RelationType::SiteMember => "member",
             RelationType::PageStar => "star",
             RelationType::PageWatch => "watch",
+            RelationType::PageAttribution => "page-attribution",
             RelationType::UserFollow => "follow",
             RelationType::UserContact => "contact",
             RelationType::UserContactRequest => "contact-request",
@@ -180,6 +182,7 @@ impl RelationType {
             RelationType::SiteMember => t!(Site, User),
             RelationType::PageStar => t!(Page, User),
             RelationType::PageWatch => t!(Page, User),
+            RelationType::PageAttribution => t!(Page, User),
             RelationType::UserFollow => t!(User, User),
             RelationType::UserContact => t!(User, User),
             RelationType::UserContactRequest => t!(User, User),

--- a/install/local/postgres/health-check.sh
+++ b/install/local/postgres/health-check.sh
@@ -1,1 +1,7 @@
-../../common/postgres/health-check.sh
+#!/bin/sh
+
+# Database is running
+sudo -u wikijump pg_isready -d wikijump
+
+# Database is accessible via network
+sudo -u wikijump pg_isready -d wikijump -h localhost -p 5432

--- a/install/local/postgres/health-check.sh
+++ b/install/local/postgres/health-check.sh
@@ -1,7 +1,1 @@
-#!/bin/sh
-
-# Database is running
-sudo -u wikijump pg_isready -d wikijump
-
-# Database is accessible via network
-sudo -u wikijump pg_isready -d wikijump -h localhost -p 5432
+../../common/postgres/health-check.sh


### PR DESCRIPTION
Convert page attribution into the generic relation system.

- Remove the dedicated page_attribution table from the base schema.
- Add page-attribution relation type (page -> user) with metadata {attribution_type, attribution_date}.
- Enforce uniqueness via relation index on (relation_type, page, user, attribution_type, attribution_date).
- Drop SeaORM page_attribution model/references; wire new relation types/metadata.

Tests: run.