### PR TITLE
Add filter to alerter event types

### DIFF
--- a/install/dev/komodo/alerters.toml
+++ b/install/dev/komodo/alerters.toml
@@ -51,3 +51,16 @@ tags = ["system"]
 enabled = true
 endpoint.type = "Custom"
 endpoint.params.url = "http://host.docker.internal:7100"
+alert_types = [
+    # Deployment / build status
+    "BuildFailed",
+    "RepoBuildFailed",
+    "ActionFailed",
+    "ProcedureFailed",
+    # Application health
+    "StackStateChange",
+    # Not build-related, but critical
+    "ServerUnreachable",
+    "ServerDisk",
+    "ServerVersionMismatch",
+]


### PR DESCRIPTION
Per discussion, we want to limit the events emitted to the `#builds` channel to be build or deployment-related, and not continual noise about the CPU occasionally going up, or automated tasks like backups running.