### PR TITLE
Rename special_action -> runtime_action

### DIFF
--- a/.github/workflows/deepwell.yaml
+++ b/.github/workflows/deepwell.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Check Configuration
         run: cd deepwell && cargo run -- config.example.toml ../install/local/deepwell/deepwell.toml ../install/dev/deepwell/deepwell.toml ../install/prod/deepwell/deepwell.toml
         env:
-          DEEPWELL_SPECIAL_ACTION: validate-config
+          DEEPWELL_RUNTIME_ACTION: validate-config
 
       - name: Test
         run: cd deepwell && cargo test --all-features -- --nocapture --test-threads 1

--- a/deepwell/src/config/mod.rs
+++ b/deepwell/src/config/mod.rs
@@ -21,14 +21,14 @@
 mod args;
 mod file;
 mod object;
+mod runtime_action;
 mod secrets;
-mod special_action;
 
 pub use self::object::Config;
 pub use self::secrets::Secrets;
 
 use self::args::parse_args;
-use self::special_action::run_special_action;
+use self::runtime_action::run_runtime_action;
 
 #[derive(Debug, Clone)]
 pub struct SetupConfig {
@@ -38,7 +38,7 @@ pub struct SetupConfig {
 
 impl SetupConfig {
     pub fn load() -> Self {
-        run_special_action();
+        run_runtime_action();
         let secrets = Secrets::load();
         let config = parse_args();
         SetupConfig { secrets, config }

--- a/deepwell/src/config/runtime_action.rs
+++ b/deepwell/src/config/runtime_action.rs
@@ -1,5 +1,5 @@
 /*
- * config/special_action.rs
+ * config/runtime_action.rs
  *
  * DEEPWELL - Wikijump API provider and database manager
  * Copyright (C) 2019-2025 Wikijump Team
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! Perform a "special action" instead of normal server execution.
+//! Perform a "runtime action" instead of normal server execution.
 //!
 //! This is useful in contexts such as CI, where we want DEEPWELL to
 //! not run as a daemon, but instead perform a special action or check,
@@ -28,18 +28,18 @@ use super::Config;
 use std::path::PathBuf;
 use std::{env, process};
 
-pub fn run_special_action() {
+pub fn run_runtime_action() {
     // Get action name, if specified.
     // Otherwise return and perform normal execution.
-    let Ok(action_name) = env::var("DEEPWELL_SPECIAL_ACTION") else {
+    let Ok(action_name) = env::var("DEEPWELL_RUNTIME_ACTION") else {
         return;
     };
 
-    // Run appropriate special action.
+    // Run appropriate runtime action.
     let return_code = match action_name.as_str() {
         "config" | "validate-config" => validate_config(),
         _ => {
-            eprintln!("Unknown special action: {action_name}");
+            eprintln!("Unknown runtime action: {action_name}");
             process::exit(1);
         }
     };
@@ -49,7 +49,7 @@ pub fn run_special_action() {
 }
 
 fn validate_config() -> i32 {
-    println!("Running special action: Validate configuration");
+    println!("Running action: Validate configuration");
 
     let mut return_code = 0;
     for value in env::args_os().skip(1) {


### PR DESCRIPTION
I've noticed that I have been overusing "special" in the deepwell code for various things, I'm going to try and rename these cases to something more specific so every other concept isn't "special XXX".