### PR TITLE
Upgrade EmailService for changes in MailCheck API

### DIFF
--- a/deepwell/.env.example
+++ b/deepwell/.env.example
@@ -37,4 +37,8 @@ S3_SECRET_ACCESS_KEY=
 # But don't include both.
 AWS_PROFILE_NAME=wikijump
 
+# MailCheck API key
+# OPTIONAL - Code works without it, but you are significantly ratelimited (5 req/hour)
+MAILCHECK_API_KEY=
+
 # vim: set ft=sh:

--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.2.28"
+version = "2026.3.6"
 dependencies = [
  "argon2",
  "arraystring",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.2.28"
+version = "2026.3.6"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -28,8 +28,9 @@ CREATE TABLE "user" (
     last_name_change_added_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     last_renamed_at TIMESTAMP WITH TIME ZONE,
     email TEXT NOT NULL,  -- Can be empty, for instance with system accounts.
-    email_is_alias BOOLEAN,
     email_verified_at TIMESTAMP WITH TIME ZONE,
+    email_validation_info JSON,  -- Can be NULL if validation was skipped
+    email_validation_at TIMESTAMP WITH TIME ZONE,
     password TEXT NOT NULL,
     multi_factor_secret TEXT,
     multi_factor_recovery_codes TEXT[],
@@ -48,6 +49,9 @@ CREATE TABLE "user" (
 
     -- Both MFA columns should either be set or unset
     CHECK ((multi_factor_secret IS NULL) = (multi_factor_recovery_codes IS NULL)),
+
+    -- Both email validation columns should either be set or unset
+    CHECK ((email_validation_info IS NULL) = (email_validation_at IS NULL)),
 
     -- Locale must be unset for system users, but set for everyone else.
     CHECK ((user_type = 'system' AND locales = '{}') OR (user_type != 'system' AND locales != '{}')),

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -39,9 +39,10 @@ use crate::services::ServiceContext;
 use crate::services::blob::MimeAnalyzer;
 use crate::services::job::JobWorker;
 use crate::utils::debug_pointer;
-use crate::{database, redis as redis_db};
+use crate::{database, info, redis as redis_db};
 use jsonrpsee::server::{RpcModule, Server, ServerHandle};
 use redis::aio::MultiplexedConnection as RedisMultiplexedConnection;
+use reqwest::Client as ReqwestClient;
 use rsmq_async::Rsmq;
 use s3::bucket::Bucket;
 use sea_orm::{DatabaseConnection, TransactionTrait};
@@ -62,6 +63,7 @@ pub struct ServerStateInner {
     pub mime_analyzer: MimeAnalyzer,
     pub s3_files_bucket: Box<Bucket>,
     pub s3_tblocks_bucket: Box<Bucket>,
+    pub mailcheck_api_client: ReqwestClient,
 }
 
 impl Debug for ServerStateInner {
@@ -75,6 +77,7 @@ impl Debug for ServerStateInner {
             .field("mime_analyzer", &self.mime_analyzer)
             .field("s3_files_bucket", &self.s3_files_bucket)
             .field("s3_tblocks_bucket", &self.s3_tblocks_bucket)
+            .field("mailcheck_api_client", &self.mailcheck_api_client)
             .finish()
     }
 }
@@ -138,6 +141,31 @@ pub async fn build_server_state(
         (files_bucket, tblocks_bucket)
     };
 
+    // Set up reqwest client for the MailCheck API
+    let mailcheck_api_client = {
+        use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+        use reqwest::redirect::Policy as RedirectPolicy;
+
+        let mut builder = ReqwestClient::builder();
+
+        if let Some(mut api_token) = mailcheck_api_key {
+            // Authorization: Bearer {token}
+            api_token.insert_str(0, "Bearer ");
+            let value = HeaderValue::from_str(&api_token).or_raise(make_error)?;
+
+            let mut headers = HeaderMap::default();
+            headers.insert(AUTHORIZATION, value);
+            builder = builder.default_headers(headers);
+        }
+
+        builder
+            .user_agent(&*info::VERSION)
+            .redirect(RedirectPolicy::none())
+            .timeout(Duration::from_secs(2))
+            .build()
+            .or_raise(make_error)?
+    };
+
     // Build server state
     let state = Arc::new(ServerStateInner {
         config,
@@ -148,6 +176,7 @@ pub async fn build_server_state(
         mime_analyzer,
         s3_files_bucket,
         s3_tblocks_bucket,
+        mailcheck_api_client,
     });
 
     // Start workers listening to the job queue (requires ServerState)

--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -89,6 +89,7 @@ pub async fn build_server_state(
         s3_region,
         s3_path_style,
         s3_credentials,
+        mailcheck_api_key,
     }: Secrets,
 ) -> Result<ServerState> {
     let make_error =

--- a/deepwell/src/config/secrets.rs
+++ b/deepwell/src/config/secrets.rs
@@ -65,6 +65,15 @@ pub struct Secrets {
     /// Alternatively you can have it read from the AWS credentials file.
     /// The profile to read from can be set in the `AWS_PROFILE_NAME` environment variable.
     pub s3_credentials: Credentials,
+
+    /// MailCheck API key.
+    ///
+    /// **Optional**. The server will still work without an API key, but MailCheck will
+    /// heavily ratelimit you.
+    ///
+    /// * No API key: 5 requests / hour
+    /// * Free tier: 1000 requests / month
+    pub mailcheck_api_key: Option<String>,
 }
 
 impl Secrets {
@@ -150,6 +159,15 @@ impl Secrets {
             }
         };
 
+        let mailcheck_api_key = {
+            let value = get_env!("MAILCHECK_API_KEY");
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        };
+
         // Build and return
         Secrets {
             database_url,
@@ -159,6 +177,7 @@ impl Secrets {
             s3_region,
             s3_path_style,
             s3_credentials,
+            mailcheck_api_key,
         }
     }
 }

--- a/deepwell/src/config/secrets.rs
+++ b/deepwell/src/config/secrets.rs
@@ -21,6 +21,7 @@
 use dotenvy::dotenv;
 use ref_map::*;
 use s3::{creds::Credentials, region::Region};
+use std::env::VarError;
 use std::{env, process};
 
 #[derive(Debug, Clone)]
@@ -159,9 +160,16 @@ impl Secrets {
             }
         };
 
-        let mailcheck_api_key = {
-            let value = get_env!("MAILCHECK_API_KEY");
-            if value.is_empty() { None } else { Some(value) }
+        let mailcheck_api_key = match env::var("MAILCHECK_API_KEY") {
+            Ok(value) if value.is_empty() => None,
+            Ok(value) => Some(value),
+            Err(VarError::NotPresent) => None,
+            Err(error) => {
+                eprintln!(
+                    "Unable to read environment variable MAILCHECK_API_KEY: {error}"
+                );
+                process::exit(1);
+            }
         };
 
         // Build and return

--- a/deepwell/src/config/secrets.rs
+++ b/deepwell/src/config/secrets.rs
@@ -161,11 +161,7 @@ impl Secrets {
 
         let mailcheck_api_key = {
             let value = get_env!("MAILCHECK_API_KEY");
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
+            if value.is_empty() { None } else { Some(value) }
         };
 
         // Build and return

--- a/deepwell/src/endpoints/email.rs
+++ b/deepwell/src/endpoints/email.rs
@@ -22,13 +22,13 @@ use super::prelude::*;
 use crate::services::email::{EmailService, EmailValidationOutput};
 
 pub async fn validate_email(
-    _ctx: &ServiceContext<'_>,
+    ctx: &ServiceContext<'_>,
     params: Params<'static>,
 ) -> Result<EmailValidationOutput> {
     let email: String = parse_one!(params);
     info!("Validating user email: {email}");
 
-    EmailService::validate(&email)
+    EmailService::validate(ctx, &email)
         .await
         .or_raise(|| Error::new("failed to validate email", ErrorType::Request))
 }

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -28,9 +28,12 @@ pub struct Model {
     pub last_renamed_at: Option<TimeDateTimeWithTimeZone>,
     #[sea_orm(column_type = "Text")]
     pub email: String,
-    pub email_is_alias: Option<bool>,
     #[serde(with = "time::serde::rfc3339::option")]
     pub email_verified_at: Option<TimeDateTimeWithTimeZone>,
+    #[sea_orm(column_type = "Json", nullable)]
+    pub email_validation_info: Option<Json>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub email_validation_at: Option<TimeDateTimeWithTimeZone>,
     #[sea_orm(column_type = "Text")]
     pub password: String,
     #[sea_orm(column_type = "Text", nullable)]

--- a/deepwell/src/services/email/service.rs
+++ b/deepwell/src/services/email/service.rs
@@ -26,6 +26,13 @@ pub struct EmailService;
 impl EmailService {
     /// Validates an email through the MailCheck API.
     pub async fn validate(email: &str) -> Result<EmailValidationOutput> {
+        if email.is_empty() {
+            bail!(Error::new(
+                "cannot validate empty email string",
+                ErrorType::BadRequest,
+            ));
+        }
+
         let make_error = || {
             Error::new(
                 format!("failed to validate email '{email}'"),

--- a/deepwell/src/services/email/service.rs
+++ b/deepwell/src/services/email/service.rs
@@ -150,12 +150,10 @@ impl EmailService {
         if mailcheck.mx_providers.is_empty() {
             if mailcheck.public_domain {
                 provider_classification = EmailProviderClassification::PublicEmail;
+            } else if mailcheck.mx {
+                provider_classification = EmailProviderClassification::SelfHosted;
             } else {
-                if mailcheck.mx {
-                    provider_classification = EmailProviderClassification::SelfHosted;
-                } else {
-                    provider_classification = EmailProviderClassification::NoProvider;
-                }
+                provider_classification = EmailProviderClassification::NoProvider;
             }
         }
 

--- a/deepwell/src/services/email/service.rs
+++ b/deepwell/src/services/email/service.rs
@@ -48,67 +48,135 @@ impl EmailService {
             .await
             .or_raise(make_error)?;
 
-        // Create the output with default parameters.
-        let mut output = EmailValidationOutput::default();
+        let mailcheck = match mailcheck {
+            MailCheckResponse::Success(data) => data,
+            MailCheckResponse::Failure(MailCheckFailureResponse { status, error }) => {
+                match status {
+                    // Invalid request, bad email
+                    400 => {
+                        error!(
+                            "MailCheck API request failed with bad response: {}",
+                            error,
+                        );
+                        bail!(Error::new(
+                            format!(
+                                "failed to validate email, MailCheck API returned an error: {}",
+                                error,
+                            ),
+                            ErrorType::EmailVerification,
+                        ));
+                    }
 
-        // Check request status.
-        match mailcheck.status {
-            // Valid request.
-            200 => {}
+                    // Exceeded rate limit
+                    429 => {
+                        error!("MailCheck API hit ratelimit: {}", error);
+                        bail!(Error::new(
+                            "failed to validate email, MailCheck API hit ratelimit",
+                            ErrorType::RateLimited,
+                        ));
+                    }
 
-            // Invalid request.
-            400 => {
-                error!(
-                    "MailCheck API request failed with bad response: {:?}",
-                    mailcheck.error,
-                );
-
-                let mut message =
-                    str!("failed to validate email, MailCheck API returned an error");
-                if let Some(remote_error) = &mailcheck.error {
-                    str_write!(&mut message, ": {remote_error}");
+                    // Other statuses.
+                    _ => {
+                        error!(
+                            "MailCheck API returned error status {}: {}",
+                            status, error,
+                        );
+                        bail!(Error::new(
+                            format!(
+                                "failed to validate email, unexpected status {} from MailCheck: {}",
+                                status, error
+                            ),
+                            ErrorType::EmailVerification
+                        ));
+                    }
                 }
-                bail!(Error::new(message, ErrorType::EmailVerification));
             }
+        };
 
-            // Exceeded rate limit.
-            429 => {
-                error!("MailCheck API hit ratelimit: {:?}", mailcheck.error);
-                bail!(Error::new(
-                    "failed to validate email, MailCheck API hit ratelimit",
-                    ErrorType::RateLimited,
-                ));
-            }
+        if mailcheck.status != 200 {
+            error!(
+                "MailCheck API returned non-success status {} with no error message",
+                mailcheck.status,
+            );
+            bail!(Error::new(
+                format!(
+                    "failed to validate email, unexpected non-success status {} from MailCheck, but no error message",
+                    mailcheck.status,
+                ),
+                ErrorType::EmailVerification,
+            ));
+        }
 
-            // Other statuses.
-            _ => {
-                warn!(
-                    "MailCheck API returned status {}: {:?}",
-                    mailcheck.status, mailcheck.error,
-                );
-            }
+        // Prepare output fields
+        let mut valid = true;
+        let mut classification = EmailClassification::Normal;
+        let mut provider_classification = EmailProviderClassification::KnownProvider;
+        let mut normalized_email = None;
+
+        // Check if the email is a role email
+        // This is for addresses like "info@example.com" or "webmaster@example.com"
+        // which are likely managed by multiple people.
+        if mailcheck.role_account {
+            classification = EmailClassification::Role;
         }
 
         // Check if the email is an alias.
-        if mailcheck.alias {
-            output.classification = EmailClassification::Alias;
+        // This was previously a boolean, now it is a derived property
+        // from comparing the email with its derived counterpart.
+        if mailcheck.email != mailcheck.normalized_email {
+            classification = EmailClassification::Alias;
+            normalized_email = Some(mailcheck.normalized_email);
         }
 
-        // Check if the email is a disposable.
         if mailcheck.disposable {
-            output.valid = false;
-            output.classification = EmailClassification::Disposable;
+            valid = false;
+            classification = EmailClassification::Disposable;
         }
 
         // Check if the domain has any MX records.
+        // If not, it's not a valid email (we cannot send anything there)
         if !mailcheck.mx {
-            output.valid = false;
-            output.classification = EmailClassification::Invalid;
+            valid = false;
+            classification = EmailClassification::Invalid;
         }
 
-        // Set "did you mean" field to mailcheck response.
-        output.did_you_mean = mailcheck.did_you_mean;
+        if mailcheck.spam {
+            valid = false;
+            classification = EmailClassification::Spam;
+        }
 
-        Ok(output)
+        // Determine email provider classification if no mx_providers
+        if mailcheck.mx_providers.is_empty() {
+            if mailcheck.public_domain {
+                provider_classification = EmailProviderClassification::PublicEmail;
+            } else {
+                if mailcheck.mx {
+                    provider_classification = EmailProviderClassification::SelfHosted;
+                } else {
+                    provider_classification = EmailProviderClassification::NoProvider;
+                }
+            }
+        }
+
+        // Move other fields to output
+        Ok(EmailValidationOutput {
+            valid,
+            classification,
+            provider_classification,
+            email: mailcheck.email,
+            normalized_email,
+            domain: mailcheck.domain,
+            domain_age_in_days: mailcheck.domain_age_in_days,
+            mx: mailcheck.mx,
+            mx_records: mailcheck.mx_records,
+            mx_providers: mailcheck.mx_providers,
+            disposable: mailcheck.disposable,
+            public_domain: mailcheck.public_domain,
+            relay_domain: mailcheck.relay_domain,
+            role_account: mailcheck.role_account,
+            spam: mailcheck.spam,
+            did_you_mean: mailcheck.did_you_mean,
+        })
     }
 }

--- a/deepwell/src/services/email/service.rs
+++ b/deepwell/src/services/email/service.rs
@@ -25,7 +25,10 @@ pub struct EmailService;
 
 impl EmailService {
     /// Validates an email through the MailCheck API.
-    pub async fn validate(ctx: &ServiceContext<'_>, email: &str) -> Result<EmailValidationOutput> {
+    pub async fn validate(
+        ctx: &ServiceContext<'_>,
+        email: &str,
+    ) -> Result<EmailValidationOutput> {
         if email.is_empty() {
             bail!(Error::new(
                 "cannot validate empty email string",
@@ -33,6 +36,7 @@ impl EmailService {
             ));
         }
 
+        let state = ctx.state();
         let make_error = || {
             Error::new(
                 format!("failed to validate email '{email}'"),
@@ -41,7 +45,11 @@ impl EmailService {
         };
 
         // Sends a GET request to the MailCheck API and deserializes the response.
-        let mailcheck = reqwest::get(format!("https://api.mailcheck.ai/email/{email}"))
+        let request_url = format!("https://api.mailcheck.ai/email/{email}");
+        let mailcheck = state
+            .mailcheck_api_client
+            .get(request_url)
+            .send()
             .await
             .or_raise(make_error)?
             .json::<MailCheckResponse>()

--- a/deepwell/src/services/email/service.rs
+++ b/deepwell/src/services/email/service.rs
@@ -25,7 +25,7 @@ pub struct EmailService;
 
 impl EmailService {
     /// Validates an email through the MailCheck API.
-    pub async fn validate(email: &str) -> Result<EmailValidationOutput> {
+    pub async fn validate(ctx: &ServiceContext<'_>, email: &str) -> Result<EmailValidationOutput> {
         if email.is_empty() {
             bail!(Error::new(
                 "cannot validate empty email string",

--- a/deepwell/src/services/email/structs.rs
+++ b/deepwell/src/services/email/structs.rs
@@ -72,7 +72,7 @@ pub struct MxProvider {
 
 /// The kind of email provider this MX record is for.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-#[serde(rename = "snake_case")] // set by MailCheck, don't change!
+#[serde(rename_all = "snake_case")] // set by MailCheck, don't change!
 pub enum MxProviderType {
     /// Full mailbox provider (e.g. Google Workspace, Microsoft 365, Fastmail)
     Mailbox,
@@ -91,7 +91,7 @@ pub enum MxProviderType {
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-#[serde(rename = "snake_case")] // set by MailCheck
+#[serde(rename_all = "snake_case")] // set by MailCheck
 pub enum MxProviderGrade {
     /// High-involvement providers with sales processes and contracts (e.g. Mimecast, Proofpoint)
     Enterprise,

--- a/deepwell/src/services/email/structs.rs
+++ b/deepwell/src/services/email/structs.rs
@@ -20,43 +20,135 @@
 
 use serde::{Deserialize, Serialize};
 
-/// A deserialized response from the MailCheck API.
+// As of March 2026, see https://www.usercheck.com/docs/api/email-endpoint.md for information
+
+/// A response from the MailCheck API.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum MailCheckResponse {
+    Success(MailCheckSuccessResponse),
+    Failure(MailCheckFailureResponse),
+}
+
+/// A deserialized successful response from the MailCheck API.
 ///
 /// Describes all the fields received from the API, but not all fields are used.
 #[derive(Deserialize, Debug, Clone)]
-#[allow(dead_code)]
-pub struct MailCheckResponse {
+pub struct MailCheckSuccessResponse {
     pub status: u16,
     pub email: String,
+    pub normalized_email: String,
     pub domain: String,
+    pub domain_age_in_days: Option<u32>,
     pub mx: bool,
+    pub mx_records: Vec<MxRecord>,
+    pub mx_providers: Vec<MxProvider>,
     pub disposable: bool,
-    pub alias: bool,
+    pub public_domain: bool,
+    pub relay_domain: bool,
+    pub role_account: bool,
+    pub spam: bool,
     pub did_you_mean: Option<String>,
-    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct MailCheckFailureResponse {
+    pub status: u16,
+    pub error: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MxRecord {
+    pub hostname: String,
+    pub priority: i32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MxProvider {
+    pub slug: String,
+    pub r#type: MxProviderType,
+    pub grade: MxProviderGrade,
+}
+
+/// The kind of email provider this MX record is for.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename = "snake_case")] // set by MailCheck, don't change!
+pub enum MxProviderType {
+    /// Full mailbox provider (e.g. Google Workspace, Microsoft 365, Fastmail)
+    Mailbox,
+
+    /// Web hosting provider with bundled email (e.g. GoDaddy, OVH, Hostinger)
+    Hosting,
+
+    /// Transactional / programmable email API service (e.g. Mailgun, SendGrid, Postmark)
+    EmailApi,
+
+    /// Email security or filtering gateway (e.g. Mimecast, Barracuda, Proofpoint)
+    SecurityGateway,
+
+    /// Email forwarding or relay service (e.g. Cloudflare, ImprovMX, SimpleLogin)
+    Forwarding,
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename = "snake_case")] // set by MailCheck
+pub enum MxProviderGrade {
+    /// High-involvement providers with sales processes and contracts (e.g. Mimecast, Proofpoint)
+    Enterprise,
+
+    /// Established paid providers (e.g. Google Workspace, Microsoft 365)
+    Professional,
+
+    /// Mid-range providers, moderate onboarding
+    Standard,
+
+    /// Low barrier to entry, minimal verification (e.g. free email hosting service)
+    Basic,
 }
 
 #[derive(Serialize, Debug, Clone)]
 pub struct EmailValidationOutput {
     pub valid: bool,
     pub classification: EmailClassification,
+    pub provider_classification: EmailProviderClassification,
+    pub email: String,
+    pub normalized_email: Option<String>,
+    pub domain: String,
+    pub domain_age_in_days: Option<u32>,
+    pub mx: bool,
+    pub mx_records: Vec<MxRecord>,
+    pub mx_providers: Vec<MxProvider>,
+    pub disposable: bool,
+    pub public_domain: bool,
+    pub relay_domain: bool,
+    pub role_account: bool,
+    pub spam: bool,
     pub did_you_mean: Option<String>,
 }
 
-impl Default for EmailValidationOutput {
-    fn default() -> Self {
-        EmailValidationOutput {
-            valid: true,
-            classification: EmailClassification::Normal,
-            did_you_mean: None,
-        }
-    }
-}
-
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum EmailClassification {
     Normal,
-    Disposable,
     Alias,
+    Role,
+    Disposable,
+    Spam,
     Invalid,
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EmailProviderClassification {
+    /// Known provider, see `mx_providers` field for information.
+    KnownProvider,
+
+    /// Public email service that runs its own infrastructure.
+    PublicEmail,
+
+    /// Self-hosted or otherwise unrecognized email infrastructure.
+    SelfHosted,
+
+    /// No detected email infrastructure.
+    NoProvider,
 }

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -100,7 +100,7 @@ impl SiteService {
                 locales: vec![locale],
                 password: String::new(),
                 bypass_filter: false,
-                bypass_email_verification: false,
+                bypass_email_verification: true,
                 ip_address,
             },
         )

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -154,6 +154,7 @@ impl UserService {
         let alias_exists = AliasService::exists(ctx, AliasType::User, &slug)
             .await
             .or_raise(make_error)?;
+
         if alias_exists {
             error!("User alias with conflicting slug already exists, cannot create");
             error!("Checked slug '{slug}'");
@@ -984,12 +985,27 @@ fn check_email_validation(
             Ok(true)
         }
 
+        EmailClassification::Role => {
+            info!(
+                "User {user_slug}'s email was verified successfully (as a role account)"
+            );
+            Ok(true)
+        }
+
         EmailClassification::Disposable => {
             error!(
                 "User {user_slug}'s email is disposable and did not pass verification",
             );
             bail!(Error::new(
                 "cannot create user, disposable emails are not permitted",
+                ErrorType::DisallowedEmail,
+            ));
+        }
+
+        EmailClassification::Spam => {
+            error!("User {user_slug}'s email is spam and did not pass verification",);
+            bail!(Error::new(
+                "cannot create user, email address flagged as spam",
                 ErrorType::DisallowedEmail,
             ));
         }

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -206,7 +206,7 @@ impl UserService {
         let (email_validation_json, email_validation_at) =
             if !bypass_email_verification && !email.is_empty() {
                 let email_validation_output =
-                    EmailService::validate(&email).await.or_raise(make_error)?;
+                    EmailService::validate(ctx, &email).await.or_raise(make_error)?;
 
                 let email_validation_json =
                     check_email_validation(&slug, &email_validation_output)
@@ -449,7 +449,7 @@ impl UserService {
 
             // Validate email
             let email_validation_output =
-                EmailService::validate(&email).await.or_raise(make_error)?;
+                EmailService::validate(ctx, &email).await.or_raise(make_error)?;
 
             let email_validation_json =
                 check_email_validation(&user.slug, &email_validation_output)

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -24,12 +24,13 @@ use crate::models::user::{self, Entity as User, Model as UserModel};
 use crate::services::alias::CreateAlias;
 use crate::services::audit::{AuditEvent, AuditService};
 use crate::services::blob::{BlobService, FinalizeBlobUploadOutput};
-use crate::services::email::{EmailClassification, EmailService};
+use crate::services::email::{EmailClassification, EmailService, EmailValidationOutput};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{AliasService, FilterService, PasswordService};
 use crate::utils::regex_replace_in_place;
 use regex::Regex;
 use sea_orm::ActiveValue;
+use serde_json::Value as JsonValue;
 use std::borrow::Cow;
 use std::cmp;
 use std::net::IpAddr;
@@ -202,19 +203,20 @@ impl UserService {
         //
         // Also bypass email verification if it's empty (obviously invalid).
         // We've already checked for empty emails above (e.g. system users can have empty emails).
-        let email_is_alias = if !bypass_email_verification && !email.is_empty() {
-            let email_validation_output =
-                EmailService::validate(&email).await.or_raise(make_error)?;
+        let (email_validation_json, email_validation_at) =
+            if !bypass_email_verification && !email.is_empty() {
+                let email_validation_output =
+                    EmailService::validate(&email).await.or_raise(make_error)?;
 
-            let is_alias =
-                check_email_validation(&slug, email_validation_output.classification)
-                    .or_raise(make_error)?;
+                let email_validation_json =
+                    check_email_validation(&slug, &email_validation_output)
+                        .or_raise(make_error)?;
 
-            Some(is_alias)
-        } else {
-            // Skipping email verification
-            None
-        };
+                (Some(email_validation_json), Some(now()))
+            } else {
+                // Skipping email validation
+                (None, None)
+            };
 
         // Insert new model
         let user = user::ActiveModel {
@@ -223,8 +225,9 @@ impl UserService {
             slug: Set(slug.clone()),
             name_changes_left: Set(ctx.config().default_name_changes),
             email: Set(email.clone()),
-            email_is_alias: Set(email_is_alias),
-            email_verified_at: Set(email_is_alias.map(|_| now())),
+            email_verified_at: Set(None),
+            email_validation_info: Set(email_validation_json),
+            email_validation_at: Set(email_validation_at),
             password: Set(password),
             multi_factor_secret: Set(None),
             multi_factor_recovery_codes: Set(None),
@@ -448,14 +451,13 @@ impl UserService {
             let email_validation_output =
                 EmailService::validate(&email).await.or_raise(make_error)?;
 
-            let is_alias = check_email_validation(
-                &user.slug,
-                email_validation_output.classification,
-            )?;
+            let email_validation_json =
+                check_email_validation(&user.slug, &email_validation_output)
+                    .or_raise(make_error)?;
 
             model.email = Set(email);
-            model.email_is_alias = Set(Some(is_alias));
-            model.email_verified_at = Set(Some(now()))
+            model.email_validation_info = Set(Some(email_validation_json));
+            model.email_validation_at = Set(Some(now()))
         }
 
         if let Maybe::Set(email_verified) = input.email_verified {
@@ -972,24 +974,31 @@ fn check_user_name(config: &Config, slug: &str, name: &str) -> Result<()> {
 
 fn check_email_validation(
     user_slug: &str,
-    classification: EmailClassification,
-) -> Result<bool> {
-    match classification {
+    validation_output: &EmailValidationOutput,
+) -> Result<JsonValue> {
+    let make_error = || {
+        Error::new(
+            format!(
+                "failed to validate email for user '{}':\n{:#?}",
+                user_slug, validation_output,
+            ),
+            ErrorType::EmailVerification,
+        )
+    };
+
+    match validation_output.classification {
         EmailClassification::Normal => {
-            info!("User {user_slug}'s email was verified successfully");
-            Ok(false)
+            info!("User {user_slug}'s email was validated successfully");
         }
 
         EmailClassification::Alias => {
-            info!("User {user_slug}'s email was verified successfully (as an alias)");
-            Ok(true)
+            info!("User {user_slug}'s email was validated successfully (is an alias)");
         }
 
         EmailClassification::Role => {
             info!(
-                "User {user_slug}'s email was verified successfully (as a role account)"
+                "User {user_slug}'s email was verified successfully (is a role account)"
             );
-            Ok(true)
         }
 
         EmailClassification::Disposable => {
@@ -1018,4 +1027,7 @@ fn check_email_validation(
             ));
         }
     }
+
+    let validation_json = serde_json::to_value(validation_output).or_raise(make_error)?;
+    Ok(validation_json)
 }

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -205,8 +205,9 @@ impl UserService {
         // We've already checked for empty emails above (e.g. system users can have empty emails).
         let (email_validation_json, email_validation_at) =
             if !bypass_email_verification && !email.is_empty() {
-                let email_validation_output =
-                    EmailService::validate(ctx, &email).await.or_raise(make_error)?;
+                let email_validation_output = EmailService::validate(ctx, &email)
+                    .await
+                    .or_raise(make_error)?;
 
                 let email_validation_json =
                     check_email_validation(&slug, &email_validation_output)
@@ -448,8 +449,9 @@ impl UserService {
             }
 
             // Validate email
-            let email_validation_output =
-                EmailService::validate(ctx, &email).await.or_raise(make_error)?;
+            let email_validation_output = EmailService::validate(ctx, &email)
+                .await
+                .or_raise(make_error)?;
 
             let email_validation_json =
                 check_email_validation(&user.slug, &email_validation_output)


### PR DESCRIPTION
The MailCheck API has made some changes to its response shape, along with a lower unauthenticated rate limit.

This PR addresses this and a few other issues with `EmailService`:
* Updates the response structures used to understand the API. This adds several more fields, and also avoids the now-deprecated `alias` field.
* Stores the whole MailCheck response in the database for future reference. Presently only the alias information was stored.
* Separates email verification time (when the user confirms that the email belongs to them) from email validation time (when we ran it through the MailCheck API).
* Optionally allows setting the `MAILCHECK_API_KEY` environment variable for using a non-anonymous requests.
* Bypass the email verification check for site users. (Not relevant and wastes our rate limit).
* Doesn't request on empty email strings.
* Adds rustdoc comments for the MailCheck API fields.
* Bumps version to `2026.3.6`.

I tested local user creation, both for valid and invalid emails.