### PR TITLE
Use JSONB instead of JSON in schemas

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -194,7 +194,7 @@ CREATE TABLE relation (
     dest_id BIGINT NOT NULL,
     from_type relation_object_type NOT NULL,
     from_id BIGINT NOT NULL,
-    metadata JSON NOT NULL DEFAULT '{}',
+    metadata JSONB NOT NULL DEFAULT '{}',
     created_by BIGINT NOT NULL REFERENCES "user"(user_id),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     overwritten_by BIGINT REFERENCES "user"(user_id),
@@ -677,7 +677,7 @@ CREATE TABLE message_draft (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE,
     user_id BIGINT NOT NULL REFERENCES "user"(user_id),
-    recipients JSON NOT NULL,
+    recipients JSONB NOT NULL,
 
     -- Text contents
     subject TEXT NOT NULL,

--- a/deepwell/src/models/message_draft.rs
+++ b/deepwell/src/models/message_draft.rs
@@ -13,6 +13,7 @@ pub struct Model {
     #[serde(with = "time::serde::rfc3339::option")]
     pub updated_at: Option<TimeDateTimeWithTimeZone>,
     pub user_id: i64,
+    #[sea_orm(column_type = "JsonBinary")]
     pub recipients: Json,
     #[sea_orm(column_type = "Text")]
     pub subject: String,

--- a/deepwell/src/models/relation.rs
+++ b/deepwell/src/models/relation.rs
@@ -15,6 +15,7 @@ pub struct Model {
     pub dest_id: i64,
     pub from_type: RelationObjectType,
     pub from_id: i64,
+    #[sea_orm(column_type = "JsonBinary")]
     pub metadata: Json,
     pub created_by: i64,
     #[serde(with = "time::serde::rfc3339")]


### PR DESCRIPTION
This is causing a crash on startup when the seeder runs and fails to add attributions, as SeaORM is generating code to compare `json = jsonb`, which Postgres doesn't support. That is, it's taking our right-hand side JSON that we want to compare and treating it as JSONB rather than JSON even though the column type was JSON.

This fixes that by just using JSONB for the column as well.

Screenshot of my local instance running:
<img width="1278" height="343" alt="image" src="https://github.com/user-attachments/assets/1c1b6d81-5b1a-4016-8237-1ccc111b08d4" />
