### PR TITLE
[WJ-1353] Fixes to deployment process

### DIFF
--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -17,8 +17,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 6
-    volumes:
-      - postgres:/var/lib/postgresql/data
 
   cache:
     build: valkey
@@ -30,8 +28,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-    volumes:
-      - redis:/data
 
   deepwell:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/deepwell:dev
@@ -131,6 +127,4 @@ services:
       - host.docker.internal:host-gateway
 
 volumes:
-  postgres:
-  redis:
   caddy:

--- a/install/dev/komodo/alerters.toml
+++ b/install/dev/komodo/alerters.toml
@@ -63,4 +63,6 @@ alert_types = [
     "ServerUnreachable",
     "ServerDisk",
     "ServerVersionMismatch",
+    # Any custom alerts
+    "Custom",
 ]

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -21,7 +21,7 @@ executions = [
 name = "Deploy Stacks"
 enabled = true
 executions = [
-    { execution.type = "BatchDeployStackIfChanged", execution.params.pattern = "wikijump-dev, *-alerter", enabled = true },
+    { execution.type = "BatchDeployStack", execution.params.pattern = "wikijump-dev, *-alerter", enabled = true },
 ]
 
 # TODO fix notifications

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -24,11 +24,3 @@ enabled = true
 executions = [
     { execution.type = "BatchDeployStack", execution.params.pattern = "wikijump-dev, *-alerter", enabled = true },
 ]
-
-# TODO fix notifications
-[[procedure.config.stage]]
-name = "Notify"
-enabled = false
-executions = [
-    { execution.type = "SendAlert", execution.params.level = "OK", execution.params.message = "Deployed Wikijump (dev)", execution.params.alerters = [], enabled = false },
-]

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -1,6 +1,6 @@
 [[procedure]]
 name = "Deploy Dev"
-description = "Automatically deploy Komodo infrastructure and Wikijump dev on push"
+description = "Automatically deploy Wikijump dev on push"
 tags = ["wikijump", "system"]
 
 [[procedure.config.stage]]
@@ -10,11 +10,12 @@ executions = [
     { execution.type = "BatchPullRepo", execution.params.pattern = "wikijump-dev", enabled = true },
 ]
 
+# TODO temporarily disable resource syncs until a long-term decision on managing these is decided
 [[procedure.config.stage]]
 name = "Update Infrastructure"
-enabled = true
+enabled = false
 executions = [
-    { execution.type = "RunSync", execution.params.sync = "wikijump-dev", enabled = true },
+    { execution.type = "RunSync", execution.params.sync = "wikijump-dev", enabled = false },
 ]
 
 [[procedure.config.stage]]

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -24,9 +24,10 @@ executions = [
     { execution.type = "BatchDeployStackIfChanged", execution.params.pattern = "wikijump-dev, *-alerter", enabled = true },
 ]
 
+# TODO fix notifications
 [[procedure.config.stage]]
 name = "Notify"
-enabled = true
+enabled = false
 executions = [
-    { execution.type = "SendAlert", execution.params.level = "OK", execution.params.message = "Deployed Wikijump (dev)", execution.params.alerters = [], enabled = true },
+    { execution.type = "SendAlert", execution.params.level = "OK", execution.params.message = "Deployed Wikijump (dev)", execution.params.alerters = [], enabled = false },
 ]


### PR DESCRIPTION
* Private volumes *were* being persisted, causing database migrations in dev to fail. (We keep the Caddy one since it has certificates and we don't want to constantly be re-fetching those on each deploy)
* Use `BatchDeployStack` instead of `BatchDeployStackIfChanged`. The "if changed" is seemingly if the `docker-compose.yaml` changes, not if any of its constituent images change.
* Disable the "update infrastructure" step. There are too many collisions and other issues while dev infra is still somewhat in flux. (For now I will update them via the resource sync manually)
* Remove the custom alert. I cannot figure out how we are supposed to structure these, since presently they show no information.
* Enable custom alerts in the alerter. (One of the things I figured out was missing was that there were no alerters to receive this type)