### PR TITLE
Add missing resources to Komodo dev TOML files

### DIFF
--- a/install/dev/komodo/builder.toml
+++ b/install/dev/komodo/builder.toml
@@ -1,0 +1,7 @@
+[[builder]]
+name = "Local"
+tags = ["system"]
+
+[builder.config]
+type = "Server"
+params.server_id = "Local"

--- a/install/dev/komodo/resource-sync.toml
+++ b/install/dev/komodo/resource-sync.toml
@@ -6,5 +6,6 @@ tags = ["wikijump", "system"]
 [resource_sync.config]
 linked_repo = "wikijump-dev"
 resource_path = ["install/dev/komodo/"]
+delete = true
 webhook_enabled = true
 include_user_groups = true

--- a/install/dev/komodo/system.toml
+++ b/install/dev/komodo/system.toml
@@ -1,0 +1,31 @@
+[[procedure]]
+name = "Backup Core Database"
+description = "Triggers the Core database backup at the scheduled time."
+tags = ["system"]
+config.schedule = "Every day at 01:00"
+
+[[procedure.config.stage]]
+name = "Run Backup"
+enabled = true
+executions = [
+    {
+        execution.type = "BackupCoreDatabase",
+        enabled = true,
+    }
+]
+
+[[procedure]]
+name = "Global Auto Update"
+description = "Pulls and auto updates Stacks and Deployments using 'poll_for_updates' or 'auto_update'."
+tags = ["system"]
+config.schedule = "Every day at 03:00"
+
+[[procedure.config.stage]]
+name = "Auto Update"
+enabled = true
+executions = [
+    {
+        execution.type = "GlobalAutoUpdate",
+        enabled = true,
+    }
+]


### PR DESCRIPTION
There are a few objects which are not presently stored in our TOML definition files, so we should add them here and then set the resource sync to delete any missing items (declaring it total).