### PR TITLE
Add commit hash to built images pushed to ECR

### DIFF
--- a/.github/workflows/docker-build-caddy.dev.yaml
+++ b/.github/workflows/docker-build-caddy.dev.yaml
@@ -35,4 +35,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-caddy.prod.yaml
+++ b/.github/workflows/docker-build-caddy.prod.yaml
@@ -35,4 +35,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-deepwell.dev.yaml
+++ b/.github/workflows/docker-build-deepwell.dev.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-deepwell.prod.yaml
+++ b/.github/workflows/docker-build-deepwell.prod.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-framerail.dev.yaml
+++ b/.github/workflows/docker-build-framerail.dev.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-framerail.prod.yaml
+++ b/.github/workflows/docker-build-framerail.prod.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-minio.test.yaml
+++ b/.github/workflows/docker-build-minio.test.yaml
@@ -35,4 +35,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-wws.dev.yaml
+++ b/.github/workflows/docker-build-wws.dev.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}

--- a/.github/workflows/docker-build-wws.prod.yaml
+++ b/.github/workflows/docker-build-wws.prod.yaml
@@ -36,4 +36,4 @@ jobs:
           secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
           region: us-east-2
           local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}


### PR DESCRIPTION
This adds an extra tag like `dev-a15a8bc2e7e70da68ffc32badfcc19e22262fcf8` to pushed images. This way we can see the associated tier and git commit for old builds. We prefix with the tier or the lifecycle policies.