### PR TITLE
Hide JSON data behind debug view

### DIFF
--- a/deepwell/src/services/view/options.rs
+++ b/deepwell/src/services/view/options.rs
@@ -31,6 +31,7 @@ const PAGE_ARGUMENTS_SCHEMA: ArgumentSchema = ArgumentSchema {
         "tags",
         "noredirect",
         "norender",
+        "debug",
         "comments",
         "discuss",
         "history",
@@ -41,6 +42,7 @@ const PAGE_ARGUMENTS_SCHEMA: ArgumentSchema = ArgumentSchema {
         "edit",
         "noredirect",
         "norender",
+        "debug",
         "rerender",
         "comments",
         "discuss",
@@ -60,6 +62,7 @@ pub struct PageOptions {
     pub tags: Option<String>,
     pub no_redirect: bool,
     pub no_render: bool,
+    pub debug: bool,
     pub rerender: bool,
     pub comments: bool,
     pub history: bool,
@@ -120,6 +123,7 @@ impl PageOptions {
         set_str_opt!(tags);
         set_bool!(no_redirect, noredirect);
         set_bool!(no_render, norender);
+        set_bool!(debug);
         set_bool!(rerender);
         set_bool!(comments);
         set_bool!(comments, discuss);

--- a/framerail/src/app.d.ts
+++ b/framerail/src/app.d.ts
@@ -50,6 +50,7 @@ declare namespace App {
       tags: string | null
       no_redirect: boolean
       no_render: boolean
+      debug: boolean
       renderer: boolean
       comments: boolean
       history: boolean

--- a/framerail/src/routes/[slug]/[...extra]/page.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/page.svelte
@@ -26,6 +26,7 @@
     let options: string[] = []
     if ($page.data.options.no_render) options.push("norender")
     if ($page.data.options.no_redirect) options.push("noredirect")
+    if ($page.data.options.debug) options.push("debug")
     options = options.map((opt) => `/${opt}`)
     goto(`/${$page.data.page.slug}${options.join("")}/edit`, {
       noScroll: true
@@ -51,13 +52,6 @@
 </script>
 
 {#if $pageLayout === Layout.WIKIDOT}
-  <h1>UNTRANSLATED:Loaded page</h1>
-  <p>
-    UNTRANSLATED:Response <textarea class="debug"
-      >{JSON.stringify($page, null, 2)}</textarea
-    >
-  </p>
-
   {#if showRevision}
     <div id="page-title">{revision.title}</div>
   {:else}
@@ -65,7 +59,10 @@
   {/if}
 
   <div id="page-content">
-    {#if $page.data.options?.no_render}
+    {#if $page.data.options?.debug}
+      <h1>UNTRANSLATED:Debug Response</h1>
+      <textarea class="debug">{JSON.stringify($page, null, 2)}</textarea>
+    {:else if $page.data.options?.no_render}
       {$page.data.internationalization["wiki-page-no-render"]}
       <textarea class="page-source" readonly={true}>{$page.data.wikitext}</textarea>
     {:else if showRevision}
@@ -287,13 +284,6 @@
     </div>
   {/if}
 {:else}
-  <h1>UNTRANSLATED:Loaded page</h1>
-  <p>
-    UNTRANSLATED:Response <textarea class="debug"
-      >{JSON.stringify($page, null, 2)}</textarea
-    >
-  </p>
-
   {#if showRevision}
     <h2>{revision.title}</h2>
   {:else}
@@ -303,7 +293,10 @@
   <hr />
 
   <div class="page-content">
-    {#if $page.data.options?.no_render}
+    {#if $page.data.options?.debug}
+      <h1>UNTRANSLATED:Debug Response</h1>
+      <textarea class="debug">{JSON.stringify($page, null, 2)}</textarea>
+    {:else if $page.data.options?.no_render}
       {$page.data.internationalization["wiki-page-no-render"]}
       <textarea class="page-source" readonly={true}>{$page.data.wikitext}</textarea>
     {:else if showRevision}

--- a/framerail/src/routes/[slug]/[...extra]/page.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/page.svelte
@@ -52,7 +52,9 @@
 </script>
 
 {#if $pageLayout === Layout.WIKIDOT}
-  {#if showRevision}
+  {#if $page.data.options?.debug}
+    <h2>UNTRANSLATED:Debug Response</h2>
+  {:else if showRevision}
     <div id="page-title">{revision.title}</div>
   {:else}
     <div id="page-title">{$page.data.page_revision.title}</div>
@@ -60,7 +62,6 @@
 
   <div id="page-content">
     {#if $page.data.options?.debug}
-      <h1>UNTRANSLATED:Debug Response</h1>
       <textarea class="debug">{JSON.stringify($page, null, 2)}</textarea>
     {:else if $page.data.options?.no_render}
       {$page.data.internationalization["wiki-page-no-render"]}
@@ -284,7 +285,9 @@
     </div>
   {/if}
 {:else}
-  {#if showRevision}
+  {#if $page.data.options?.debug}
+    <h2>UNTRANSLATED:Debug Response</h2>
+  {:else if showRevision}
     <h2>{revision.title}</h2>
   {:else}
     <h2>{$page.data.page_revision.title}</h2>
@@ -294,7 +297,6 @@
 
   <div class="page-content">
     {#if $page.data.options?.debug}
-      <h1>UNTRANSLATED:Debug Response</h1>
       <textarea class="debug">{JSON.stringify($page, null, 2)}</textarea>
     {:else if $page.data.options?.no_render}
       {$page.data.internationalization["wiki-page-no-render"]}


### PR DESCRIPTION
We don't have any real reason to be exposing this anymore. I've added a `/debug` option which is what shows the `<textarea>` with the raw JSON response.

**Normal view:** (`/start`)
<img width="1117" height="795" alt="image" src="https://github.com/user-attachments/assets/0b2b49d4-a91e-469e-8320-502ba3e2891d" />

**Debug view (key only):** (`/start/debug`)
<img width="736" height="641" alt="image" src="https://github.com/user-attachments/assets/cfedef42-52bc-40c3-b9ea-af54db522c5d" />

**Debug view (key and value):** (`/start/debug/true`)
<img width="784" height="646" alt="image" src="https://github.com/user-attachments/assets/a3e44e91-db58-49df-90bb-15b7da9caaff" />

**Normal view (false value):** (`/start/debug/false`)
<img width="859" height="683" alt="image" src="https://github.com/user-attachments/assets/ae1fb04a-6c29-43e2-b5cb-25bb20cec391" />

