### PR TITLE
Add more options to generated Caddyfiles

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.3.8"
+version = "2026.3.12"
 dependencies = [
  "argon2",
  "arraystring",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.3.8"
+version = "2026.3.12"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -77,6 +77,29 @@ www.{{ domain }} {
 	}
 }
 {% endif %}
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to {{ framerail_host }}
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to {{ wws_host }}
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 
 {%- if let Some(deploy_host) = deploy_host %}
 #
@@ -108,7 +131,7 @@ deploy{{ files_domain }} {
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy {{ wws_host }}
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -135,7 +158,7 @@ deploy{{ files_domain }} {
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy {{ framerail_host }}
+	import reverse_proxy_framerail
 }
 
 {% for (site_id, site_slug, preferred_domain) in sites -%}
@@ -173,14 +196,14 @@ deploy{{ files_domain }} {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy {{ wws_host }}
+	import reverse_proxy_wws *
 }
 
 {{ files_domain_no_dot }} {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy {{ wws_host }}
+	import reverse_proxy_wws *
 }
 {% if should_use_wildcard -%}
 {#
@@ -237,7 +260,7 @@ http://*{{ files_domain }} {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.{{ self::site_slug_split_index(main_domain) }}}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy {{ wws_host }}
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -127,6 +127,9 @@ deploy{{ files_domain }} {
 	}
 	redir @redirect https://{vars.site_slug}{{ files_domain }}{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.basic_local
+++ b/deepwell/test/caddy/Caddyfile.basic_local
@@ -50,6 +50,9 @@
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.localhost{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.basic_local
+++ b/deepwell/test/caddy/Caddyfile.basic_local
@@ -14,6 +14,29 @@
 	request_header -X-Wikijump-*
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to framerail:3393
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws:3466
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # MAIN
 #
@@ -31,7 +54,7 @@
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws:3466
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -58,7 +81,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3393
+	import reverse_proxy_framerail
 }
 
 
@@ -117,14 +140,14 @@ www.example.com {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 wjfiles.localhost {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 *.wjfiles.localhost {
@@ -153,7 +176,7 @@ wjfiles.localhost {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/test/caddy/Caddyfile.basic_localdev
+++ b/deepwell/test/caddy/Caddyfile.basic_localdev
@@ -53,6 +53,9 @@
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.localhost{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.basic_localdev
+++ b/deepwell/test/caddy/Caddyfile.basic_localdev
@@ -17,6 +17,29 @@
 	request_header -X-Wikijump-*
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to framerail:3393
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws:3466
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # MAIN
 #
@@ -34,7 +57,7 @@
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws:3466
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -61,7 +84,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3393
+	import reverse_proxy_framerail
 }
 
 
@@ -120,14 +143,14 @@ www.example.com {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 wjfiles.localhost {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 *.wjfiles.localhost {
@@ -156,7 +179,7 @@ wjfiles.localhost {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/test/caddy/Caddyfile.basic_prod
+++ b/deepwell/test/caddy/Caddyfile.basic_prod
@@ -20,6 +20,29 @@
 	}
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to framerail:3393
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws:3466
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # INFRASTRUCTURE
 #
@@ -49,7 +72,7 @@ deploy.wjfiles.test {
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws:3466
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -76,7 +99,7 @@ deploy.wjfiles.test {
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3393
+	import reverse_proxy_framerail
 }
 
 
@@ -135,14 +158,14 @@ www.example.com {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 wjfiles.test {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 *.wjfiles.test {
@@ -173,7 +196,7 @@ wjfiles.test {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/test/caddy/Caddyfile.basic_prod
+++ b/deepwell/test/caddy/Caddyfile.basic_prod
@@ -68,6 +68,9 @@ deploy.wjfiles.test {
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.test{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.full_prod
+++ b/deepwell/test/caddy/Caddyfile.full_prod
@@ -68,6 +68,9 @@ deploy.wjfiles.test {
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.test{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.full_prod
+++ b/deepwell/test/caddy/Caddyfile.full_prod
@@ -20,6 +20,29 @@
 	}
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to framerail:3393
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws:3466
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # INFRASTRUCTURE
 #
@@ -49,7 +72,7 @@ deploy.wjfiles.test {
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws:3466
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -76,7 +99,7 @@ deploy.wjfiles.test {
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3393
+	import reverse_proxy_framerail
 }
 
 
@@ -230,14 +253,14 @@ www.scpwiki.wikijump.test {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 wjfiles.test {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 *.wjfiles.test {
@@ -277,7 +300,7 @@ wjfiles.test {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/test/caddy/Caddyfile.long
+++ b/deepwell/test/caddy/Caddyfile.long
@@ -48,6 +48,9 @@
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.host.site.somedomain.example.com{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.long
+++ b/deepwell/test/caddy/Caddyfile.long
@@ -12,6 +12,29 @@
 	request_header -X-Wikijump-*
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to framerail:3393
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws:3466
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # MAIN
 #
@@ -29,7 +52,7 @@
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws:3466
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -56,7 +79,7 @@
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy framerail:3393
+	import reverse_proxy_framerail
 }
 
 
@@ -115,14 +138,14 @@ www.example.com {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 wjfiles.host.site.somedomain.example.com {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 
@@ -163,7 +186,7 @@ http://*.wjfiles.host.site.somedomain.example.com {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.3}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws:3466
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains

--- a/deepwell/test/caddy/Caddyfile.proxies
+++ b/deepwell/test/caddy/Caddyfile.proxies
@@ -60,6 +60,9 @@ deploy.wjfiles.test {
 	}
 	redir @redirect https://{vars.site_slug}.wjfiles.test{uri}
 
+	# Enable HTTP/2 server push
+	push
+
 	# Enable default compression settings
 	encode
 

--- a/deepwell/test/caddy/Caddyfile.proxies
+++ b/deepwell/test/caddy/Caddyfile.proxies
@@ -12,6 +12,29 @@
 	request_header -X-Wikijump-*
 }
 
+(reverse_proxy_framerail) {
+	reverse_proxy * {
+		# TODO: support multiple upstreams
+		to web_proxy_host
+
+		lb_policy least_conn
+
+		fail_duration 30s
+		unhealthy_latency 4s
+	}
+}
+
+(reverse_proxy_wws) {
+	reverse_proxy {args[0]} {
+		# TODO: support multiple upstreams
+		to wws_proxy_host
+
+		lb_policy least_conn
+
+		health_uri /-/health-check
+		health_timeout 1s
+	}
+}
 #
 # INFRASTRUCTURE
 #
@@ -41,7 +64,7 @@ deploy.wjfiles.test {
 		path /-/health-check
 	}
 	request_header @proxy X-Wikijump-Target-Server main
-	reverse_proxy @proxy wws_proxy_host
+	import reverse_proxy_wws @proxy
 
 	# Redirect, true route is on the files server
 	@redirect {
@@ -68,7 +91,7 @@ deploy.wjfiles.test {
 
 	# Finally, proxy to framerail to get the actual HTML
 	# Note, the x-wikijump-site-* headers have already been set at this point
-	reverse_proxy web_proxy_host
+	import reverse_proxy_framerail
 }
 
 
@@ -127,14 +150,14 @@ www.example.com {
 
 	# Reverse proxy
 	request_header X-Wikijump-Target-Server files
-	reverse_proxy wws_proxy_host
+	import reverse_proxy_wws *
 }
 
 wjfiles.test {
 	import strip_headers
 	request_header X-Wikijump-Basic-Error 1
 	rewrite * /-/basic-error/file-root
-	reverse_proxy wws_proxy_host
+	import reverse_proxy_wws *
 }
 
 
@@ -175,7 +198,7 @@ http://*.wjfiles.test {
 	request_header X-Wikijump-Basic-Error 1
 	request_header X-Wikijump-Site-Slug {labels.2}
 	rewrite * /-/basic-error/site-slug
-	reverse_proxy wws_proxy_host
+	import reverse_proxy_wws *
 }
 
 # Missing custom domains


### PR DESCRIPTION
This PR makes two changes to the generated `Caddyfile`s produced by `CaddyService`:

* It adds the [`push`](https://caddyserver.com/docs/caddyfile/directives/push) directive to servers.
* It adds load balancing options to `reverse_proxy`. Presently this is not too useful, because there is only one backend, but in the future this could be extended to specifying a list of framerail / WWS instances.
* It adds health checks to `reverse_proxy`.
  * For WWS, this is an active health check since it's just pinging a particular route.
  * For framerail, this is a passive health check. Caddy is being told to remember if requests fail and avoid such unhealthy hosts.

Tested by running a local instance, routing worked as expected.