### PR TITLE
Add better errors for filter failures

### DIFF
--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -14,6 +14,14 @@
         "user": true
     },
     {
+        "site": "www",
+        "regex": "^(foo|bar)-",
+        "description": "Pages or files starting with foo or bar aren't allowed (example)",
+        "case-sensitive": true,
+        "page": true,
+        "file": true
+    },
+    {
         "site": null,
         "regex": "^.*@example\\.net$",
         "description": "Cannot join using example.net emails (example)",

--- a/deepwell/seeder/filters.json
+++ b/deepwell/seeder/filters.json
@@ -15,8 +15,8 @@
     },
     {
         "site": null,
-        "regex": "^.*@example\\.com$",
-        "description": "Cannot join using example.com emails (example)",
+        "regex": "^.*@example\\.net$",
+        "description": "Cannot join using example.net emails (example)",
         "case-sensitive": false,
         "email": true
     },

--- a/deepwell/src/error/convert.rs
+++ b/deepwell/src/error/convert.rs
@@ -28,7 +28,7 @@ use super::{Error, ErrorType};
 use exn::{ErrorExt, Exn, Frame};
 use jsonrpsee::types::error::ErrorObjectOwned;
 use sea_orm::TransactionError;
-use serde_json::json;
+use serde_json::{Value as JsonValue, json};
 
 /// Unwraps Sea-ORM transaction error into a standard crate error.
 ///
@@ -60,11 +60,16 @@ pub fn exn_error_to_rpc_error(exn_error: Exn<Error>) -> ErrorObjectOwned {
         JsonrpcError(&'e ErrorObjectOwned),
     }
 
-    fn walk<'e>(frame: &'e Frame, code_trace: &mut Vec<i32>) -> Option<TopError<'e>> {
+    fn walk<'e>(
+        frame: &'e Frame,
+        code_trace: &mut Vec<i32>,
+        extra_data: &mut Vec<JsonValue>,
+    ) -> Option<TopError<'e>> {
         let crate_error = frame.error().downcast_ref::<Error>();
         if let Some(error) = crate_error {
-            // Log error code for trace
+            // Add error code and data for history
             code_trace.push(error.code());
+            extra_data.push(error.data());
 
             // If acceptable, return
             if !error.error_type.is_high_level() {
@@ -78,12 +83,22 @@ pub fn exn_error_to_rpc_error(exn_error: Exn<Error>) -> ErrorObjectOwned {
             _ => frame
                 .children()
                 .iter()
-                .find_map(|frame| walk(frame, code_trace)),
+                .find_map(|frame| walk(frame, code_trace, extra_data)),
         }
     }
 
     let mut code_trace = Vec::new();
-    let top_error = walk(exn_error.frame(), &mut code_trace);
+    let mut extra_data = Vec::new();
+    let top_error = walk(exn_error.frame(), &mut code_trace, &mut extra_data);
+
+    // Special case
+    // If all the extra data fields are null, then just replace the list with that.
+    let extra_data = if extra_data.iter().all(JsonValue::is_null) {
+        None
+    } else {
+        Some(extra_data)
+    };
+
     match top_error {
         // Get the top non-request crate error
         Some(TopError::CrateError(error)) => {
@@ -98,7 +113,7 @@ pub fn exn_error_to_rpc_error(exn_error: Exn<Error>) -> ErrorObjectOwned {
                 _ => Some(json!({
                     "call_trace": format!("{exn_error:?}"),
                     "code_trace": code_trace,
-                    "extra": error.data(),
+                    "extra": extra_data,
                 })),
             };
             ErrorObjectOwned::owned(error_code, message, data)
@@ -114,6 +129,7 @@ pub fn exn_error_to_rpc_error(exn_error: Exn<Error>) -> ErrorObjectOwned {
             let data = json!({
                 "call_trace": format!("{exn_error:?}"),
                 "code_trace": code_trace,
+                "extra": extra_data,
             });
             ErrorObjectOwned::owned(0, message, Some(data))
         }

--- a/deepwell/src/error/error_type.rs
+++ b/deepwell/src/error/error_type.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::hash::BlobHash;
+use crate::services::filter::FilterSummary;
 use crate::services::view::ViewType;
 use fluent::FluentError;
 use fluent_syntax::parser::ParserError as FluentParserError;
@@ -184,6 +185,7 @@ pub enum ErrorType {
     FilterViolation {
         field: String,
         value: String,
+        failed: Vec<FilterSummary>,
     },
     FilterRegexInvalid {
         regex: String,

--- a/deepwell/src/error/error_type.rs
+++ b/deepwell/src/error/error_type.rs
@@ -731,8 +731,21 @@ impl ErrorType {
     pub fn data(&self) -> JsonValue {
         use crate::hash::blob_hash_to_hex;
         use serde_json::json;
+        use std::fmt::Display;
+
+        fn misc_errors_to_json<T: Display>(errors: &[T]) -> JsonValue {
+            errors
+                .iter()
+                .map(|e| JsonValue::from(str!(e)))
+                .collect::<Vec<_>>()
+                .into()
+        }
 
         match self {
+            ErrorType::GetView(view_type) => json!(view_type),
+            ErrorType::Fluent(errors) => misc_errors_to_json(errors),
+            ErrorType::FluentParser(errors) => misc_errors_to_json(errors),
+            ErrorType::Cryptography(extra) => json!(extra),
             ErrorType::SessionUserId {
                 active_user_id,
                 session_user_id,
@@ -740,13 +753,39 @@ impl ErrorType {
                 "active_user_id": active_user_id,
                 "session_user_id": session_user_id,
             }),
-            ErrorType::BlobSizeMismatch { expected, actual } => json!({
-                "expected": expected,
-                "actual": actual,
-            }),
             ErrorType::FileNameTooLong { length, maximum } => json!({
                 "length": length,
                 "maximum": maximum,
+            }),
+            ErrorType::LocaleInvalid { locale } | ErrorType::LocaleMissing { locale } => {
+                json!({ "locale": locale })
+            }
+            ErrorType::LocaleMessageMissing { message_key }
+            | ErrorType::LocaleMessageValueMissing { message_key } => json!({
+                "message_key": message_key,
+            }),
+            ErrorType::LocaleMessageAttributeMissing {
+                message_key,
+                attribute,
+            } => json!({
+                "message_key": message_key,
+                "attribute": attribute,
+            }),
+            ErrorType::FilterViolation {
+                field,
+                value,
+                failed,
+            } => json!({
+                "field": field,
+                "value": value,
+                "failed": failed,
+            }),
+            ErrorType::FilterRegexInvalid { regex } => json!({
+                "regex": regex,
+            }),
+            ErrorType::BlobSizeMismatch { expected, actual } => json!({
+                "expected": expected,
+                "actual": actual,
             }),
             ErrorType::BlobBlacklisted(bytes) => json!(*blob_hash_to_hex(bytes)),
             _ => json!(null),

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -63,12 +63,14 @@ impl FilterMatcher {
             return Ok(());
         }
 
+        let mut failed = Vec::new();
         for index in matches {
-            let description = &self.filter_data[index];
+            let info = &self.filter_data[index];
             error!(
                 "String failed filter ID {} (regex '{}'): {}",
-                description.filter_id, description.regex, description.description,
+                info.filter_id, info.regex, info.description,
             );
+            failed.push(info.clone());
 
             // TODO audit log, with contextual data (what it's checking)
             //      (will need to add extra args)
@@ -80,6 +82,7 @@ impl FilterMatcher {
             ErrorType::FilterViolation {
                 field: str!(field),
                 value: str!(text),
+                failed,
             },
         ));
     }

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use regex::RegexSet;
 
 /// Describes one filter which a `FilterMatcher` can verify against.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct FilterSummary {
     pub filter_id: i64,
     pub regex: String,

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -25,6 +25,7 @@ use regex::RegexSet;
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct FilterSummary {
     pub filter_id: i64,
+    pub regex: String,
     pub description: String,
 }
 
@@ -65,8 +66,8 @@ impl FilterMatcher {
         for index in matches {
             let description = &self.filter_data[index];
             error!(
-                "String failed filter ID {}: {}",
-                description.filter_id, description.description,
+                "String failed filter ID {} (regex '{}'): {}",
+                description.filter_id, description.regex, description.description,
             );
 
             // TODO audit log, with contextual data (what it's checking)

--- a/deepwell/src/services/filter/service.rs
+++ b/deepwell/src/services/filter/service.rs
@@ -115,11 +115,15 @@ impl FilterService {
 
         info!("Updating filter with ID {filter_id}");
 
+        let regex2 = regex.to_option().cloned();
         let make_error = || {
-            Error::new(
-                format!("failed to update filter ID {}", filter_id),
-                ErrorType::Filter,
-            )
+            let mut message = format!("failed to update filter ID {filter_id}");
+
+            if let Some(regex) = regex2 {
+                str_write!(&mut message, " (new regex '{regex}')");
+            }
+
+            Error::new(message, ErrorType::Filter)
         };
 
         let mut model = filter::ActiveModel {
@@ -398,11 +402,12 @@ impl FilterService {
             ..
         } in filters
         {
-            regexes.push(regex);
             filter_data.push(FilterSummary {
                 filter_id,
+                regex: str!(regex.as_str()),
                 description,
             });
+            regexes.push(regex);
         }
 
         let regex_set = RegexSet::new(regexes).or_raise(|| {


### PR DESCRIPTION
While working on #2736, I noticed that the errors produced by our new error system could be improved. This is something that we will periodically bump in to, as we enhance error messages with additional context while we work on them.

This change adds the regex of the failed filter(s) to the logging, but also more broadly exposes the contextual error data to the full error result.

With the `exn` crate, we have a layered error system which shows the call trace that this error took to fail. Our `ErrorType` also has associated contextual data, but all except for the top-most layer is not preserved.

This changes that, instead having a _list_ of the associated error data under the field `extra`.

New call trace:
```
[1001] method 'user_create' failed, at src/api.rs:378:5
|
|-> [1008] failed to create user, at src/endpoints/user.rs:37:10
|
|-> [1008] failed to create user 'some-person' with email 'foobar@example.net', at src/services/user/service.rs:86:13
|
|-> [1008] user failed email filter, at src/services/user/service.rs:867:14
|
|-> [5100] filter failure for field 'email', at src/services/filter/matcher.rs:80:9
```

JSON:
```json
{
    "code": 5100,
    "message": "The request violates a configured content filter",
    "data": {
        "call_trace": "[... see above ...]",
        "code_trace": [
            1001,
            1008,
            1008,
            1008,
            5100
        ],
        "extra": [
            null,
            null,
            null,
            null,
            {
                "failed": [
                    {
                        "description": "Cannot join using example.net emails (example)",
                        "filter_id": 4,
                        "regex": "(?i)^.*@example\\.net$"
                    }
                ],
                "field": "email",
                "value": "foobar@example.net"
            }
        ]
    }
}
```

This shows which filter(s) failed, the regex that triggered it, and the listed description value associated with the filter.