### PR TITLE
Change recipients column to plain JSON

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -691,7 +691,7 @@ CREATE TABLE message_draft (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE,
     user_id BIGINT NOT NULL REFERENCES "user"(user_id),
-    recipients JSONB NOT NULL,
+    recipients JSON NOT NULL,
 
     -- Text contents
     subject TEXT NOT NULL,


### PR DESCRIPTION
While the Sea-ORM codegen script has trouble with it, it seems that the library does have support for plain `JSON` (without the indexing intrinsic to `JSONB`, which we don't need for this column).

Discovered while working on #2736 

Tested through a `MessageService::create_draft()` call, which has successfully written to the database:
<img width="945" height="159" alt="image" src="https://github.com/user-attachments/assets/725e01d1-681e-4ba6-b70a-82c4ac184405" />
