### PR TITLE
Temporarily disable wildcard_cert in dev

### DIFF
--- a/install/dev/caddy/request.json
+++ b/install/dev/caddy/request.json
@@ -5,7 +5,7 @@
 	"params": {
 		"debug": false,
 		"local": false,
-		"wildcard_cert": "digitalocean {env.DIGITALOCEAN_API_TOKEN}",
+		"_wildcard_cert": "digitalocean {env.DIGITALOCEAN_API_TOKEN}",
 		"deploy_host": "host.docker.internal:9120",
 		"framerail_host": "framerail:3393",
 		"wws_host": "wws:3466"


### PR DESCRIPTION
Due to the current DNS issues with `wjfiles.dev`, Caddy will fail getting wildcard certificates. For now, we can disable the certificate fetch in dev to prevent it from being chronically unhealthy.

We'll restore the key when DNS is operating as expected.