### PR TITLE
WJ-1206: add page attribution service and RPC endpoints

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -29,9 +29,9 @@
 use crate::config::{Config, Secrets};
 use crate::endpoints::{
     auth::*, blob::*, category::*, domain::*, email::*, file::*, file_revision::*,
-    info::*, link::*, locale::*, message::*, misc::*, page::*, page_revision::*,
-    parent::*, routing::*, site::*, site_member::*, special_error::*, text::*,
-    text_block::*, user::*, user_bot::*, view::*, vote::*,
+    info::*, link::*, locale::*, message::*, misc::*, page::*, page_attribution::*,
+    page_revision::*, parent::*, routing::*, site::*, site_member::*, special_error::*,
+    text::*, text_block::*, user::*, user_bot::*, view::*, vote::*,
 };
 use crate::locales::Localizations;
 use crate::services::blob::MimeAnalyzer;
@@ -283,6 +283,11 @@ async fn build_module(app_state: ServerState) -> anyhow::Result<RpcModule<Server
     register!("page_rerender", page_rerender);
     register!("page_restore", page_restore);
     register!("page_set_layout", page_set_layout);
+
+    // Page attributions
+    register!("page_attribution_get_page", page_attribution_get_page);
+    register!("page_attribution_update", page_attribution_update);
+    register!("page_attribution_delete", page_attribution_delete);
 
     // Page revisions
     register!("page_revision_create", page_revision_edit);

--- a/deepwell/src/endpoints/mod.rs
+++ b/deepwell/src/endpoints/mod.rs
@@ -55,6 +55,7 @@ pub mod locale;
 pub mod message;
 pub mod misc;
 pub mod page;
+pub mod page_attribution;
 pub mod page_revision;
 pub mod parent;
 pub mod routing;

--- a/deepwell/src/endpoints/page_attribution.rs
+++ b/deepwell/src/endpoints/page_attribution.rs
@@ -58,7 +58,7 @@ pub async fn page_attribution_update(
 pub async fn page_attribution_delete(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
-) -> Result<Vec<PageAttribution>> {
+) -> Result<()> {
     let input: ClearPageAttributions<'_> = params.parse()?;
 
     info!(

--- a/deepwell/src/endpoints/page_attribution.rs
+++ b/deepwell/src/endpoints/page_attribution.rs
@@ -20,17 +20,20 @@
 
 use super::prelude::*;
 use crate::services::relation::{
-    GetPageAttributions, PageAttribution, RelationService, RemovePageAttribution,
-    UpdatePageAttribution,
+    ClearPageAttributions, GetPageAttributions, PageAttribution, RelationService,
+    SetPageAttributions,
 };
 
 pub async fn page_attribution_get_page(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
 ) -> Result<Vec<PageAttribution>> {
-    let input: GetPageAttributions = params.parse()?;
+    let input: GetPageAttributions<'_> = params.parse()?;
 
-    info!("Getting page attributions for page {}", input.page_id);
+    info!(
+        "Getting page attributions for page {:?} on site {}",
+        input.page, input.site_id,
+    );
 
     RelationService::get_page_attributions(ctx, input).await
 }
@@ -38,31 +41,30 @@ pub async fn page_attribution_get_page(
 pub async fn page_attribution_update(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
-) -> Result<PageAttribution> {
-    let input: UpdatePageAttribution = params.parse()?;
+) -> Result<Vec<PageAttribution>> {
+    let input: SetPageAttributions<'_> = params.parse()?;
 
     info!(
-        "Updating page attribution for page {} user {} ({:?} @ {}) (relation {:?})",
-        input.page_id,
-        input.user_id,
-        input.metadata.attribution_type,
-        input.metadata.attribution_date,
-        input.relation_id,
+        "Setting {} page attributions for page {:?} on site {} (requested by {})",
+        input.attributions.len(),
+        input.page,
+        input.site_id,
+        input.updated_by,
     );
 
-    RelationService::update_page_attribution(ctx, input).await
+    RelationService::set_page_attributions(ctx, input).await
 }
 
 pub async fn page_attribution_delete(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
-) -> Result<PageAttribution> {
-    let input: RemovePageAttribution = params.parse()?;
+) -> Result<Vec<PageAttribution>> {
+    let input: ClearPageAttributions<'_> = params.parse()?;
 
     info!(
-        "Deleting page attribution relation {} (requested by {})",
-        input.relation_id, input.removed_by,
+        "Clearing page attributions for page {:?} on site {} (requested by {})",
+        input.page, input.site_id, input.removed_by,
     );
 
-    RelationService::remove_page_attribution(ctx, input).await
+    RelationService::clear_page_attributions(ctx, input).await
 }

--- a/deepwell/src/endpoints/page_attribution.rs
+++ b/deepwell/src/endpoints/page_attribution.rs
@@ -1,0 +1,68 @@
+/*
+ * endpoints/page_attribution.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2025 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use crate::services::relation::{
+    GetPageAttributions, PageAttribution, RelationService, RemovePageAttribution,
+    UpdatePageAttribution,
+};
+
+pub async fn page_attribution_get_page(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<Vec<PageAttribution>> {
+    let input: GetPageAttributions = params.parse()?;
+
+    info!("Getting page attributions for page {}", input.page_id);
+
+    RelationService::get_page_attributions(ctx, input).await
+}
+
+pub async fn page_attribution_update(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<PageAttribution> {
+    let input: UpdatePageAttribution = params.parse()?;
+
+    info!(
+        "Updating page attribution for page {} user {} ({:?} @ {}) (relation {:?})",
+        input.page_id,
+        input.user_id,
+        input.metadata.attribution_type,
+        input.metadata.attribution_date,
+        input.relation_id,
+    );
+
+    RelationService::update_page_attribution(ctx, input).await
+}
+
+pub async fn page_attribution_delete(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<PageAttribution> {
+    let input: RemovePageAttribution = params.parse()?;
+
+    info!(
+        "Deleting page attribution relation {} (requested by {})",
+        input.relation_id, input.removed_by,
+    );
+
+    RelationService::remove_page_attribution(ctx, input).await
+}

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -65,7 +65,7 @@ pub struct CreatePageAttribution {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct PageAttributionInput {
+pub struct PageAttributionEntry {
     pub user_id: i64,
     pub metadata: PageAttributionMetadata,
 }
@@ -75,7 +75,7 @@ pub struct SetPageAttributions<'a> {
     pub site_id: i64,
     pub page: Reference<'a>,
     pub updated_by: i64,
-    pub attributions: Vec<PageAttributionInput>,
+    pub attributions: Vec<PageAttributionEntry>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -204,7 +204,7 @@ impl RelationService {
         // Insert the new set.
         let mut created = Vec::with_capacity(attributions.len());
         let mut seen = BTreeSet::new();
-        for PageAttributionInput { user_id, metadata } in attributions {
+        for PageAttributionEntry { user_id, metadata } in attributions {
             if !seen.insert((user_id, metadata)) {
                 continue;
             }
@@ -234,7 +234,7 @@ impl RelationService {
             page,
             removed_by,
         }: ClearPageAttributions<'_>,
-    ) -> Result<Vec<PageAttribution>> {
+    ) -> Result<()> {
         let page = PageService::get(ctx, site_id, page).await?;
         let txn = ctx.transaction();
 
@@ -250,10 +250,11 @@ impl RelationService {
             .exec(txn)
             .await?;
 
-        Ok(Vec::new())
+        Ok(())
     }
 }
 
+/// Builds a condition for querying one specific page attribution entry.
 fn page_attribution_condition(
     page_id: i64,
     user_id: i64,
@@ -272,6 +273,7 @@ fn page_attribution_condition(
         .add(relation::Column::DeletedAt.is_null())
 }
 
+/// Builds a condition for querying all page attribution entries for a page.
 fn page_attributions_condition(page_id: i64) -> Condition {
     Condition::all()
         .add(relation::Column::RelationType.eq(

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -19,9 +19,12 @@
  */
 
 use super::prelude::*;
+use crate::services::PageService;
+use crate::types::Reference;
+use std::collections::BTreeSet;
 use time::{Date, OffsetDateTime};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum PageAttributionKind {
     Author,
@@ -30,7 +33,7 @@ pub enum PageAttributionKind {
     Maintainer,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageAttributionMetadata {
     pub attribution_type: PageAttributionKind,
     pub attribution_date: Date,
@@ -62,23 +65,30 @@ pub struct CreatePageAttribution {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct UpdatePageAttribution {
-    pub relation_id: Option<i64>,
-    pub page_id: i64,
+pub struct PageAttributionInput {
     pub user_id: i64,
     pub metadata: PageAttributionMetadata,
-    pub created_by: i64,
 }
 
-#[derive(Deserialize, Debug, Copy, Clone)]
-pub struct GetPageAttributions {
-    pub page_id: i64,
+#[derive(Deserialize, Debug, Clone)]
+pub struct SetPageAttributions<'a> {
+    pub site_id: i64,
+    pub page: Reference<'a>,
+    pub updated_by: i64,
+    pub attributions: Vec<PageAttributionInput>,
 }
 
-#[derive(Deserialize, Debug, Copy, Clone)]
-pub struct RemovePageAttribution {
-    pub relation_id: i64,
+#[derive(Deserialize, Debug, Clone)]
+pub struct ClearPageAttributions<'a> {
+    pub site_id: i64,
+    pub page: Reference<'a>,
     pub removed_by: i64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct GetPageAttributions<'a> {
+    pub site_id: i64,
+    pub page: Reference<'a>,
 }
 
 impl RelationService {
@@ -95,6 +105,7 @@ impl RelationService {
             created_by,
         }: CreatePageAttribution,
     ) -> Result<PageAttribution> {
+        let txn = ctx.transaction();
         let metadata_json = serde_json::to_value(&metadata)?;
 
         if let Some(model) =
@@ -105,7 +116,7 @@ impl RelationService {
                 page_id, user_id, metadata.attribution_type, metadata.attribution_date,
             );
 
-            return PageAttribution::try_from_model(model);
+            return PageAttribution::try_from(model);
         }
 
         debug!(
@@ -128,8 +139,8 @@ impl RelationService {
             ..Default::default()
         };
 
-        let model = model.insert(ctx.transaction()).await?;
-        PageAttribution::try_from_model(model)
+        let model = model.insert(txn).await?;
+        PageAttribution::try_from(model)
     }
 
     #[allow(dead_code)]
@@ -147,113 +158,99 @@ impl RelationService {
 
     pub async fn get_page_attributions(
         ctx: &ServiceContext<'_>,
-        GetPageAttributions { page_id }: GetPageAttributions,
+        GetPageAttributions { site_id, page }: GetPageAttributions<'_>,
     ) -> Result<Vec<PageAttribution>> {
-        debug!("Getting page attributions for page {}", page_id);
-
+        let page = PageService::get(ctx, site_id, page).await?;
         let txn = ctx.transaction();
         let models = Relation::find()
-            .filter(
-                Condition::all()
-                    .add(relation::Column::RelationType.eq(
-                        RelationType::PageAttribution.value(),
-                    ))
-                    .add(relation::Column::DestType.eq(RelationObjectType::Page))
-                    .add(relation::Column::FromType.eq(RelationObjectType::User))
-                    .add(relation::Column::DestId.eq(page_id))
-                    .add(relation::Column::OverwrittenAt.is_null())
-                    .add(relation::Column::DeletedAt.is_null()),
-            )
-            .order_by_asc(relation::Column::CreatedAt)
+            .filter(page_attributions_condition(page.page_id))
             .all(txn)
             .await?;
 
-        models
+        let mut attributions = models
             .into_iter()
-            .map(PageAttribution::try_from_model)
-            .collect()
+            .map(PageAttribution::try_from)
+            .collect::<Result<Vec<_>>>()?;
+
+        sort_attributions(&mut attributions);
+        Ok(attributions)
     }
 
-    pub async fn update_page_attribution(
+    pub async fn set_page_attributions(
         ctx: &ServiceContext<'_>,
-        UpdatePageAttribution {
-            relation_id,
-            page_id,
-            user_id,
-            metadata,
-            created_by,
-        }: UpdatePageAttribution,
-    ) -> Result<PageAttribution> {
-        let metadata_json = serde_json::to_value(&metadata)?;
+        SetPageAttributions {
+            site_id,
+            page,
+            updated_by,
+            attributions,
+        }: SetPageAttributions<'_>,
+    ) -> Result<Vec<PageAttribution>> {
+        let page = PageService::get(ctx, site_id, page).await?;
+        let txn = ctx.transaction();
 
-        let previous = match relation_id {
-            Some(relation_id) => {
-                let model = get_page_attribution_by_id(ctx, relation_id).await?;
-                debug!(
-                    "Updating existing page attribution relation {} for page {}",
-                    relation_id, model.dest_id,
-                );
-                Some(model)
-            }
-            None => None,
+        // Delete existing active attributions for this page.
+        let delete_model = relation::ActiveModel {
+            deleted_by: Set(Some(updated_by)),
+            deleted_at: Set(Some(now())),
+            ..Default::default()
         };
 
-        if let Some(model) =
-            find_page_attribution(ctx, page_id, user_id, &metadata_json).await?
-        {
-            if let Some(previous) = previous.as_ref() {
-                if previous.relation_id != model.relation_id {
-                    overwrite_page_attribution(ctx, previous.relation_id, created_by)
-                        .await?;
-                }
+        Relation::update_many()
+            .set(delete_model)
+            .filter(page_attributions_condition(page.page_id))
+            .exec(txn)
+            .await?;
+
+        // Insert the new set.
+        let mut created = Vec::with_capacity(attributions.len());
+        let mut seen = BTreeSet::new();
+        for PageAttributionInput { user_id, metadata } in attributions {
+            if !seen.insert((user_id, metadata)) {
+                continue;
             }
 
-            debug!(
-                "Page attribution already exists for page {} user {} ({:?} @ {})",
-                page_id, user_id, metadata.attribution_type, metadata.attribution_date,
-            );
+            let attribution = Self::create_page_attribution(
+                ctx,
+                CreatePageAttribution {
+                    page_id: page.page_id,
+                    user_id,
+                    metadata,
+                    created_by: updated_by,
+                },
+            )
+            .await?;
 
-            return PageAttribution::try_from_model(model);
+            created.push(attribution);
         }
 
-        if let Some(previous) = previous {
-            overwrite_page_attribution(ctx, previous.relation_id, created_by).await?;
-        }
-
-        Self::create_page_attribution(
-            ctx,
-            CreatePageAttribution {
-                page_id,
-                user_id,
-                metadata,
-                created_by,
-            },
-        )
-        .await
+        sort_attributions(&mut created);
+        Ok(created)
     }
 
-    pub async fn remove_page_attribution(
+    pub async fn clear_page_attributions(
         ctx: &ServiceContext<'_>,
-        RemovePageAttribution {
-            relation_id,
+        ClearPageAttributions {
+            site_id,
+            page,
             removed_by,
-        }: RemovePageAttribution,
-    ) -> Result<PageAttribution> {
-        let existing = get_page_attribution_by_id(ctx, relation_id).await?;
-        debug!(
-            "Removing page attribution relation {} for page {}",
-            relation_id, existing.dest_id,
-        );
+        }: ClearPageAttributions<'_>,
+    ) -> Result<Vec<PageAttribution>> {
+        let page = PageService::get(ctx, site_id, page).await?;
+        let txn = ctx.transaction();
 
-        let model = relation::ActiveModel {
-            relation_id: Set(relation_id),
+        let delete_model = relation::ActiveModel {
             deleted_by: Set(Some(removed_by)),
             deleted_at: Set(Some(now())),
             ..Default::default()
         };
 
-        let model = model.update(ctx.transaction()).await?;
-        PageAttribution::try_from_model(model)
+        Relation::update_many()
+            .set(delete_model)
+            .filter(page_attributions_condition(page.page_id))
+            .exec(txn)
+            .await?;
+
+        Ok(Vec::new())
     }
 }
 
@@ -271,6 +268,18 @@ fn page_attribution_condition(
         .add(relation::Column::FromType.eq(RelationObjectType::User))
         .add(relation::Column::FromId.eq(user_id))
         .add(relation::Column::Metadata.eq(metadata_json.clone()))
+        .add(relation::Column::OverwrittenAt.is_null())
+        .add(relation::Column::DeletedAt.is_null())
+}
+
+fn page_attributions_condition(page_id: i64) -> Condition {
+    Condition::all()
+        .add(relation::Column::RelationType.eq(
+            RelationType::PageAttribution.value(),
+        ))
+        .add(relation::Column::DestType.eq(RelationObjectType::Page))
+        .add(relation::Column::FromType.eq(RelationObjectType::User))
+        .add(relation::Column::DestId.eq(page_id))
         .add(relation::Column::OverwrittenAt.is_null())
         .add(relation::Column::DeletedAt.is_null())
 }
@@ -296,8 +305,10 @@ fn convert_model(model: RelationModel) -> Result<PageAttribution> {
     })
 }
 
-impl PageAttribution {
-    fn try_from_model(model: RelationModel) -> Result<Self> {
+impl TryFrom<RelationModel> for PageAttribution {
+    type Error = Error;
+
+    fn try_from(model: RelationModel) -> Result<Self> {
         convert_model(model)
     }
 }
@@ -316,44 +327,16 @@ async fn find_page_attribution(
         .map_err(Into::into)
 }
 
-async fn get_page_attribution_by_id(
-    ctx: &ServiceContext<'_>,
-    relation_id: i64,
-) -> Result<RelationModel> {
-    let txn = ctx.transaction();
-    let model = Relation::find()
-        .filter(
-            Condition::all()
-                .add(relation::Column::RelationId.eq(relation_id))
-                .add(relation::Column::DestType.eq(RelationObjectType::Page))
-                .add(relation::Column::FromType.eq(RelationObjectType::User))
-                .add(relation::Column::RelationType.eq(
-                    RelationType::PageAttribution.value(),
-                ))
-                .add(relation::Column::OverwrittenAt.is_null())
-                .add(relation::Column::DeletedAt.is_null()),
-        )
-        .one(txn)
-        .await?;
-
-    match model {
-        Some(model) => Ok(model),
-        None => Err(Error::RelationNotFound),
-    }
-}
-
-async fn overwrite_page_attribution(
-    ctx: &ServiceContext<'_>,
-    relation_id: i64,
-    overwritten_by: i64,
-) -> Result<()> {
-    let model = relation::ActiveModel {
-        relation_id: Set(relation_id),
-        overwritten_by: Set(Some(overwritten_by)),
-        overwritten_at: Set(Some(now())),
-        ..Default::default()
-    };
-
-    model.update(ctx.transaction()).await?;
-    Ok(())
+fn sort_attributions(attributions: &mut [PageAttribution]) {
+    attributions.sort_by(|a, b| {
+        b.metadata
+            .attribution_date
+            .cmp(&a.metadata.attribution_date)
+            .then_with(|| {
+                a.metadata
+                    .attribution_type
+                    .cmp(&b.metadata.attribution_type)
+            })
+            .then_with(|| a.user_id.cmp(&b.user_id))
+    });
 }

--- a/deepwell/src/services/relation/page_attribution.rs
+++ b/deepwell/src/services/relation/page_attribution.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use time::Date;
+use time::{Date, OffsetDateTime};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -36,6 +36,23 @@ pub struct PageAttributionMetadata {
     pub attribution_date: Date,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PageAttribution {
+    pub relation_id: i64,
+    pub page_id: i64,
+    pub user_id: i64,
+    pub created_by: i64,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+    pub overwritten_by: Option<i64>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub overwritten_at: Option<OffsetDateTime>,
+    pub deleted_by: Option<i64>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub deleted_at: Option<OffsetDateTime>,
+    pub metadata: PageAttributionMetadata,
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct CreatePageAttribution {
     pub page_id: i64,
@@ -44,12 +61,31 @@ pub struct CreatePageAttribution {
     pub created_by: i64,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct UpdatePageAttribution {
+    pub relation_id: Option<i64>,
+    pub page_id: i64,
+    pub user_id: i64,
+    pub metadata: PageAttributionMetadata,
+    pub created_by: i64,
+}
+
+#[derive(Deserialize, Debug, Copy, Clone)]
+pub struct GetPageAttributions {
+    pub page_id: i64,
+}
+
+#[derive(Deserialize, Debug, Copy, Clone)]
+pub struct RemovePageAttribution {
+    pub relation_id: i64,
+    pub removed_by: i64,
+}
+
 impl RelationService {
     /// Creates a page attribution relation without overwriting other attributions
     /// for the same page / user combination. This mirrors the unique constraint of
     /// (page_id, user_id, attribution_type, attribution_date) from the former
     /// dedicated table.
-    #[allow(dead_code)] // TEMP
     pub async fn create_page_attribution(
         ctx: &ServiceContext<'_>,
         CreatePageAttribution {
@@ -58,34 +94,18 @@ impl RelationService {
             metadata,
             created_by,
         }: CreatePageAttribution,
-    ) -> Result<()> {
-        let txn = ctx.transaction();
-
+    ) -> Result<PageAttribution> {
         let metadata_json = serde_json::to_value(&metadata)?;
-        let already_exists = Relation::find()
-            .filter(
-                Condition::all()
-                    .add(relation::Column::RelationType.eq(
-                        RelationType::PageAttribution.value(),
-                    ))
-                    .add(relation::Column::DestType.eq(RelationObjectType::Page))
-                    .add(relation::Column::DestId.eq(page_id))
-                    .add(relation::Column::FromType.eq(RelationObjectType::User))
-                    .add(relation::Column::FromId.eq(user_id))
-                    .add(relation::Column::Metadata.eq(metadata_json.clone()))
-                    .add(relation::Column::OverwrittenAt.is_null())
-                    .add(relation::Column::DeletedAt.is_null()),
-            )
-            .one(txn)
-            .await?
-            .is_some();
 
-        if already_exists {
+        if let Some(model) =
+            find_page_attribution(ctx, page_id, user_id, &metadata_json).await?
+        {
             debug!(
                 "Page attribution already exists for page {} user {} ({:?} @ {})",
                 page_id, user_id, metadata.attribution_type, metadata.attribution_date,
             );
-            return Ok(());
+
+            return PageAttribution::try_from_model(model);
         }
 
         debug!(
@@ -108,37 +128,232 @@ impl RelationService {
             ..Default::default()
         };
 
-        model.insert(txn).await?;
-        Ok(())
+        let model = model.insert(ctx.transaction()).await?;
+        PageAttribution::try_from_model(model)
     }
 
-    #[allow(dead_code)] // TEMP
+    #[allow(dead_code)]
     pub async fn page_attribution_exists(
         ctx: &ServiceContext<'_>,
         page_id: i64,
         user_id: i64,
         metadata: &PageAttributionMetadata,
     ) -> Result<bool> {
-        let txn = ctx.transaction();
         let metadata_json = serde_json::to_value(metadata)?;
-        let exists = Relation::find()
+        find_page_attribution(ctx, page_id, user_id, &metadata_json)
+            .await
+            .map(|relation| relation.is_some())
+    }
+
+    pub async fn get_page_attributions(
+        ctx: &ServiceContext<'_>,
+        GetPageAttributions { page_id }: GetPageAttributions,
+    ) -> Result<Vec<PageAttribution>> {
+        debug!("Getting page attributions for page {}", page_id);
+
+        let txn = ctx.transaction();
+        let models = Relation::find()
             .filter(
                 Condition::all()
                     .add(relation::Column::RelationType.eq(
                         RelationType::PageAttribution.value(),
                     ))
                     .add(relation::Column::DestType.eq(RelationObjectType::Page))
-                    .add(relation::Column::DestId.eq(page_id))
                     .add(relation::Column::FromType.eq(RelationObjectType::User))
-                    .add(relation::Column::FromId.eq(user_id))
-                    .add(relation::Column::Metadata.eq(metadata_json))
+                    .add(relation::Column::DestId.eq(page_id))
                     .add(relation::Column::OverwrittenAt.is_null())
                     .add(relation::Column::DeletedAt.is_null()),
             )
-            .one(txn)
-            .await?
-            .is_some();
+            .order_by_asc(relation::Column::CreatedAt)
+            .all(txn)
+            .await?;
 
-        Ok(exists)
+        models
+            .into_iter()
+            .map(PageAttribution::try_from_model)
+            .collect()
     }
+
+    pub async fn update_page_attribution(
+        ctx: &ServiceContext<'_>,
+        UpdatePageAttribution {
+            relation_id,
+            page_id,
+            user_id,
+            metadata,
+            created_by,
+        }: UpdatePageAttribution,
+    ) -> Result<PageAttribution> {
+        let metadata_json = serde_json::to_value(&metadata)?;
+
+        let previous = match relation_id {
+            Some(relation_id) => {
+                let model = get_page_attribution_by_id(ctx, relation_id).await?;
+                debug!(
+                    "Updating existing page attribution relation {} for page {}",
+                    relation_id, model.dest_id,
+                );
+                Some(model)
+            }
+            None => None,
+        };
+
+        if let Some(model) =
+            find_page_attribution(ctx, page_id, user_id, &metadata_json).await?
+        {
+            if let Some(previous) = previous.as_ref() {
+                if previous.relation_id != model.relation_id {
+                    overwrite_page_attribution(ctx, previous.relation_id, created_by)
+                        .await?;
+                }
+            }
+
+            debug!(
+                "Page attribution already exists for page {} user {} ({:?} @ {})",
+                page_id, user_id, metadata.attribution_type, metadata.attribution_date,
+            );
+
+            return PageAttribution::try_from_model(model);
+        }
+
+        if let Some(previous) = previous {
+            overwrite_page_attribution(ctx, previous.relation_id, created_by).await?;
+        }
+
+        Self::create_page_attribution(
+            ctx,
+            CreatePageAttribution {
+                page_id,
+                user_id,
+                metadata,
+                created_by,
+            },
+        )
+        .await
+    }
+
+    pub async fn remove_page_attribution(
+        ctx: &ServiceContext<'_>,
+        RemovePageAttribution {
+            relation_id,
+            removed_by,
+        }: RemovePageAttribution,
+    ) -> Result<PageAttribution> {
+        let existing = get_page_attribution_by_id(ctx, relation_id).await?;
+        debug!(
+            "Removing page attribution relation {} for page {}",
+            relation_id, existing.dest_id,
+        );
+
+        let model = relation::ActiveModel {
+            relation_id: Set(relation_id),
+            deleted_by: Set(Some(removed_by)),
+            deleted_at: Set(Some(now())),
+            ..Default::default()
+        };
+
+        let model = model.update(ctx.transaction()).await?;
+        PageAttribution::try_from_model(model)
+    }
+}
+
+fn page_attribution_condition(
+    page_id: i64,
+    user_id: i64,
+    metadata_json: &serde_json::Value,
+) -> Condition {
+    Condition::all()
+        .add(relation::Column::RelationType.eq(
+            RelationType::PageAttribution.value(),
+        ))
+        .add(relation::Column::DestType.eq(RelationObjectType::Page))
+        .add(relation::Column::DestId.eq(page_id))
+        .add(relation::Column::FromType.eq(RelationObjectType::User))
+        .add(relation::Column::FromId.eq(user_id))
+        .add(relation::Column::Metadata.eq(metadata_json.clone()))
+        .add(relation::Column::OverwrittenAt.is_null())
+        .add(relation::Column::DeletedAt.is_null())
+}
+
+fn convert_model(model: RelationModel) -> Result<PageAttribution> {
+    assert_eq!(model.relation_type, RelationType::PageAttribution.value());
+    assert_eq!(model.dest_type, RelationObjectType::Page);
+    assert_eq!(model.from_type, RelationObjectType::User);
+
+    let metadata: PageAttributionMetadata = serde_json::from_value(model.metadata)?;
+
+    Ok(PageAttribution {
+        relation_id: model.relation_id,
+        page_id: model.dest_id,
+        user_id: model.from_id,
+        created_by: model.created_by,
+        created_at: model.created_at,
+        overwritten_by: model.overwritten_by,
+        overwritten_at: model.overwritten_at,
+        deleted_by: model.deleted_by,
+        deleted_at: model.deleted_at,
+        metadata,
+    })
+}
+
+impl PageAttribution {
+    fn try_from_model(model: RelationModel) -> Result<Self> {
+        convert_model(model)
+    }
+}
+
+async fn find_page_attribution(
+    ctx: &ServiceContext<'_>,
+    page_id: i64,
+    user_id: i64,
+    metadata_json: &serde_json::Value,
+) -> Result<Option<RelationModel>> {
+    let txn = ctx.transaction();
+    Relation::find()
+        .filter(page_attribution_condition(page_id, user_id, metadata_json))
+        .one(txn)
+        .await
+        .map_err(Into::into)
+}
+
+async fn get_page_attribution_by_id(
+    ctx: &ServiceContext<'_>,
+    relation_id: i64,
+) -> Result<RelationModel> {
+    let txn = ctx.transaction();
+    let model = Relation::find()
+        .filter(
+            Condition::all()
+                .add(relation::Column::RelationId.eq(relation_id))
+                .add(relation::Column::DestType.eq(RelationObjectType::Page))
+                .add(relation::Column::FromType.eq(RelationObjectType::User))
+                .add(relation::Column::RelationType.eq(
+                    RelationType::PageAttribution.value(),
+                ))
+                .add(relation::Column::OverwrittenAt.is_null())
+                .add(relation::Column::DeletedAt.is_null()),
+        )
+        .one(txn)
+        .await?;
+
+    match model {
+        Some(model) => Ok(model),
+        None => Err(Error::RelationNotFound),
+    }
+}
+
+async fn overwrite_page_attribution(
+    ctx: &ServiceContext<'_>,
+    relation_id: i64,
+    overwritten_by: i64,
+) -> Result<()> {
+    let model = relation::ActiveModel {
+        relation_id: Set(relation_id),
+        overwritten_by: Set(Some(overwritten_by)),
+        overwritten_at: Set(Some(now())),
+        ..Default::default()
+    };
+
+    model.update(ctx.transaction()).await?;
+    Ok(())
 }


### PR DESCRIPTION
Feature [WJ-1206](https://scuttle.atlassian.net/browse/WJ-1206).

Adds a page attribution relation service and wires JSON-RPC endpoints to manage it.

Service/API:
- List active attributions for a page via `page_attribution_get_page`.
- Idempotent create/update via `page_attribution_update` with overwrite tracking and uniqueness on page/user/kind/date.
- Soft-delete via `page_attribution_delete` with actor attribution.

Behavior:
- Converts relation models to DTOs with metadata and timestamps.
- Filters out overwritten/deleted relations.
- Ensures object types match the page→user relation contract.

Tests: ran through docker.


[WJ-1206]: https://scuttle.atlassian.net/browse/WJ-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ