### PR TITLE
Update Caddyfile every 5 minutes

### DIFF
--- a/install/common/caddy/crontab
+++ b/install/common/caddy/crontab
@@ -1,2 +1,2 @@
-# Hourly regeneration of Caddyfile from DEEPWELL
+# Regeneration of Caddyfile from DEEPWELL every 5 minutes
 */5 * * * * /usr/local/bin/wikijump-update-caddyfile

--- a/install/common/caddy/crontab
+++ b/install/common/caddy/crontab
@@ -1,2 +1,2 @@
 # Hourly regeneration of Caddyfile from DEEPWELL
-0 * * * * /usr/local/bin/wikijump-update-caddyfile
+*/5 * * * * /usr/local/bin/wikijump-update-caddyfile


### PR DESCRIPTION
Five minutes is a much more reasonable time to wait for domain settings to become live. I think this is a safe interval because:
* Caddyfile generation is not a particularly expensive process, it's essentially doing three queries and then generating a string.
* Caddy detects if the Caddyfile is different from the current one, and if so, takes no action.
* Even when Caddy does update its configuration, it does so very quickly and without disruption to ongoing operations.