### PR TITLE
[hotfix] Fix minio container build workflow path

### DIFF
--- a/.github/workflows/docker-push-minio.yaml
+++ b/.github/workflows/docker-push-minio.yaml
@@ -6,8 +6,7 @@ on:
       - develop
     paths:
       - 'install/local/minio/*'
-      - '.github/workflows/docker-build-minio.local.yaml'
-      - '.github/workflows/docker-push-minio.local.yaml'
+      - '.github/workflows/docker-push-minio.yaml'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Forgot to update this path when I changed the file.