### PR TITLE
[hotfix] Correct Komodo TOML for inline objects

### DIFF
--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -7,44 +7,26 @@ tags = ["wikijump", "system"]
 name = "Pull Wikijump"
 enabled = true
 executions = [
-    {
-        execution.type = "BatchPullRepo",
-        execution.params.pattern = "wikijump-dev",
-        enabled = true,
-    }
+    { execution.type = "BatchPullRepo", execution.params.pattern = "wikijump-dev", enabled = true },
 ]
 
 [[procedure.config.stage]]
 name = "Update Infrastructure"
 enabled = true
 executions = [
-    {
-        execution.type = "RunSync",
-        execution.params.sync = "wikijump-dev",
-        enabled = true,
-    }
+    { execution.type = "RunSync", execution.params.sync = "wikijump-dev", enabled = true },
 ]
 
 [[procedure.config.stage]]
 name = "Deploy Stacks"
 enabled = true
 executions = [
-    {
-        execution.type = "BatchDeployStackIfChanged",
-        execution.params.pattern = "wikijump-dev, *-alerter",
-        enabled = true,
-    }
+    { execution.type = "BatchDeployStackIfChanged", execution.params.pattern = "wikijump-dev, *-alerter", enabled = true },
 ]
 
 [[procedure.config.stage]]
 name = "Notify"
 enabled = true
 executions = [
-    {
-        execution.type = "SendAlert",
-        execution.params.level = "OK",
-        execution.params.message = "Deployed Wikijump (dev)",
-        execution.params.alerters = [],
-        enabled = true,
-    }
+    { execution.type = "SendAlert", execution.params.level = "OK", execution.params.message = "Deployed Wikijump (dev)", execution.params.alerters = [], enabled = true },
 ]

--- a/install/dev/komodo/system.toml
+++ b/install/dev/komodo/system.toml
@@ -8,10 +8,7 @@ config.schedule = "Every day at 01:00"
 name = "Run Backup"
 enabled = true
 executions = [
-    {
-        execution.type = "BackupCoreDatabase",
-        enabled = true,
-    }
+    { execution.type = "BackupCoreDatabase", enabled = true },
 ]
 
 [[procedure]]
@@ -24,8 +21,5 @@ config.schedule = "Every day at 03:00"
 name = "Auto Update"
 enabled = true
 executions = [
-    {
-        execution.type = "GlobalAutoUpdate",
-        enabled = true,
-    }
+    { execution.type = "GlobalAutoUpdate", enabled = true },
 ]


### PR DESCRIPTION
Apparently Komodo doesn't support multiple lines for these objects, so we need to join them on one line and make them less readable:

<img width="940" height="577" alt="image" src="https://github.com/user-attachments/assets/b9a741b2-605d-4b27-85fa-2001a729ad1a" />
