### PR TITLE
Always record call_trace

### DIFF
--- a/deepwell/src/error/convert.rs
+++ b/deepwell/src/error/convert.rs
@@ -104,18 +104,11 @@ pub fn exn_error_to_rpc_error(exn_error: Exn<Error>) -> ErrorObjectOwned {
         Some(TopError::CrateError(error)) => {
             let error_code = error.code();
             let message = error.summary();
-            let data = match error.error_type {
-                // Special case, if authentication then don't include call trace
-                // See comment in auth_login in endpoints/auth.rs
-                ErrorType::InvalidAuthentication => None,
-
-                // Normal case, provide error context
-                _ => Some(json!({
-                    "call_trace": format!("{exn_error:?}"),
-                    "code_trace": code_trace,
-                    "extra": extra_data,
-                })),
-            };
+            let data = Some(json!({
+                "call_trace": format!("{exn_error:?}"),
+                "code_trace": code_trace,
+                "extra": extra_data,
+            }));
             ErrorObjectOwned::owned(error_code, message, data)
         }
 


### PR DESCRIPTION
As noted in [discussion on #2701](https://github.com/scpwiki/wikijump/pull/2701#discussion_r2837833130), the `call_trace` field will be retained internally only, and so it is safe to record the data even in the case of authentication issues. (This is because only developers will be reviewing the logs and it cannot be used by attackers to determine internal authentication state).