### PR TITLE
Remove invalid test case

### DIFF
--- a/deepwell/src/utils/string.rs
+++ b/deepwell/src/utils/string.rs
@@ -111,7 +111,6 @@ fn test_replace_in_place() {
         }};
     }
 
-    test!("" => "", "/" => "_");
     test!("foo/bar" => "foo + bar", "/" => " + ");
     test!("apple banana cherry" => "pple bnn cherry", "a" => "");
     test!("apple banana cherry" => "appluxi banana chuxirry", "e" => "uxi");


### PR DESCRIPTION
Empty replacement is tested in a `#[should_panic]` test below. Given that it panics on empty inputs, this shouldn't be in here.