### PR TITLE
Adjust deepwell health check delays to account for bootstrap period

### DIFF
--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       timeout: 2s
       retries: 3
       start_period: 600s
-      start_interval: 30s
+      start_interval: 10s
     depends_on:
       cache:
         condition: service_healthy

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
       interval: 120s
       timeout: 2s
       retries: 3
+      start_period: 600s
+      start_interval: 30s
     depends_on:
       cache:
         condition: service_healthy

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -71,9 +71,11 @@ services:
     restart: always
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
-      interval: 600s
+      interval: 120s
       timeout: 2s
       retries: 3
+      start_period: 600s
+      start_interval: 30s
     depends_on:
       cache:
         condition: service_healthy

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -75,7 +75,7 @@ services:
       timeout: 2s
       retries: 3
       start_period: 600s
-      start_interval: 30s
+      start_interval: 10s
     depends_on:
       cache:
         condition: service_healthy


### PR DESCRIPTION
Make use of the docker options `--start-period` and `--start-interval` to prevent health check fails during startup period.

This solves the problem mentioned in #2472.