### PR TITLE
Move ping endpoint to new module

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -29,8 +29,8 @@
 use crate::config::{Config, Secrets};
 use crate::endpoints::{
     auth::*, basic_error::*, blob::*, category::*, domain::*, email::*, file::*,
-    file_revision::*, info::*, link::*, locale::*, message::*, misc::*, page::*,
-    page_attribution::*, page_revision::*, parent::*, routing::*, site::*,
+    file_revision::*, health::*, info::*, link::*, locale::*, message::*, misc::*,
+    page::*, page_attribution::*, page_revision::*, parent::*, routing::*, site::*,
     site_member::*, text::*, text_block::*, user::*, user_bot::*, view::*, vote::*,
 };
 use crate::error::prelude::*;

--- a/deepwell/src/endpoints/health.rs
+++ b/deepwell/src/endpoints/health.rs
@@ -1,0 +1,60 @@
+/*
+ * endpoints/health.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2026 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use super::prelude::*;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+
+async fn postgres_check(ctx: &ServiceContext<'_>) -> Result<()> {
+    ctx.transaction()
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            str!("SELECT 1"),
+        ))
+        .await
+        .or_raise(|| Error::new("failed to ping PostgreSQL", ErrorType::DatabaseQuery))?;
+
+    debug!("Successfully pinged Postgres");
+    Ok(())
+}
+
+async fn redis_check(ctx: &ServiceContext<'_>) -> Result<()> {
+    let mut redis = ctx.redis();
+
+    redis
+        .send_packed_command(redis::Cmd::new().arg("PING"))
+        .await
+        .or_raise(|| Error::new("failed to ping Redis", ErrorType::RedisQuery))?;
+
+    debug!("Successfully pinged Redis");
+    Ok(())
+}
+
+pub async fn ping(
+    ctx: &ServiceContext<'_>,
+    _params: Params<'static>,
+) -> Result<&'static str> {
+    // Ensure the database and cache are connected, and only then return.
+    info!("Ping request");
+
+    try_join!(postgres_check(ctx), redis_check(ctx))
+        .or_raise(|| Error::new("ping failed", ErrorType::HealthCheck))?;
+
+    Ok("Pong!")
+}

--- a/deepwell/src/endpoints/misc.rs
+++ b/deepwell/src/endpoints/misc.rs
@@ -19,47 +19,8 @@
  */
 
 use super::prelude::*;
-use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 use serde_json::Value as JsonValue;
 use wikidot_normalize::normalize;
-
-async fn postgres_check(ctx: &ServiceContext<'_>) -> Result<()> {
-    ctx.transaction()
-        .execute(Statement::from_string(
-            DatabaseBackend::Postgres,
-            str!("SELECT 1"),
-        ))
-        .await
-        .or_raise(|| Error::new("failed to ping PostgreSQL", ErrorType::DatabaseQuery))?;
-
-    debug!("Successfully pinged Postgres");
-    Ok(())
-}
-
-async fn redis_check(ctx: &ServiceContext<'_>) -> Result<()> {
-    let mut redis = ctx.redis();
-
-    redis
-        .send_packed_command(redis::Cmd::new().arg("PING"))
-        .await
-        .or_raise(|| Error::new("failed to ping Redis", ErrorType::RedisQuery))?;
-
-    debug!("Successfully pinged Redis");
-    Ok(())
-}
-
-pub async fn ping(
-    ctx: &ServiceContext<'_>,
-    _params: Params<'static>,
-) -> Result<&'static str> {
-    // Ensure the database and cache are connected, and only then return.
-    info!("Ping request");
-
-    try_join!(postgres_check(ctx), redis_check(ctx))
-        .or_raise(|| Error::new("ping failed", ErrorType::HealthCheck))?;
-
-    Ok("Pong!")
-}
 
 pub async fn echo(
     _ctx: &ServiceContext<'_>,

--- a/deepwell/src/endpoints/mod.rs
+++ b/deepwell/src/endpoints/mod.rs
@@ -54,6 +54,7 @@ pub mod domain;
 pub mod email;
 pub mod file;
 pub mod file_revision;
+pub mod health;
 pub mod info;
 pub mod link;
 pub mod locale;


### PR DESCRIPTION
This is the largest endpoint in `misc.rs` and is overall an odd one out. It makes more semantic sense for it to be in a new module called `health.rs` to reflect its purpose.