### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/docker-build-caddy.dev.yaml
+++ b/.github/workflows/docker-build-caddy.dev.yaml
@@ -8,30 +8,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/caddy
-  DESCRIPTION: Caddy server configured for Wikijump
-  NAME: caddy
-  TIER: dev
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/develop'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/caddy
+      image-name: caddy
+      tier: dev
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-caddy.dev.yaml
+++ b/.github/workflows/docker-build-caddy.dev.yaml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'install/dev/caddy/*'
       - '.github/workflows/docker-build-caddy.dev.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-caddy.prod.yaml
+++ b/.github/workflows/docker-build-caddy.prod.yaml
@@ -8,30 +8,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/caddy
-  DESCRIPTION: Caddy server configured for Wikijump
-  NAME: caddy
-  TIER: prod
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/prod'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/caddy
+      image-name: caddy
+      tier: prod
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-caddy.prod.yaml
+++ b/.github/workflows/docker-build-caddy.prod.yaml
@@ -5,8 +5,6 @@ on:
     paths:
       - 'install/prod/caddy/*'
       - '.github/workflows/docker-build-caddy.prod.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-deepwell.dev.yaml
+++ b/.github/workflows/docker-build-deepwell.dev.yaml
@@ -6,8 +6,6 @@ on:
       - 'deepwell/**'
       - 'install/dev/deepwell/Dockerfile'
       - '.github/workflows/docker-build-deepwell.dev.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-deepwell.dev.yaml
+++ b/.github/workflows/docker-build-deepwell.dev.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/deepwell
-  DESCRIPTION: DEEPWELL backend and internal API for Wikijump
-  NAME: deepwell
-  TIER: dev
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/develop'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/deepwell
+      image-name: deepwell
+      tier: dev
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-deepwell.prod.yaml
+++ b/.github/workflows/docker-build-deepwell.prod.yaml
@@ -6,8 +6,6 @@ on:
       - 'deepwell/**'
       - 'install/prod/deepwell/Dockerfile'
       - '.github/workflows/docker-build-deepwell.prod.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-deepwell.prod.yaml
+++ b/.github/workflows/docker-build-deepwell.prod.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/deepwell
-  DESCRIPTION: DEEPWELL backend and internal API for Wikijump
-  NAME: deepwell
-  TIER: prod
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/prod'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/deepwell
+      image-name: deepwell
+      tier: prod
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-framerail.dev.yaml
+++ b/.github/workflows/docker-build-framerail.dev.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/framerail
-  DESCRIPTION: Web server for Wikijump
-  NAME: framerail
-  TIER: dev
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/develop'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/framerail
+      image-name: framerail
+      tier: dev
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-framerail.dev.yaml
+++ b/.github/workflows/docker-build-framerail.dev.yaml
@@ -6,8 +6,6 @@ on:
       - 'framerail/**'
       - 'install/dev/framerail/Dockerfile'
       - '.github/workflows/docker-build-framerail.dev.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-framerail.prod.yaml
+++ b/.github/workflows/docker-build-framerail.prod.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/framerail
-  DESCRIPTION: Web server for Wikijump
-  NAME: framerail
-  TIER: prod
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/prod'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/framerail
+      image-name: framerail
+      tier: prod
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-framerail.prod.yaml
+++ b/.github/workflows/docker-build-framerail.prod.yaml
@@ -6,8 +6,6 @@ on:
       - 'framerail/**'
       - 'install/prod/framerail/Dockerfile'
       - '.github/workflows/docker-build-framerail.prod.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-template.yaml
+++ b/.github/workflows/docker-build-template.yaml
@@ -1,0 +1,49 @@
+# Generic reusable workflow for building Docker images and pushing them to ECR
+name: 'Docker build'
+
+on:
+  workflow_call:
+    inputs:
+      image-repository:
+        type: string
+        required: true
+        description: 'The repository to push the image to, e.g. wikijump/deepwell'
+      image-name:
+        type: string
+        required: true
+        description: 'The name of the image to push, e.g. deepwell'
+      tier:
+        type: string
+        required: true
+        description: 'The tier that this image is for, used as the image label, e.g. prod'
+      push:
+        type: boolean
+        default: false
+        description: 'Whether to push the image to ECR after build (for deployment)'
+    secrets:
+      aws-access-key:
+        required: true
+      aws-secret-key:
+        required: true
+
+jobs:
+  build_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build --tag ${{ inputs.image-repository }}:${{ inputs.tier }} -f install/${{ inputs.tier }}/${{ inputs.image-name }}/Dockerfile .
+        env:
+          DOCKER_BUILDKIT: 1
+
+      - name: Push image to ECR
+        if: ${{ inputs.push }}
+        uses: jwalton/gh-ecr-push@v2
+        with:
+          access-key-id: ${{ secrets.aws-access-key }}
+          secret-access-key: ${{ secrets.aws-secret-key }}
+          region: us-east-2
+          local-image: ${{ inputs.image-repository }}:${{ inputs.tier }}
+          image: ${{ inputs.image-repository }}:${{ inputs.tier }}, ${{ inputs.image-repository }}:${{ inputs.tier }}-${{ github.sha }}

--- a/.github/workflows/docker-build-wws.dev.yaml
+++ b/.github/workflows/docker-build-wws.dev.yaml
@@ -6,8 +6,6 @@ on:
       - 'wws/**'
       - 'install/dev/wws/Dockerfile'
       - '.github/workflows/docker-build-wws.dev.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-wws.dev.yaml
+++ b/.github/workflows/docker-build-wws.dev.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/wws
-  DESCRIPTION: Wilson's Web Server, file and static routing for Wikijump
-  NAME: wws
-  TIER: dev
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/develop'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/wws
+      image-name: wws
+      tier: dev
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/docker-build-wws.prod.yaml
+++ b/.github/workflows/docker-build-wws.prod.yaml
@@ -6,8 +6,6 @@ on:
       - 'wws/**'
       - 'install/prod/wws/Dockerfile'
       - '.github/workflows/docker-build-wws.prod.yaml'
-  workflow_call:
-    # Runs on deployment (merge to develop or prod)
 
 jobs:
   build:

--- a/.github/workflows/docker-build-wws.prod.yaml
+++ b/.github/workflows/docker-build-wws.prod.yaml
@@ -9,30 +9,13 @@ on:
   workflow_call:
     # Runs on deployment (merge to develop or prod)
 
-env:
-  IMAGE_NAME: wikijump/wws
-  DESCRIPTION: Wilson's Web Server, file and static routing for Wikijump
-  NAME: wws
-  TIER: prod
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Build image
-        run: docker build --tag ${{ env.IMAGE_NAME }}:${{ env.TIER }} -f install/${{ env.TIER }}/${{ env.NAME }}/Dockerfile .
-        env:
-          DOCKER_BUILDKIT: 1
-
-      - name: Push image to ECR
-        if: github.ref == 'refs/heads/prod'
-        uses: jwalton/gh-ecr-push@v2
-        with:
-          access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY }}
-          secret-access-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
-          region: us-east-2
-          local-image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.TIER }}, ${{ env.IMAGE_NAME }}:${{ env.TIER }}-${{ github.sha }}
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/wws
+      image-name: wws
+      tier: prod
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}

--- a/.github/workflows/komodo-deploy.dev.yaml
+++ b/.github/workflows/komodo-deploy.dev.yaml
@@ -9,16 +9,48 @@ jobs:
   # Wait for image push jobs to complete
   # See https://stackoverflow.com/a/75597437
   caddy:
-    uses: ./.github/workflows/docker-build-caddy.dev.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/caddy
+      image-name: caddy
+      tier: dev
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   deepwell:
-    uses: ./.github/workflows/docker-build-deepwell.dev.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/deepwell
+      image-name: deepwell
+      tier: dev
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   framerail:
-    uses: ./.github/workflows/docker-build-framerail.dev.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/framerail
+      image-name: framerail
+      tier: dev
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   wws:
-    uses: ./.github/workflows/docker-build-wws.dev.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/wws
+      image-name: wws
+      tier: dev
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   # Then send webhook notification for Komodo to deploy.
   #

--- a/.github/workflows/komodo-deploy.prod.yaml
+++ b/.github/workflows/komodo-deploy.prod.yaml
@@ -9,16 +9,48 @@ jobs:
   # Wait for image push jobs to complete
   # See https://stackoverflow.com/a/75597437
   caddy:
-    uses: ./.github/workflows/docker-build-caddy.prod.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/caddy
+      image-name: caddy
+      tier: prod
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   deepwell:
-    uses: ./.github/workflows/docker-build-deepwell.prod.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/deepwell
+      image-name: deepwell
+      tier: prod
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   framerail:
-    uses: ./.github/workflows/docker-build-framerail.prod.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/framerail
+      image-name: framerail
+      tier: prod
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   wws:
-    uses: ./.github/workflows/docker-build-wws.prod.yaml
+    uses: ./.github/workflows/docker-build-template.yaml
+    with:
+      image-repository: wikijump/wws
+      image-name: wws
+      tier: prod
+      push: true
+    secrets:
+      aws-access-key: ${{ secrets.AWS_ECR_ACCESS_KEY }}
+      aws-secret-key: ${{ secrets.AWS_ECR_SECRET_KEY }}
 
   # Then send webhook notification for Komodo to deploy.
   #


### PR DESCRIPTION
Since this was my first time setting up a "reusable workflow", I was misinformed on how it handles arguments and secrets. These were not present in my simpler prototype version in the temporary git repository.

So I have instead created a proper reusable workflow for all the Docker image build and push flows, and set those to simply invoke this one, abstracted workflow. This includes the deployment workflow itself, which simply invokes all the builds / pushes for its necessary images and then afterwards tells Komodo that's all set to deploy the stack.

I temporarily set this to run on push to this branch for testing:
<img width="332" height="280" alt="image" src="https://github.com/user-attachments/assets/732e1ac4-b70e-42f7-89dc-2b9bce23b441" />
<img width="816" height="394" alt="image" src="https://github.com/user-attachments/assets/b4a02a75-f61d-4cef-9dca-b860aceadc03" />
