### PR TITLE
[chore] Bump deepwell version

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.1.17"
+version = "2026.1.18"
 dependencies = [
  "anyhow",
  "argon2",
@@ -5482,6 +5482,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.1.17"
+version = "2026.1.18"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 


### PR DESCRIPTION
After merging #2623, we should bump the deepwell version since that's a notable change.