### PR TITLE
Use rust:bullseye for Rust containers

### DIFF
--- a/install/local/deepwell/Dockerfile
+++ b/install/local/deepwell/Dockerfile
@@ -6,7 +6,7 @@
 # full rust container and rebuilds as needed, to ease
 # iteration during development.
 
-FROM rust:latest AS rust
+FROM rust:bullseye AS rust
 
 # Install system dependencies
 RUN apt update

--- a/install/local/wws/Dockerfile
+++ b/install/local/wws/Dockerfile
@@ -6,7 +6,7 @@
 # full rust container and rebuilds as needed, to ease
 # iteration during development.
 
-FROM rust:latest AS rust
+FROM rust:bullseye AS rust
 
 # Install helpers
 RUN cargo install cargo-watch


### PR DESCRIPTION
Due to apparent issues with `rust:latest`, switching to `rust:bullseye` should provide more stability for `libmagic` installation when building images.