### PR TITLE
Remove framerail error view cases that do not exist anymore

### DIFF
--- a/framerail/src/lib/server/load/admin.ts
+++ b/framerail/src/lib/server/load/admin.ts
@@ -52,21 +52,13 @@ export async function loadAdminPage(request, cookies) {
     case "admin_permissions":
       errorStatus = 401
       break
-    case "site_missing":
-      errorStatus = 404
-      break
     default:
       // Unexpected response type!
       // There is an inconsistency between here / DEEPWELL
       errorStatus = 500
   }
 
-  if (errorStatus !== null) {
-    translateKeys = {
-      ...translateKeys,
-      "site-not-exist": {}
-    }
-  } else {
+  if (errorStatus === null) {
     translateKeys = {
       ...translateKeys,
 

--- a/framerail/src/lib/server/load/user.ts
+++ b/framerail/src/lib/server/load/user.ts
@@ -55,9 +55,6 @@ export async function loadUser(username?: string, request, cookies) {
       viewData.user = null
       errorStatus = 404
       break
-    case "site_missing":
-      errorStatus = 404
-      break
     default:
       // Unexpected response type!
       // There is an inconsistency between here / DEEPWELL

--- a/framerail/src/routes/[x+2d]/admin/+error.svelte
+++ b/framerail/src/routes/[x+2d]/admin/+error.svelte
@@ -13,9 +13,6 @@ as soon as we can figure out prettier support for it.
 {#if $page.error.view === "admin_permissions"}
   UNTRANSLATED:Lacks permissions for page
   {@html $page.error.html}
-{:else if $page.error.view === "site_missing"}
-  UNTRANSLATED:No such site
-  {@html $page.error.html}
 {:else}
   UNTRANSLATED:Fatal error: Unable to display view
 {/if}

--- a/framerail/src/routes/[x+2d]/user/+error.svelte
+++ b/framerail/src/routes/[x+2d]/user/+error.svelte
@@ -16,9 +16,6 @@ as soon as we can figure out prettier support for it.
   {:else}
     {$page.error.internationalization?.["user-not-exist"]}
   {/if}
-{:else if $page.error.view === "site_missing"}
-  UNTRANSLATED:No such site
-  {@html $page.error.html}
 {:else}
   UNTRANSLATED:Fatal error: Unable to display view
 {/if}


### PR DESCRIPTION
Removes `site_missing` error cases for user view and admin view, reference #2283 and #2355