### PR TITLE
Hotfix: Don't import tls section on local

### DIFF
--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -223,7 +223,9 @@ Or - it's local, in which case the certificates don't matter, so do that
 # Missing canonical domains
 {% if should_use_wildcard -%}
 *{{ main_domain }} {
+	{%- if !local %}
 	import wildcard_tls
+	{%- endif %}
 {%- else -%}
 http://*{{ main_domain }},
 http://*{{ files_domain }} {

--- a/deepwell/test/caddy/Caddyfile.basic_local
+++ b/deepwell/test/caddy/Caddyfile.basic_local
@@ -146,7 +146,6 @@ wjfiles.localhost {
 
 # Missing canonical domains
 *.wikijump.localhost {
-	import wildcard_tls
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}

--- a/deepwell/test/caddy/Caddyfile.basic_localdev
+++ b/deepwell/test/caddy/Caddyfile.basic_localdev
@@ -149,7 +149,6 @@ wjfiles.localhost {
 
 # Missing canonical domains
 *.wikijump.localhost {
-	import wildcard_tls
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}

--- a/install/local/docker-compose.dev.yaml
+++ b/install/local/docker-compose.dev.yaml
@@ -25,6 +25,10 @@ services:
         read_only: true
       # Configuration data
       - type: bind
+        source: ../../deepwell/askama.toml
+        target: /src/deepwell/askama.toml
+        read_only: true
+      - type: bind
         source: ../../install/local/deepwell/config.toml
         target: /etc/deepwell.toml
       # Translation data


### PR DESCRIPTION
Local is a situation where we _do_ use wildcards (since we have fake certs) but _don't_ have a `wildcard_tls` section to import (for the same reason).

Runs locally:
<img width="1177" height="337" alt="image" src="https://github.com/user-attachments/assets/44fc4811-ec0a-45b4-8830-6ddf0adad750" />
