### PR TITLE
[WJ-1349] Update infrastructure files for dev tier

### DIFF
--- a/deepwell/.env.example
+++ b/deepwell/.env.example
@@ -12,7 +12,12 @@ DATABASE_URL=postgres://localhost
 REDIS_URL=redis://localhost
 
 # S3 configuration settings
-S3_BUCKET=deepwell-files
+
+# Bucket for storing files / blobs
+S3_FILES_BUCKET=deepwell-files
+
+# Bucket for storing extracted text blocks
+S3_TEXT_BLOCKS_BUCKET=deepwell-text-blocks
 
 # Region, either specify:
 S3_AWS_REGION=us-east-2

--- a/deepwell/src/services/caddy/service.rs
+++ b/deepwell/src/services/caddy/service.rs
@@ -115,6 +115,7 @@ impl CaddyService {
         CaddyfileOptions {
             debug,
             local,
+            auto_https,
             http_port,
             https_port,
             framerail_host,
@@ -153,6 +154,10 @@ impl CaddyService {
 
         if *local {
             str_writeln!(&mut caddyfile, "\tlocal_certs\n\tskip_install_trust");
+        }
+
+        if !*auto_https {
+            str_writeln!(&mut caddyfile, "\tauto_https off");
         }
 
         str_write!(

--- a/deepwell/src/services/caddy/structs.rs
+++ b/deepwell/src/services/caddy/structs.rs
@@ -29,6 +29,9 @@ pub struct CaddyfileOptions<'a> {
     #[serde(default)]
     pub local: bool,
 
+    #[serde(default = "default_true")]
+    pub auto_https: bool,
+
     #[serde(default)]
     pub http_port: Option<i64>,
 
@@ -50,4 +53,9 @@ pub struct SiteData {
 pub struct SiteDomainData {
     pub aliases: Vec<String>,
     pub custom_domains: Vec<String>,
+}
+
+#[inline]
+fn default_true() -> bool {
+    true
 }

--- a/deepwell/src/services/caddy/test.rs
+++ b/deepwell/src/services/caddy/test.rs
@@ -208,7 +208,7 @@ fn write_test_file(path: &str, caddyfile: &str) {
 
 #[test]
 fn generate_caddyfiles() {
-    const FRAMERAIL_HOST: &str = "framerail:3000";
+    const FRAMERAIL_HOST: &str = "framerail:3393";
     const WWS_HOST: &str = "wws:7000";
 
     // Build different configurations for various test cases

--- a/deepwell/src/services/caddy/test.rs
+++ b/deepwell/src/services/caddy/test.rs
@@ -164,6 +164,7 @@ macro_rules! test_file_path {
 }
 
 const CADDYFILE_BASIC_PROD: &str = test_file_path!("basic_prod");
+const CADDYFILE_BASIC_PROD_HTTP: &str = test_file_path!("basic_prod_http");
 const CADDYFILE_BASIC_LOCAL: &str = test_file_path!("basic_local");
 const CADDYFILE_BASIC_LOCAL_DEV: &str = test_file_path!("basic_localdev");
 const CADDYFILE_BASIC_DIFFERENT_PROXIES: &str = test_file_path!("proxies");
@@ -264,7 +265,23 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: false,
             local: false,
+            auto_https: true,
             http_port: None,
+            https_port: None,
+            framerail_host: cow!(FRAMERAIL_HOST),
+            wws_host: cow!(WWS_HOST),
+        },
+    );
+
+    check!(
+        CADDYFILE_BASIC_PROD_HTTP,
+        config_basic,
+        sites_basic,
+        CaddyfileOptions {
+            debug: false,
+            local: false,
+            auto_https: false,
+            http_port: Some(80),
             https_port: None,
             framerail_host: cow!(FRAMERAIL_HOST),
             wws_host: cow!(WWS_HOST),
@@ -278,6 +295,7 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: false,
             local: true,
+            auto_https: true,
             http_port: None,
             https_port: None,
             framerail_host: cow!(FRAMERAIL_HOST),
@@ -292,6 +310,7 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: true,
             local: true,
+            auto_https: true,
             http_port: Some(8000),
             https_port: Some(8443),
             framerail_host: cow!(FRAMERAIL_HOST),
@@ -306,6 +325,7 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: false,
             local: false,
+            auto_https: true,
             http_port: None,
             https_port: None,
             framerail_host: cow!("web_proxy_host"),
@@ -320,6 +340,7 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: false,
             local: false,
+            auto_https: true,
             http_port: None,
             https_port: None,
             framerail_host: cow!(FRAMERAIL_HOST),
@@ -334,6 +355,7 @@ UNIT TEST INFO:
         CaddyfileOptions {
             debug: false,
             local: false,
+            auto_https: true,
             http_port: None,
             https_port: None,
             framerail_host: cow!(FRAMERAIL_HOST),

--- a/deepwell/test/caddy/Caddyfile.basic_local
+++ b/deepwell/test/caddy/Caddyfile.basic_local
@@ -53,7 +53,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 foo.wikijump.localhost {

--- a/deepwell/test/caddy/Caddyfile.basic_localdev
+++ b/deepwell/test/caddy/Caddyfile.basic_localdev
@@ -56,7 +56,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 foo.wikijump.localhost {

--- a/deepwell/test/caddy/Caddyfile.basic_prod
+++ b/deepwell/test/caddy/Caddyfile.basic_prod
@@ -51,7 +51,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 foo.wikijump.test {

--- a/deepwell/test/caddy/Caddyfile.basic_prod_http
+++ b/deepwell/test/caddy/Caddyfile.basic_prod_http
@@ -3,6 +3,8 @@
 	metrics {
 		per_host
 	}
+	http_port 80
+	auto_https off
 }
 
 (strip_headers) {

--- a/deepwell/test/caddy/Caddyfile.basic_prod_http
+++ b/deepwell/test/caddy/Caddyfile.basic_prod_http
@@ -53,7 +53,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 foo.wikijump.test {

--- a/deepwell/test/caddy/Caddyfile.full_prod
+++ b/deepwell/test/caddy/Caddyfile.full_prod
@@ -51,7 +51,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 wikijump.test {

--- a/deepwell/test/caddy/Caddyfile.long
+++ b/deepwell/test/caddy/Caddyfile.long
@@ -51,7 +51,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3000
+	reverse_proxy framerail:3393
 }
 
 foo.site.wikijump.com {

--- a/docs/deployment/dev.md
+++ b/docs/deployment/dev.md
@@ -1,0 +1,38 @@
+## Dev Environment
+
+This illustrates the setup for the [Dokploy](https://dokploy.com)-based dev tier hosting `wikijump.dev`:
+
+1. Create a Virtual Private Server with Ubuntu 24.04 LTS.
+2. Set up a non-root administrator account:
+```
+# adduser --disabled-password maintainer
+# gpasswd -a maintainer sudo
+```
+3. Disable password-based SSH (if not already disabled):
+```
+$ sudoedit /etc/ssh/sshd_config
+PasswordAuthentication no
+PermitEmptyPasswords no
+$ sudo systemctl reload ssh.service
+```
+4. Add SSH keys to enable login as `maintainer`:
+```
+$ mkdir -m700 .ssh
+$ nano .ssh/authorized_keys
+$ chmod 600 .ssh/authorized_keys
+```
+5. Install Dokploy:
+```
+# curl -sSL https://dokploy.com/install.sh | sh
+```
+6. Go to the new HTTP endpoint and set up the Dokploy owner account.
+7. Set up the HTTPS custom domain for Dokploy (here, `deploy.wikijump.dev`).
+8. Add [GitHub Container Registry to Dokploy](https://docs.dokploy.com/docs/core/registry/ghcr).
+9. Add S3 buckets to Dokploy and configure regular backups.
+10. Add git repository connection to Dokploy.
+11. Create "Wikijump" project.
+  1. Add PostgreSQL database. Set database / user to `wikijump`.
+  2. Add Valkey / Redis database.
+  3. Add "Compose" application. This uses the git repository to read the docker-compose file at `install/dev/docker-compose.yaml` on branch `develop`.
+12. Create all relevant domains (and subdomains) for the project. Each needs to point to `caddy` at port 80, and should have Let's Encrypt provide TLS certificates.
+13. Create deployments for all services.

--- a/framerail/vite.config.ts
+++ b/framerail/vite.config.ts
@@ -11,7 +11,7 @@ try {
 const config: UserConfig = {
   server: {
     host: "::",
-    port: 3000,
+    port: 3393,
     strictPort: true,
 
     // This setting was added to avoid a security issue:

--- a/install/common/framerail/health-check.sh
+++ b/install/common/framerail/health-check.sh
@@ -3,4 +3,4 @@ curl \
 	-If \
 	-H 'x-wikijump-site-slug: www' \
 	-H 'x-wikijump-site-id: 1' \
-	http://localhost:3000/
+	http://localhost:3393/

--- a/install/dev/caddy/request.json
+++ b/install/dev/caddy/request.json
@@ -5,7 +5,8 @@
 	"params": {
 		"debug": false,
 		"local": false,
-		"framerail_host": "framerail:3000",
+		"auto_https": false,
+		"framerail_host": "framerail:3008",
 		"wws_host": "wws:7000"
 	}
 }

--- a/install/dev/caddy/request.json
+++ b/install/dev/caddy/request.json
@@ -6,7 +6,7 @@
 		"debug": false,
 		"local": false,
 		"auto_https": false,
-		"framerail_host": "framerail:3008",
+		"framerail_host": "framerail:3393",
 		"wws_host": "wws:7000"
 	}
 }

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
   framerail:
     image: ghcr.io/scpwiki/wikijump:framerail-dev
     ports:
-      - "3008:3000"
+      - "3393:3393"
     links:
       - deepwell
     environment:

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -1,10 +1,20 @@
 services:
   deepwell:
-    build:
-      context: ../..
-      dockerfile: install/dev/deepwell/Dockerfile
+    image: ghcr.io/scpwiki/wikijump:deepwell-dev
     ports:
       - "2747:2747"
+    networks:
+      - dokploy-network
+    environment:
+      - "DATABASE_URL=${DATABASE_URL}"
+      - "REDIS_URL=${REDIS_URL}"
+      - "S3_FILES_BUCKET=${S3_FILES_BUCKET}"
+      - "S3_TEXT_BLOCKS_BUCKET=${S3_TEXT_BLOCKS_BUCKET}"
+      - "S3_REGION_NAME=${S3_REGION_NAME}"
+      - "S3_CUSTOM_ENDPOINT=${S3_CUSTOM_ENDPOINT}"
+      - "S3_PATH_STYLE=${S3_PATH_STYLE}"
+      - "S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}"
+      - "S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}"
     restart: always
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
@@ -15,11 +25,9 @@ services:
       start_interval: 10s
 
   framerail:
-    build:
-      context: ../..
-      dockerfile: install/dev/framerail/Dockerfile
+    image: ghcr.io/scpwiki/wikijump:framerail-dev
     ports:
-      - "3000:3000"
+      - "3008:3000"
     links:
       - deepwell
     environment:
@@ -35,16 +43,24 @@ services:
         condition: service_healthy
 
   wws:
-    build:
-      context: ../..
-      dockerfile: install/dev/wws/Dockerfile
+    image: ghcr.io/scpwiki/wikijump:wws-dev
     ports:
       - "7000:7000"
+    networks:
+      - dokploy-network
     links:
       - deepwell
     environment:
       - "ADDRESS=[::]:7000"
       - "DEEPWELL_URL=http://deepwell:2747"
+      - "REDIS_URL=${REDIS_URL}"
+      - "S3_FILES_BUCKET=${S3_FILES_BUCKET}"
+      - "S3_TEXT_BLOCKS_BUCKET=${S3_TEXT_BLOCKS_BUCKET}"
+      - "S3_REGION_NAME=${S3_REGION_NAME}"
+      - "S3_CUSTOM_ENDPOINT=${S3_CUSTOM_ENDPOINT}"
+      - "S3_PATH_STYLE=${S3_PATH_STYLE}"
+      - "S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}"
+      - "S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}"
     restart: always
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
@@ -56,13 +72,7 @@ services:
         condition: service_healthy
 
   caddy:
-    build:
-      context: ../..
-      dockerfile: install/dev/caddy/Dockerfile
-    ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"
+    image: ghcr.io/scpwiki/wikijump:caddy-dev
     links:
       - framerail
       - wws

--- a/install/dev/framerail/Dockerfile
+++ b/install/dev/framerail/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 USER node:node
 ENV NODE_ENV=production
 ENV FRAMERAIL_ENV=dev
-ENV PORT=3000
-EXPOSE 3000
+ENV PORT=3393
+EXPOSE 3393
 
 CMD ["/usr/local/bin/node", "build"]

--- a/install/local/caddy/request.json
+++ b/install/local/caddy/request.json
@@ -5,7 +5,7 @@
 	"params": {
 		"debug": false,
 		"local": true,
-		"framerail_host": "framerail:3000",
+		"framerail_host": "framerail:3393",
 		"wws_host": "wws:7000"
 	}
 }

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
       context: ../..
       dockerfile: install/local/framerail/Dockerfile
     ports:
-      - "3000:3000"
+      - "3393:3393"
     links:
       - deepwell
     environment:

--- a/install/local/framerail/Dockerfile
+++ b/install/local/framerail/Dockerfile
@@ -16,6 +16,6 @@ COPY ./install/local/framerail/health-check.sh /usr/local/bin/wikijump-health-ch
 # Install node dependencies
 RUN pnpm install
 
-EXPOSE 3000
+EXPOSE 3393
 ENV FRAMERAIL_ENV=local
 CMD ["pnpm", "dev"]

--- a/install/prod/caddy/request.json
+++ b/install/prod/caddy/request.json
@@ -5,7 +5,7 @@
 	"params": {
 		"debug": false,
 		"local": false,
-		"framerail_host": "framerail:3000",
+		"framerail_host": "framerail:3393",
 		"wws_host": "wws:7000"
 	}
 }

--- a/install/prod/framerail/Dockerfile
+++ b/install/prod/framerail/Dockerfile
@@ -24,6 +24,6 @@ RUN \
 USER node:node
 ENV NODE_ENV=production
 ENV FRAMERAIL_ENV=prod
-EXPOSE 3000
+EXPOSE 3393
 
 CMD ["/usr/local/bin/node", "build"]


### PR DESCRIPTION
I have been setting up our dev tier via Dokploy, which has necessitated some file changes to enable this:

* Updating the `docker-compose.yaml` for the Dokploy environment.
* Updating the `.env.example` file in deepwell.
* Updating the framerail port to 3393.
  * This is because Dokploy uses port 3000 internally, and we may as well make it something more unique. In this case, it's an article that's related to Foundation terminals, which is akin to the role framerail plays!
* Adding a `auto_https` option to CaddyService. This allows us to disable HTTPS redirects and getting TLS certificates since we have to be behind Traefik for Dokploy (something I'm not liking about it).
* Adding a documentation file for the dev tier.