### PR TITLE
Quick fix: deny relation creation when from and dest are the same

### DIFF
--- a/deepwell/src/services/relation/mod.rs
+++ b/deepwell/src/services/relation/mod.rs
@@ -90,6 +90,12 @@ impl RelationService {
     ) -> Result<RelationModel> {
         debug!("Create relation for {dest:?} ← {relation_type:?} ← {from:?}");
 
+        // Relations are not permitted to point to themselves
+        if dest == from {
+            error!("Source and destination are the same: {dest:?}, cannot create relation");
+            return Err(Error::BadRequest);
+        }
+
         // Get previous relation, if present
         let txn = ctx.transaction();
         if let Some(relation) = Self::get_optional(

--- a/deepwell/src/services/relation/mod.rs
+++ b/deepwell/src/services/relation/mod.rs
@@ -92,7 +92,10 @@ impl RelationService {
 
         // Relations are not permitted to point to themselves
         if dest == from {
-            error!("Source and destination are the same: {dest:?}, cannot create relation");
+            error!(
+                "Source and destination are the same: {:?}, cannot create relation",
+                dest,
+            );
             return Err(Error::BadRequest);
         }
 


### PR DESCRIPTION
This blocks e.g. users from friending themselves or blocking themselves. I can't think of any cases where a relation would want self-to-self data, and if there is, we can work it out when we cross that bridge.