### PR TITLE
Fix webhook_enabled in resource sync TOML

### DIFF
--- a/install/dev/komodo/resource-sync.toml
+++ b/install/dev/komodo/resource-sync.toml
@@ -7,5 +7,5 @@ tags = ["wikijump", "system"]
 linked_repo = "wikijump-dev"
 resource_path = ["install/dev/komodo/"]
 delete = true
-webhook_enabled = true
+webhook_enabled = false
 include_user_groups = true


### PR DESCRIPTION
Was meant to originally be false, and it cannot sync itself.