### PR TITLE
Set up deploy-on-push for Komodo dev

### DIFF
--- a/.github/workflows/docker-build-caddy.dev.yaml
+++ b/.github/workflows/docker-build-caddy.dev.yaml
@@ -1,13 +1,12 @@
 name: '[backend] Docker build Caddy (DEV)'
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     paths:
       - 'install/dev/caddy/*'
       - '.github/workflows/docker-build-caddy.dev.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/caddy

--- a/.github/workflows/docker-build-caddy.prod.yaml
+++ b/.github/workflows/docker-build-caddy.prod.yaml
@@ -1,13 +1,12 @@
 name: '[backend] Docker build Caddy (PROD)'
 
 on:
-  push:
-    branches:
-      - prod
   pull_request:
     paths:
       - 'install/prod/caddy/*'
       - '.github/workflows/docker-build-caddy.prod.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/caddy

--- a/.github/workflows/docker-build-deepwell.dev.yaml
+++ b/.github/workflows/docker-build-deepwell.dev.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build DEEWELL (DEV)'
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     paths:
       - 'deepwell/**'
       - 'install/dev/deepwell/Dockerfile'
       - '.github/workflows/docker-build-deepwell.dev.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/deepwell

--- a/.github/workflows/docker-build-deepwell.prod.yaml
+++ b/.github/workflows/docker-build-deepwell.prod.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build DEEPWELL (PROD)'
 
 on:
-  push:
-    branches:
-      - prod
   pull_request:
     paths:
       - 'deepwell/**'
       - 'install/prod/deepwell/Dockerfile'
       - '.github/workflows/docker-build-deepwell.prod.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/deepwell

--- a/.github/workflows/docker-build-framerail.dev.yaml
+++ b/.github/workflows/docker-build-framerail.dev.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build Framerail (DEV)'
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     paths:
       - 'framerail/**'
       - 'install/dev/framerail/Dockerfile'
       - '.github/workflows/docker-build-framerail.dev.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/framerail

--- a/.github/workflows/docker-build-framerail.prod.yaml
+++ b/.github/workflows/docker-build-framerail.prod.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build Framerail (PROD)'
 
 on:
-  push:
-    branches:
-      - prod
   pull_request:
     paths:
       - 'framerail/**'
       - 'install/prod/framerail/Dockerfile'
       - '.github/workflows/docker-build-framerail.prod.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/framerail

--- a/.github/workflows/docker-build-wws.dev.yaml
+++ b/.github/workflows/docker-build-wws.dev.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build WWS (DEV)'
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     paths:
       - 'wws/**'
       - 'install/dev/wws/Dockerfile'
       - '.github/workflows/docker-build-wws.dev.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/wws

--- a/.github/workflows/docker-build-wws.prod.yaml
+++ b/.github/workflows/docker-build-wws.prod.yaml
@@ -1,14 +1,13 @@
 name: '[backend] Docker build WWS (PROD)'
 
 on:
-  push:
-    branches:
-      - prod
   pull_request:
     paths:
       - 'wws/**'
       - 'install/prod/wws/Dockerfile'
       - '.github/workflows/docker-build-wws.prod.yaml'
+  workflow_call:
+    # Runs on deployment (merge to develop or prod)
 
 env:
   IMAGE_NAME: wikijump/wws

--- a/.github/workflows/komodo-deploy.dev.yaml
+++ b/.github/workflows/komodo-deploy.dev.yaml
@@ -1,0 +1,36 @@
+name: '[komodo] Deploy Dev'
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  # Wait for image push jobs to complete
+  # See https://stackoverflow.com/a/75597437
+  caddy:
+    uses: ./.github/workflows/docker-build-caddy.dev.yaml
+
+  deepwell:
+    uses: ./.github/workflows/docker-build-deepwell.dev.yaml
+
+  framerail:
+    uses: ./.github/workflows/docker-build-framerail.dev.yaml
+
+  wws:
+    uses: ./.github/workflows/docker-build-wws.dev.yaml
+
+  # Then send webhook notification for Komodo to deploy.
+  #
+  # This ensures that all images are built and pushed up before
+  # attempting to redeploy the stack.
+  notify_komodo:
+    name: Deploy Komodo (dev)
+    runs-on: ubuntu-latest
+    needs: [caddy, deepwell, framerail, wws]
+    steps:
+      - name: Invoke deployment hook
+        uses: distributhor/workflow-webhook@v3
+        with:
+          webhook_url: ${{ secrets.KOMODO_DEPLOY_DEV_WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.KOMODO_DEPLOY_DEV_WEBHOOK_SECRET }}

--- a/.github/workflows/komodo-deploy.prod.yaml
+++ b/.github/workflows/komodo-deploy.prod.yaml
@@ -1,0 +1,36 @@
+name: '[komodo] Deploy Prod'
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  # Wait for image push jobs to complete
+  # See https://stackoverflow.com/a/75597437
+  caddy:
+    uses: ./.github/workflows/docker-build-caddy.prod.yaml
+
+  deepwell:
+    uses: ./.github/workflows/docker-build-deepwell.prod.yaml
+
+  framerail:
+    uses: ./.github/workflows/docker-build-framerail.prod.yaml
+
+  wws:
+    uses: ./.github/workflows/docker-build-wws.prod.yaml
+
+  # Then send webhook notification for Komodo to deploy.
+  #
+  # This ensures that all images are built and pushed up before
+  # attempting to redeploy the stack.
+  notify_komodo:
+    name: Deploy Komodo (prod)
+    runs-on: ubuntu-latest
+    needs: [caddy, deepwell, framerail, wws]
+    steps:
+      - name: Invoke deployment hook
+        uses: distributhor/workflow-webhook@v3
+        with:
+          webhook_url: ${{ secrets.KOMODO_DEPLOY_PROD_WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.KOMODO_DEPLOY_PROD_WEBHOOK_SECRET }}

--- a/docs/deployment/dev.md
+++ b/docs/deployment/dev.md
@@ -66,22 +66,6 @@ In order to add the rest of the infrastructure, we need to add a git repository 
   5. Set "Sync Variables" back to false.
 10. Add secrets.
 It is not good practice to add secrets to code, and triply so if the repository is public. As such, `install/dev/komodo/variables.toml` is missing values for those marked "secret" (see the file for more information). Some of these are secret values that need to be generated, and some come from your infrastructure. Fill in the values as appropriate.
-
-If you are using AWS ECR for storing images, you will need to generate a login identity. Do the following:
-```
-Temporarily set appropriate access key and secret key:
-$ aws configure
-# Get your user ID
-$ aws sts get-caller-identity --query Account --output text
-# Get the 'token' field
-$ aws ecr get-login-password
-# Now, remove the temporary credentials from `~/.aws`
-```
-
-Then in Komodo, navigate to _Settings → Providers → Registry Accounts_ and add a new one:
-* __Domain:__ Your AWS ECR registry URL, that is `[user ID].dkr.ecr.[region].amazonaws.com`
-* __Username:__ `AWS`
-* __Token:__ The login password you generated above.
 11. Go to the `wikijump-dev` stack and **pull images**. If everything is configured properly so far, it should be able to retrieve the images and be in a state to deploy it.
 12. Now, deploy the `wikijump-dev` stack. This will first build the local images (the two databases) and attempt to start the containers per the topology in `docker-compose.yaml`.
 On the first deploy, it may take some time to populate the database. You may need to restart services dependent on `deepwell` (i.e. `caddy`, `framerail`, `wws`) if they are reporting as unhealthy.

--- a/install/dev/komodo/compose.env.example
+++ b/install/dev/komodo/compose.env.example
@@ -6,6 +6,7 @@ KOMODO_HOST=https://deploy.wikijump.dev
 KOMODO_TITLE=Komodo - Wikijump Dev
 
 # TODO generate secrets
+# Note that KOMODO_WEBHOOK_SECRET should be set as KOMODO_DEPLOY_DEV_WEBHOOK_SECRET in GitHub secrets
 KOMODO_PASSKEY=
 KOMODO_WEBHOOK_SECRET=
 KOMODO_JWT_SECRET=

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -1,0 +1,38 @@
+[[procedure]]
+name = "Deploy Dev"
+tags = ["wikijump", "system"]
+description = "Automatically deploy Komodo infrastructure and Wikijump dev on push"
+config.webhook_secret = ""  # TODO: fill in with random value!
+
+[[procedure.config.stage]]
+name = "Pull Wikijump"
+enabled = true
+executions = [
+    {
+        execution.type = "BatchPullRepo",
+        execution.params.pattern = "wikijump-dev",
+        enabled = true,
+    }
+]
+
+[[procedure.config.stage]]
+name = "Update Infrastructure"
+enabled = true
+executions = [
+    {
+        execution.type = "RunSync",
+        execution.params.sync = "wikijump-dev",
+        enabled = true,
+    }
+]
+
+[[procedure.config.stage]]
+name = "Deploy Stacks"
+enabled = true
+executions = [
+    {
+        execution.type = "BatchDeployStackIfChanged",
+        execution.params.pattern = "wikijump-dev, *-alerter",
+        enabled = true,
+    }
+]

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -1,8 +1,7 @@
 [[procedure]]
 name = "Deploy Dev"
-tags = ["wikijump", "system"]
 description = "Automatically deploy Komodo infrastructure and Wikijump dev on push"
-config.webhook_secret = ""  # TODO: fill in with random value!
+tags = ["wikijump", "system"]
 
 [[procedure.config.stage]]
 name = "Pull Wikijump"

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -35,3 +35,16 @@ executions = [
         enabled = true,
     }
 ]
+
+[[procedure.config.stage]]
+name = "Notify"
+enabled = true
+executions = [
+    {
+        execution.type = "SendAlert",
+        execution.params.level = "OK",
+        execution.params.message = "Deployed Wikijump (dev)",
+        execution.params.alerters = [],
+        enabled = true,
+    }
+]

--- a/install/dev/komodo/resource-sync.toml
+++ b/install/dev/komodo/resource-sync.toml
@@ -1,7 +1,10 @@
 [[resource_sync]]
 name = "wikijump-dev"
-tags = ["wikijump"]
+description = "Synchronizes infrastructure changes, as defined in TOML files in Wikijump source."
+tags = ["wikijump", "system"]
 
 [resource_sync.config]
 linked_repo = "wikijump-dev"
 resource_path = ["install/dev/komodo/"]
+webhook_enabled = true
+include_user_groups = true


### PR DESCRIPTION
This adds infrastructure for deploy-on-push for Komodo dev. That is, with every merge to `develop`, the platorm will automatically update infrastructure and deploy a new stack.

I tested this with a temporary GitHub repository to verify that the configuration worked prior to merge:
* https://github.com/emmiegit/deploy-workflow-test/tree/main/.github/workflows
* https://github.com/emmiegit/deploy-workflow-test/actions/runs/23093689065/job/67082505682

After verifying it worked as expected, including waiting after _all_ the jobs finished (which were set to take different amounts of time), I copied the relevant parts of the configuration to this PR.

(Note that this repo will likely be deleted soon after this PR is merged)