### PR TITLE
WJ-1341: include page attributions in page view

### DIFF
--- a/deepwell/src/services/view/service.rs
+++ b/deepwell/src/services/view/service.rs
@@ -124,6 +124,7 @@ impl ViewService {
             Found {
                 page: PageModel,
                 page_revision: PageRevisionModel,
+                attributions: Vec<PageAttribution>,
             },
             Missing,
             Private,
@@ -180,10 +181,20 @@ impl ViewService {
                         TextService::get(ctx, &page_revision.compiled_hash),
                     )?;
 
+                    let attributions = RelationService::get_page_attributions(
+                        ctx,
+                        GetPageAttributions {
+                            site_id: page.site_id,
+                            page: Reference::Id(page.page_id),
+                        },
+                    )
+                    .await?;
+
                     (
                         PageStatus::Found {
                             page,
                             page_revision,
+                            attributions,
                         },
                         wikitext,
                         compiled_html,
@@ -259,30 +270,17 @@ impl ViewService {
             license_url,
             user_session,
         };
-        let attributions = match &status {
-            PageStatus::Found { page, .. } => Some(
-                RelationService::get_page_attributions(
-                    ctx,
-                    GetPageAttributions {
-                        site_id: page.site_id,
-                        page: Reference::Id(page.page_id),
-                    },
-                )
-                .await?,
-            ),
-            _ => None,
-        };
-
         let output = match status {
             PageStatus::Found {
                 page,
                 page_revision,
+                attributions,
             } => GetPageViewOutput::Found {
                 viewer,
                 options,
                 page,
                 page_revision,
-                attributions: attributions.unwrap_or_default(),
+                attributions,
                 redirect_page,
                 wikitext,
                 compiled_html,

--- a/deepwell/src/services/view/service.rs
+++ b/deepwell/src/services/view/service.rs
@@ -39,6 +39,9 @@ use crate::services::{
     DomainService, PageRevisionService, PageService, SessionService, SiteService,
     SpecialPageService, TextService, UserService,
 };
+use crate::services::relation::{
+    GetPageAttributions, PageAttribution, RelationService,
+};
 use crate::utils::{parse_locales, split_category};
 use ftml::prelude::*;
 use ftml::render::html::HtmlOutput;
@@ -256,6 +259,20 @@ impl ViewService {
             license_url,
             user_session,
         };
+        let attributions = match &status {
+            PageStatus::Found { page, .. } => Some(
+                RelationService::get_page_attributions(
+                    ctx,
+                    GetPageAttributions {
+                        site_id: page.site_id,
+                        page: Reference::Id(page.page_id),
+                    },
+                )
+                .await?,
+            ),
+            _ => None,
+        };
+
         let output = match status {
             PageStatus::Found {
                 page,
@@ -265,6 +282,7 @@ impl ViewService {
                 options,
                 page,
                 page_revision,
+                attributions: attributions.unwrap_or_default(),
                 redirect_page,
                 wikitext,
                 compiled_html,

--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -64,6 +64,7 @@ pub enum GetPageViewOutput {
         options: PageOptions,
         page: PageModel,
         page_revision: PageRevisionModel,
+        attributions: Vec<crate::services::relation::PageAttribution>,
         redirect_page: Option<String>,
         wikitext: String,
         compiled_html: String,

--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -25,6 +25,7 @@ use crate::models::page_revision::Model as PageRevisionModel;
 use crate::models::session::Model as SessionModel;
 use crate::models::site::Model as SiteModel;
 use crate::models::user::Model as UserModel;
+use crate::services::relation::PageAttribution;
 
 // NOTE: Any changes to the output structures here, including the variant names,
 //       MUST be reflected in framerail!
@@ -64,7 +65,7 @@ pub enum GetPageViewOutput {
         options: PageOptions,
         page: PageModel,
         page_revision: PageRevisionModel,
-        attributions: Vec<crate::services::relation::PageAttribution>,
+        attributions: Vec<PageAttribution>,
         redirect_page: Option<String>,
         wikitext: String,
         compiled_html: String,


### PR DESCRIPTION
Fixes WJ-1341.

Add page attribution data to page views so Framerail can display authorship.

Changes:
- Extend `GetPageViewOutput::Found` with `attributions: Vec<PageAttribution>`.
- `ViewService::page` fetches attributions for the found page (site_id + page reference); Missing/Permissions cases unchanged.

Tests: ran.
