### PR TITLE
Use unless-stopped restart policy

### DIFF
--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "S3_PATH_STYLE=${S3_PATH_STYLE}"
       - "S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}"
       - "S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -32,7 +32,7 @@ services:
       - deepwell
     environment:
       - "DEEPWELL_HOST=deepwell"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -61,7 +61,7 @@ services:
       - "S3_PATH_STYLE=${S3_PATH_STYLE}"
       - "S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}"
       - "S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -76,7 +76,7 @@ services:
     links:
       - framerail
       - wws
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 30s

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "POSTGRES_INITDB_ARGS=--locale en_US.UTF-8"
     ports:
       - "5432:5432"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 10s
@@ -20,7 +20,7 @@ services:
 
   files:
     build: minio
-    restart: always
+    restart: unless-stopped
     environment:
       - "MINIO_ROOT_USER=minio"
       - "MINIO_ROOT_PASSWORD=defaultpassword"
@@ -38,7 +38,7 @@ services:
 
   cache:
     build: valkey
-    restart: always
+    restart: unless-stopped
     # You can add a volume for /data if you wish
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
@@ -68,7 +68,7 @@ services:
       - "S3_CUSTOM_ENDPOINT=http://files:9000"
       - "S3_ACCESS_KEY_ID=minio"
       - "S3_SECRET_ACCESS_KEY=defaultpassword"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -94,7 +94,7 @@ services:
       - deepwell
     environment:
       - "DEEPWELL_HOST=deepwell"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -125,7 +125,7 @@ services:
       - "S3_CUSTOM_ENDPOINT=http://files:9000"
       - "S3_ACCESS_KEY_ID=minio"
       - "S3_SECRET_ACCESS_KEY=defaultpassword"
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 120s
@@ -152,7 +152,7 @@ services:
     links:
       - framerail
       - wws
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]
       interval: 30s


### PR DESCRIPTION
This policy is more in line with our intentions - we want the containers to restart on error, but if they are manually stopped we don't want them resurrecting themselves.

Testing by running locally.