### PR TITLE
Allow custom domains to make the www redirect optional

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.3.12"
+version = "2026.3.14"
 dependencies = [
  "argon2",
  "arraystring",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.3.12"
+version = "2026.3.14"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -155,6 +155,7 @@ CREATE TABLE site_domain (
     domain TEXT PRIMARY KEY,
     site_id BIGINT NOT NULL REFERENCES site(site_id),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    www_redirect BOOLEAN NOT NULL,
 
     CHECK (length(domain) > 0)
 );

--- a/deepwell/seeder/sites.dev.patch
+++ b/deepwell/seeder/sites.dev.patch
@@ -1,4 +1,13 @@
-32,33c32,33
+14,19c14
+<         "domains": [
+<             {
+<                 "domain": "test-site.localhost",
+<                 "www-redirect": false
+<             }
+<         ],
+---
+>         "domains": [],
+40,41c35,36
 <         "domains": ["scpwiki.dev", "scpwiki.localhost"],
 <         "preferred-domain": "scpwiki.localhost",
 ---

--- a/deepwell/seeder/sites.json
+++ b/deepwell/seeder/sites.json
@@ -11,7 +11,12 @@
     {
         "slug": "test",
         "aliases": ["check"],
-        "domains": [],
+        "domains": [
+            {
+                "domain": "test-site.localhost",
+                "www-redirect": false
+            }
+        ],
         "name": "Test site",
         "tagline": "The other kind of sandbox",
         "description": "Platform testing and experiments",

--- a/deepwell/src/database/seeder/data.rs
+++ b/deepwell/src/database/seeder/data.rs
@@ -145,7 +145,7 @@ pub struct Site {
     pub aliases: Vec<String>,
 
     #[serde(default)]
-    pub domains: Vec<String>,
+    pub domains: Vec<SiteDomain>,
 
     #[serde(default)]
     pub preferred_domain: Option<String>,
@@ -158,6 +158,37 @@ pub struct Site {
     pub layout: Option<Layout>,
     pub license: License,
     pub locale: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum SiteDomain {
+    DomainOnly(String),
+    WithRedirect {
+        domain: String,
+
+        #[serde(rename = "www-redirect", default = "default_true")]
+        www_redirect: bool,
+    },
+}
+
+impl SiteDomain {
+    pub fn domain(&self) -> &str {
+        match self {
+            SiteDomain::DomainOnly(domain) => domain,
+            SiteDomain::WithRedirect { domain, .. } => domain,
+        }
+    }
+
+    pub fn into_fields(self) -> (String, bool) {
+        match self {
+            SiteDomain::DomainOnly(domain) => (domain, true),
+            SiteDomain::WithRedirect {
+                domain,
+                www_redirect,
+            } => (domain, www_redirect),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -213,4 +244,9 @@ pub struct File {
 
     #[serde(default)]
     pub deleted: bool,
+}
+
+#[inline]
+const fn default_true() -> bool {
+    true
 }

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -213,20 +213,21 @@ pub async fn seed(state: &ServerState) -> Result<()> {
 
         if let Some(preferred_domain) = &site.preferred_domain {
             assert!(
-                site.domains.contains(preferred_domain),
+                site.domains.iter().any(|d| d.domain() == preferred_domain),
                 "The site's preferred domain must be a listed custom domain",
             );
         }
 
-        for domain in site.domains {
-            info!("Creating site domain '{domain}'");
+        for site_domain in site.domains {
+            let (domain, www_redirect) = site_domain.into_fields();
+            info!("Creating site domain '{domain}' (www redirect: {www_redirect})");
 
             DomainService::create_custom(
                 &ctx,
                 CreateCustomDomain {
                     site_id,
                     domain,
-                    www_redirect: todo!(),
+                    www_redirect,
                 },
             )
             .await

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -221,9 +221,16 @@ pub async fn seed(state: &ServerState) -> Result<()> {
         for domain in site.domains {
             info!("Creating site domain '{domain}'");
 
-            DomainService::create_custom(&ctx, CreateCustomDomain { site_id, domain })
-                .await
-                .or_raise(make_error)?;
+            DomainService::create_custom(
+                &ctx,
+                CreateCustomDomain {
+                    site_id,
+                    domain,
+                    www_redirect: todo!(),
+                },
+            )
+            .await
+            .or_raise(make_error)?;
         }
 
         SiteService::update(

--- a/deepwell/src/endpoints/domain.rs
+++ b/deepwell/src/endpoints/domain.rs
@@ -46,7 +46,7 @@ pub async fn site_custom_domain_create(
 
     DomainService::create_custom(ctx, input).await.or_raise(|| {
         Error::new(
-            "failed to add a new customm domain",
+            "failed to add a new custom domain",
             ErrorType::SiteSettings,
         )
     })

--- a/deepwell/src/endpoints/domain.rs
+++ b/deepwell/src/endpoints/domain.rs
@@ -45,10 +45,7 @@ pub async fn site_custom_domain_create(
     let input: CreateCustomDomain = parse!(params, SiteSettings);
 
     DomainService::create_custom(ctx, input).await.or_raise(|| {
-        Error::new(
-            "failed to add a new custom domain",
-            ErrorType::SiteSettings,
-        )
+        Error::new("failed to add a new custom domain", ErrorType::SiteSettings)
     })
 }
 

--- a/deepwell/src/models/site_domain.rs
+++ b/deepwell/src/models/site_domain.rs
@@ -11,6 +11,7 @@ pub struct Model {
     pub site_id: i64,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: TimeDateTimeWithTimeZone,
+    pub www_redirect: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -1,5 +1,5 @@
 {#
-Editor notice:
+Text editor notice:
 
 This file contains hard tabs, as this is what we want to use for
 `Caddyfile` generation. If you're opening this file, mind the git

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -30,10 +30,12 @@ www.{{ domain }} {
 {% endmacro -%}
 
 {%- macro render_redirect(domain, preferred_domain, www_redirect) %}
-{{ domain }},
 {% if www_redirect -%}
+{{ domain }},
 www.{{ domain }} {
-{% endif %}
+{%- else -%}
+{{ domain }} {
+{%- endif %}
 	redir https://{{ preferred_domain }}{uri}
 }
 {% endmacro -%}

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -167,7 +167,7 @@ deploy{{ files_domain }} {
 {% let preferred_domain = self::get_preferred_domain(&preferred_domain, &canonical_domain) %}
 # Canonical domain
 {{- render_entry(site_id, site_slug, canonical_domain, preferred_domain) -}}
-{% for domain in custom_domains -%}
+{% for CustomDomainData { domain, www_redirect } in custom_domains -%}
 {% if loop.first %}
 # Custom domains
 {%- endif -%}

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -9,7 +9,7 @@ If your editor munges the tabs please discard those changes.
 Remember, 'git add -p' is your friend!
 #}
 
-{%- macro render_preferred_domain(site_id, site_slug, domain) %}
+{%- macro render_preferred_domain(site_id, site_slug, domain, www_redirect) %}
 {{ domain }} {
 	import strip_headers
 
@@ -22,23 +22,27 @@ Remember, 'git add -p' is your friend!
 	request_header X-Wikijump-Site-Slug {vars.site_slug}
 	import serve_main
 }
+{% if www_redirect -%}
 www.{{ domain }} {
 	redir https://{{ domain }}{uri}
 }
+{% endif -%}
 {% endmacro -%}
 
-{%- macro render_redirect(domain, preferred_domain) %}
+{%- macro render_redirect(domain, preferred_domain, www_redirect) %}
 {{ domain }},
+{% if www_redirect -%}
 www.{{ domain }} {
+{% endif %}
 	redir https://{{ preferred_domain }}{uri}
 }
 {% endmacro -%}
 
-{% macro render_entry(site_id, site_slug, domain, preferred_domain) -%}
+{% macro render_entry(site_id, site_slug, domain, preferred_domain, www_redirect) -%}
 {% if domain == preferred_domain -%}
-{{ render_preferred_domain(site_id, site_slug, domain) }}
+{{ render_preferred_domain(site_id, site_slug, domain, www_redirect) }}
 {%- else -%}
-{{ render_redirect(domain, preferred_domain) }}
+{{ render_redirect(domain, preferred_domain, www_redirect) }}
 {%- endif -%}
 {% endmacro -%}
 
@@ -164,21 +168,21 @@ deploy{{ files_domain }} {
 {% for (site_id, site_slug, preferred_domain) in sites -%}
 {% let SiteDomainData { aliases, custom_domains } = &domains[site_id] -%}
 {% let canonical_domain = self::get_canonical_domain(config, site_slug) -%}
-{% let preferred_domain = self::get_preferred_domain(&preferred_domain, &canonical_domain) %}
+{% let (preferred_domain, preferred_www_redirect) = self::get_preferred_domain(&custom_domains, &preferred_domain, &canonical_domain) %}
 # Canonical domain
-{{- render_entry(site_id, site_slug, canonical_domain, preferred_domain) -}}
+{{- render_entry(site_id, site_slug, canonical_domain, preferred_domain, preferred_www_redirect) -}}
 {% for CustomDomainData { domain, www_redirect } in custom_domains -%}
 {% if loop.first %}
 # Custom domains
 {%- endif -%}
-{{- render_entry(site_id, site_slug, domain, preferred_domain) -}}
+{{- render_entry(site_id, site_slug, domain, preferred_domain, www_redirect) -}}
 {% endfor -%}
 {% for alias_slug in aliases -%}
 {% if loop.first %}
 # Aliases
 {%- endif -%}
 {% let domain = DomainService::get_canonical(config, alias_slug) %}
-{{- render_redirect(domain, preferred_domain) -}}
+{{- render_redirect(domain, preferred_domain, true) -}}
 {%- endfor -%}
 {% endfor %}
 

--- a/deepwell/src/services/caddy/service.rs
+++ b/deepwell/src/services/caddy/service.rs
@@ -194,10 +194,23 @@ fn get_canonical_domain<'s>(config: &'s Config, site_slug: &'s str) -> Cow<'s, s
 }
 
 fn get_preferred_domain<'s>(
+    custom_domains: &[CustomDomainData],
     preferred_domain: &'s Option<String>,
     canonical_domain: &'s str,
-) -> &'s str {
-    preferred_domain.as_deref().unwrap_or(canonical_domain)
+) -> (&'s str, bool) {
+    match preferred_domain {
+        None => (canonical_domain, true),
+        Some(preferred_domain) => {
+            let preferred_domain = preferred_domain.as_str();
+
+            custom_domains
+                .iter()
+                .find(|custom| custom.domain == preferred_domain)
+                .map(|custom| (preferred_domain, custom.www_redirect))
+                // Consistency error: Preferred custom domain should be in the list of the site's custom domains
+                .expect("No matching custom domain for preferred domain")
+        }
+    }
 }
 
 /// Determines the index to give to Caddy to get the site slug from a domain.

--- a/deepwell/src/services/caddy/service.rs
+++ b/deepwell/src/services/caddy/service.rs
@@ -112,8 +112,9 @@ impl CaddyService {
                     .order_by_asc(site_domain::Column::Domain)
                     .select_only()
                     .column(site_domain::Column::Domain)
+                    .column(site_domain::Column::WwwRedirect)
                     .filter(site_domain::Column::SiteId.eq(site_id))
-                    .into_tuple()
+                    .into_model::<CustomDomainData>()
                     .all(txn)
                     .await
                     .or_raise(make_error)?;

--- a/deepwell/src/services/caddy/structs.rs
+++ b/deepwell/src/services/caddy/structs.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use sea_orm::FromQueryResult;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -97,5 +98,11 @@ pub struct SiteData {
 #[derive(Deserialize, Debug, Default, Clone)]
 pub struct SiteDomainData {
     pub aliases: Vec<String>,
-    pub custom_domains: Vec<String>,
+    pub custom_domains: Vec<CustomDomainData>,
+}
+
+#[derive(Deserialize, FromQueryResult, Debug, Default, Clone)]
+pub struct CustomDomainData {
+    pub domain: String,
+    pub www_redirect: bool,
 }

--- a/deepwell/src/services/caddy/test.rs
+++ b/deepwell/src/services/caddy/test.rs
@@ -101,6 +101,19 @@ fn build_config(main_domain: &str, files_domain: &str) -> Config {
 }
 
 fn build_site_data() -> (SiteData, SiteData) {
+    macro_rules! domain {
+        ($domain:expr $(,)?) => {
+            domain!($domain, true)
+        };
+
+        ($domain:expr, $www_redirect:expr $(,)?) => {
+            CustomDomainData {
+                domain: str!($domain),
+                www_redirect: $www_redirect,
+            }
+        };
+    }
+
     let basic = SiteData {
         sites: vec![
             (1, str!("foo"), None),
@@ -110,7 +123,7 @@ fn build_site_data() -> (SiteData, SiteData) {
             1 => SiteDomainData::default(),
             2 => SiteDomainData {
                 aliases: vec![],
-                custom_domains: vec![str!("example.com")],
+                custom_domains: vec![domain!("example.com")],
             },
         },
     };
@@ -132,19 +145,19 @@ fn build_site_data() -> (SiteData, SiteData) {
             2 => SiteDomainData::default(),
             3 => SiteDomainData {
                 aliases: vec![str!("check")],
-                custom_domains: vec![str!("example.com"), str!("example.net")],
+                custom_domains: vec![domain!("example.com"), domain!("example.net", false)],
             },
             4 => SiteDomainData {
                 aliases: vec![],
-                custom_domains: vec![str!("wandererslibrary.com")],
+                custom_domains: vec![domain!("wandererslibrary.com")],
             },
             5 => SiteDomainData {
                 aliases: vec![str!("scpwiki")],
                 custom_domains: vec![
-                    str!("scpwiki.com"),
-                    str!("scp-wiki.net"),
-                    str!("scp.foundation"),
-                    str!("foundation.scp"),
+                    domain!("scpwiki.com"),
+                    domain!("scp-wiki.net", false),
+                    domain!("foundation.scp", false),
+                    domain!("scp.foundation"),
                 ],
             },
         },

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -38,7 +38,11 @@ impl DomainService {
     /// Creates a custom domain for a site.
     pub async fn create_custom(
         ctx: &ServiceContext<'_>,
-        CreateCustomDomain { domain, site_id }: CreateCustomDomain,
+        CreateCustomDomain {
+            domain,
+            site_id,
+            www_redirect,
+        }: CreateCustomDomain,
     ) -> Result<()> {
         info!("Creating custom domain '{domain}' (site ID {site_id})");
 
@@ -81,6 +85,7 @@ impl DomainService {
             domain: Set(domain),
             site_id: Set(site_id),
             created_at: Set(now()),
+            www_redirect: Set(www_redirect),
         };
         model.insert(txn).await.or_raise(make_error)?;
         Ok(())

--- a/deepwell/src/services/domain/structs.rs
+++ b/deepwell/src/services/domain/structs.rs
@@ -22,4 +22,5 @@
 pub struct CreateCustomDomain {
     pub domain: String,
     pub site_id: i64,
+    pub www_redirect: bool,
 }

--- a/deepwell/test/caddy/Caddyfile.full_prod
+++ b/deepwell/test/caddy/Caddyfile.full_prod
@@ -160,8 +160,7 @@ www.example.com {
 	redir https://mytest.wikijump.test{uri}
 }
 
-example.net,
-www.example.net {
+example.net {
 	redir https://mytest.wikijump.test{uri}
 }
 
@@ -217,18 +216,16 @@ www.scpwiki.com {
 	redir https://scpwiki.com{uri}
 }
 
-scp-wiki.net,
-www.scp-wiki.net {
+scp-wiki.net {
+	redir https://scpwiki.com{uri}
+}
+
+foundation.scp {
 	redir https://scpwiki.com{uri}
 }
 
 scp.foundation,
 www.scp.foundation {
-	redir https://scpwiki.com{uri}
-}
-
-foundation.scp,
-www.foundation.scp {
 	redir https://scpwiki.com{uri}
 }
 


### PR DESCRIPTION
Previously, by default, for all custom domains, CaddyService would automatically add a `www.` subdomain redirect to the preferred domain. This is helpful for users visiting a custom domain, but this means that if there is no DNS record for the subdomain (perhaps because the site's admins don't fully control the DNS records for a domain, or deem it unnecessary, such as for `www.some.very.long.domain.example.com`), then Caddy will fail at the certificate step.

This adds a new flag `www_redirect` (default `true`) to the `site_domain` table. When disabled, this will _not_ emit any `www.` subdomain records in the generated Caddyfile for this domain.

Ran locally:

```
$ scripts/request.py 'custom_domain_create' '{"domain": "example.net", "site_id": 2, "www_redirect": false}'

$ curl -ik -H 'Host: example.net' https://localhost
HTTP/2 302 
alt-svc: h3=":443"; ma=2592000
location: https://test.wikijump.localhost/
server: Caddy
content-length: 0
date: Sat, 14 Mar 2026 22:38:22 GMT

$ curl -ik -H 'Host: www.example.net' https://localhost
HTTP/2 404 
access-control-allow-origin: *
alt-svc: h3=":443"; ma=2592000
content-type: text/html; charset=utf-8
date: Sat, 14 Mar 2026 22:38:27 GMT
vary: accept-encoding
via: 1.1 Caddy

<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>No such site - Wikijump</title></head><body><article><h1>No Wikijump site exists with this address</h1>
<p>
  No site has the custom domain <a href="https://⁨www.example.net⁩/"><code>⁨www.example.net⁩</code></a>.
</p>

<p>
  Return to <a href="https://⁨wikijump.localhost⁩/">Wikijump</a>.
</p></article></body></html>
```