### PR TITLE
Add option to translate call to strip Fluent control characters

### DIFF
--- a/deepwell/src/endpoints/locale.rs
+++ b/deepwell/src/endpoints/locale.rs
@@ -20,7 +20,7 @@
 
 use super::prelude::*;
 use crate::locales::MessageArguments;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use unic_langid::LanguageIdentifier;
 
 #[derive(Serialize, Debug, Clone)]
@@ -35,6 +35,19 @@ pub struct LocaleOutput {
 pub struct TranslateInput {
     locales: Vec<String>,
     messages: HashMap<String, MessageArguments<'static>>,
+
+    /// A list of message keys to run `strip_fluent_control_chars()` on.
+    ///
+    /// For each of the keys here, the translated message has its Fluent-added
+    /// control characters stripped before it is returned in the response.
+    ///
+    /// By default this is empty, meaning to leave all messages unmodified.
+    ///
+    /// # Errors
+    /// If there are any keys in this list which are not in `messages`, then
+    /// an error will be returned.
+    #[serde(default)]
+    strip_message_keys: HashSet<String>,
 }
 
 type TranslateOutput = HashMap<String, Option<String>>;
@@ -58,7 +71,11 @@ pub async fn translate_strings(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
 ) -> Result<TranslateOutput> {
-    let TranslateInput { locales, messages } = params.parse()?;
+    let TranslateInput {
+        locales,
+        messages,
+        strip_message_keys,
+    } = params.parse()?;
 
     if locales.is_empty() {
         error!("No locales specified in translate call");

--- a/deepwell/src/endpoints/locale.rs
+++ b/deepwell/src/endpoints/locale.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::locales::MessageArguments;
+use crate::utils::strip_fluent_control_chars;
 use std::collections::{HashMap, HashSet};
 use unic_langid::LanguageIdentifier;
 
@@ -77,9 +78,20 @@ pub async fn translate_strings(
         strip_message_keys,
     } = params.parse()?;
 
+    // Check that locales are specified
     if locales.is_empty() {
         error!("No locales specified in translate call");
         return Err(ServiceError::NoLocalesSpecified);
+    }
+
+    // Check that all message keys to strip are being requested
+    for message_key in &strip_message_keys {
+        if !messages.contains_key(message_key.as_str()) {
+            error!(
+                "Input mentions stripping control characters from a message not requested to be translated: {message_key}"
+            );
+            return Err(ServiceError::BadRequest);
+        }
     }
 
     info!(
@@ -107,11 +119,20 @@ pub async fn translate_strings(
         );
 
         let arguments = arguments_raw.into_fluent_args();
-        let translation =
-            ctx.localization()
-                .translate_option(&locales, &message_key, &arguments)?;
+        let translation = ctx
+            .localization()
+            .translate_option(&locales, &message_key, &arguments)?
+            .map(|translation| {
+                let mut translation = translation.to_string();
 
-        output.insert(message_key, translation.map(|t| t.to_string()));
+                if strip_message_keys.contains(&message_key) {
+                    strip_fluent_control_chars(&mut translation);
+                }
+
+                translation
+            });
+
+        output.insert(message_key, translation);
     }
 
     Ok(output)

--- a/deepwell/src/services/special_page/service.rs
+++ b/deepwell/src/services/special_page/service.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::site::Model as SiteModel;
 use crate::services::{PageRevisionService, PageService, RenderService, TextService};
 use crate::types::Reference;
-use crate::utils::{regex_replace_in_place, split_category};
+use crate::utils::{regex_replace_in_place, split_category, strip_fluent_control_chars};
 use fluent::{FluentArgs, FluentValue};
 use ftml::prelude::*;
 use ref_map::*;
@@ -171,20 +171,8 @@ impl SpecialPageService {
             .translate(locales, translate_key, &args)?
             .into_owned();
 
-        // Fluent adds U+2068 and U+2069 characters to assist text layout engines
-        // when dealing with LTR / RTL text. However, this causes parsing issues
-        // for us in wikitext, since these characters can gum up string concatenation
-        // cases like URL construction.
-        //
-        // So as a special case here, we strip out any of these characters.
-        // We don't remove these characters from other locale strings since they are
-        // a desired localization property of Fluent.
-        //
-        // See https://fluent-compiler.readthedocs.io/en/latest/usage.html#:~:text=You%20will%20notice%20the%20extra%20characters%20\u2068%20and%20\u2069%20in%20the%20output.
-        static CONTROL_CHAR_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new("[\u{2068}\u{2069}]").unwrap());
-
-        regex_replace_in_place(&mut wikitext, &CONTROL_CHAR_REGEX, "");
+        // Remove control chars because this string is intended to be wikitext
+        strip_fluent_control_chars(&mut wikitext);
 
         Ok(wikitext)
     }

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -79,6 +79,26 @@ pub fn trim_spaces_in_place(string: &mut String) {
     regex_replace_in_place(string, &LEADING_TRAILING_SPACES, "");
 }
 
+/// This helper function removes U+2068 and U+2069 control characters from a string.
+///
+/// Fluent adds these U+2068 and U+2069 characters to assist text layout engines
+/// when dealing with LTR / RTL text. However, this causes parsing issues
+/// for us in wikitext or HTML, since these characters can gum up string
+/// concatenation cases like URL construction.
+///
+/// So as a special case here, we provide a helper function to strip out any of
+/// these characters. We don't remove these characters from all locale strings
+/// since they are a desired localization property of Fluent.
+///
+/// See https://fluent-compiler.readthedocs.io/en/latest/usage.html#:~:text=You%20will%20notice%20the%20extra%20characters%20\u2068%20and%20\u2069%20in%20the%20output.
+#[inline]
+pub fn strip_fluent_control_chars(string: &mut String) {
+    static CONTROL_CHAR_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("[\u{2068}\u{2069}]").unwrap());
+
+    regex_replace_in_place(string, &CONTROL_CHAR_REGEX, "");
+}
+
 // Tests
 
 #[test]

--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -206,3 +206,25 @@ fn test_trim_spaces_in_place() {
     test!("\r\t  cherry" => "cherry");
     test!(" 🥭  " => "🥭");
 }
+
+#[test]
+fn test_strip_fluent_control_chars() {
+    macro_rules! test {
+        ($input:expr => $output:expr $(,)?) => {{
+            let mut string = str!($input);
+            strip_fluent_control_chars(&mut string);
+            assert_eq!(string, $output, "Trimmed contents did not match expected");
+        }};
+
+        // Unmodified case, where no substition occurs
+        ($input:expr $(,)?) => {
+            test!($input => $input)
+        };
+    }
+
+    test!("");
+    test!("Hello, world!");
+    test!("Berry: 🍓");
+    test!("Good morning \u{2068}John\u{2069}" => "Good morning John");
+    test!("\u{2068}alpha\u{2069} beta \u{2068}\u{2069}gamma" => "alpha beta gamma");
+}

--- a/framerail/src/lib/server/deepwell/translate.ts
+++ b/framerail/src/lib/server/deepwell/translate.ts
@@ -3,10 +3,12 @@ import type { TranslateKeys, TranslatedKeys } from "$lib/types"
 
 export async function translate(
   locales: string[],
-  keys: TranslateKeys
+  keys: TranslateKeys,
+  stripKeys: string[] = []
 ): Promise<TranslatedKeys> {
   return client.request("translate", {
     locales,
-    messages: keys
+    messages: keys,
+    strip_message_keys: stripKeys
   })
 }


### PR DESCRIPTION
Some Fluent strings are used to build wikitext or HTML, and as such the default behavior of wrapping parameters in control characters to hint to RTL / LTR renderers causes generation to be incorrect. For such cases, we want to remove these characters.

Special pages used this feature, but framerail does as well, so I moved the logic to a utility function and aded a feature to `translate` that allows for optionally stripping only certain translated messages.

This new argument is optional, so all existing deepwell queries should work fine. I've added the argument to framerail as well.

----

Tested locally:

```javascript
/* Default */
$ scripts/request.py translate '{"locales":["en"],"messages":{"license.cc-by-2-5":{},"base-title":{"title":"Foo Bar"}}}'     
OK  
{
    "base-title": "\u2068Foo Bar\u2069 | Wikijump",
    "license.cc-by-2-5": "Creative Commons Attribution 2.5"
}

/* Empty */
$ scripts/request.py translate '{"locales":["en"],"messages":{"license.cc-by-2-5":{},"base-title":{"title":"Foo Bar"}},"strip_message_keys":[]}'
OK  
{
    "license.cc-by-2-5": "Creative Commons Attribution 2.5",
    "base-title": "\u2068Foo Bar\u2069 | Wikijump"
}


/* Strip message */
$ scripts/request.py translate '{"locales":["en"],"messages":{"license.cc-by-2-5":{},"base-title":{"title":"Foo Bar"}},"strip_message_keys":["base-title"]}' 
OK  
{
    "license.cc-by-2-5": "Creative Commons Attribution 2.5",
    "base-title": "Foo Bar | Wikijump"
}

/* Invalid message key to strip */
$ scripts/request.py translate '{"locales":["en"],"messages":{"license.cc-by-2-5":{},"base-title":{"title":"Foo Bar"}},"strip_message_keys":["xxx"]}'
ERR 
{
    "code": 4000,
    "message": "The request is in some way malformed or incorrect",
    "data": null
}
```