### PR TITLE
Add domain validation step for DomainService

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.3.14"
+version = "2026.3.19"
 dependencies = [
  "argon2",
  "arraystring",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.3.14"
+version = "2026.3.19"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/src/error/error_type.rs
+++ b/deepwell/src/error/error_type.rs
@@ -215,6 +215,12 @@ pub enum ErrorType {
     // 5400
     CustomDomainSubdomain,
     CustomDomainWrongSite,
+    CustomDomainUsePunycode {
+        domain: String,
+    },
+    InvalidDomainValue {
+        domain: String,
+    },
 
     // 6000
     Relation,
@@ -457,6 +463,8 @@ impl ErrorType {
             // 5400 - Domains
             ErrorType::CustomDomainWrongSite => 5400,
             ErrorType::CustomDomainSubdomain => 5401,
+            ErrorType::CustomDomainUsePunycode { .. } => 5402,
+            ErrorType::InvalidDomainValue { .. } => 5403,
 
             //
             // 6000 -- Client / Request Errors - Composite Data
@@ -688,6 +696,12 @@ impl ErrorType {
             }
             ErrorType::CustomDomainWrongSite => {
                 "Cannot use custom domain, as it belongs to a different site"
+            }
+            ErrorType::CustomDomainUsePunycode { .. } => {
+                "Submitted domain values should use punycode"
+            }
+            ErrorType::InvalidDomainValue { .. } => {
+                "Domain value contains unexpected characters"
             }
 
             // 6000

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -292,5 +292,49 @@ fn validate_domain(domain: &str) -> Result<()> {
 
 #[test]
 fn test_validate_domain() {
-    todo!()
+    macro_rules! test_ok {
+        ($domain:expr $(,)?) => {
+            validate_domain($domain).expect("domain was detected as invalid")
+        };
+    }
+
+    macro_rules! test_err {
+        ($domain:expr $(,)?) => {
+            validate_domain($domain).expect_err("domain was detected as valid")
+        };
+    }
+
+    test_err!("");
+    test_ok!("example.com");
+    test_ok!("ftp.example.com");
+    test_ok!("foo.bar.baz.example.com");
+    test_err!(
+        "this.domain.is.far.far.too.long.and.not.permitted.by.the.dns.standard.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.xxxxxxxx.example.net",
+    );
+    test_ok!("alpha1.beta2.my-host.wikijump.dev");
+    test_ok!("ALLUPPERCASEANDABITLONG.COM");
+    test_ok!("foo.bar.somesite.co.uk");
+    test_err!("this has whitespace in it");
+    test_err!(" this-has-whitespace-too ");
+    test_err!("site1\n.com");
+    test_err!("ascii$but^not_valid.net");
+
+    // Punycode tests
+    test_err!("bücher.tld");
+    test_err!("xn--bücher.tld");
+    test_ok!("xn--bcher-kva.tld");
+    test_err!("例.tld");
+    test_ok!("xn--fsq.tld");
+    test_err!("🦘.tld");
+    test_ok!("xn--ot9h.tld");
+    test_err!("правда.ru");
+    test_ok!("xn--80aafi6cg.ru");
+    test_err!("ความสงบสุข.th");
+    test_ok!("xn--22cdj0f7a9awc1e5c.th");
+    test_err!("도메인.or.kr");
+    test_ok!("xn--hq1bm8jm9l.or.kr");
+    test_err!("ドメイン名例.co.jp");
+    test_ok!("xn--eckwd4c7cu47r2wf.co.jp");
+    test_err!("MajiでKoiする5秒前.co.jp");
+    test_ok!("xn--MajiKoi5-783gue6qz075azm5e.co.jp");
 }

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -27,7 +27,9 @@ use super::prelude::*;
 use crate::models::site::{self, Entity as Site, Model as SiteModel};
 use crate::models::site_domain::{self, Entity as SiteDomain, Model as SiteDomainModel};
 use crate::services::SiteService;
+use regex::Regex;
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
 pub const DEFAULT_SITE_SLUG: &str = "www";
 
@@ -216,4 +218,68 @@ impl DomainService {
 
         Ok(models)
     }
+}
+
+fn validate_domain(domain: &str) -> Result<()> {
+    const PUNYCODE_PREFIX: &str = "xn--";
+    const DOMAIN_MAX_BYTES: usize = 253;
+
+    static DOMAIN_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[A-Za-z0-9\-\.]{1,253}$").unwrap());
+
+    // First, more user-friendly check for unicode characters
+    let has_unicode = !domain.is_ascii();
+    if !domain.starts_with(PUNYCODE_PREFIX) && has_unicode {
+        error!(
+            "Custom domain '{}' has non-ASCII characters but is not using punycode",
+            domain,
+        );
+        bail!(Error::new(
+            format!(
+                "domain should use punycode to convey non-ASCII characters: {}",
+                domain,
+            ),
+            ErrorType::CustomDomainUsePunycode {
+                domain: str!(domain),
+            }
+        ));
+    }
+
+    // Now do more specific domain validation checks
+    //
+    // * Isn't ASCII (but we aren't giving the punycode-specific error) (reusing this prior result)
+    // * Domains can only be at most 253 bytes long (excludes the trailing null byte / dot)
+    // * Domains may only be composed of the limited subset of characters allowed by DNS
+
+    macro_rules! raise_error {
+        ($($arg:tt)*) => {{
+            let message = format!($($arg)*);
+            error!("Custom domain verification failed, {message}: {domain}");
+            bail!(Error::new(message, ErrorType::InvalidDomainValue { domain: str!(domain) }));
+        }};
+    }
+
+    if has_unicode {
+        raise_error!("punycode domain '{}' has non-ASCII characters", domain);
+    }
+
+    if domain.len() > DOMAIN_MAX_BYTES {
+        raise_error!(
+            "domain '{}' is too long ({} > {})",
+            domain,
+            domain.len(),
+            DOMAIN_MAX_BYTES,
+        );
+    }
+
+    if !DOMAIN_REGEX.is_match(domain) {
+        raise_error!("domain '{}' contains invalid characters", domain);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_domain() {
+    todo!()
 }

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -65,6 +65,8 @@ impl DomainService {
             ));
         }
 
+        validate_domain(&domain).or_raise(make_error)?;
+
         let config = ctx.config();
         if domain.ends_with(&config.main_domain) || domain.ends_with(&config.files_domain)
         {

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -57,7 +57,10 @@ impl DomainService {
 
         // Correctness checks
 
-        if Self::custom_domain_exists(ctx, &domain).await? {
+        if Self::custom_domain_exists(ctx, &domain)
+            .await
+            .or_raise(make_error)?
+        {
             error!("Custom domain '{domain}' already exists, cannot create");
             bail!(Error::new(
                 format!("cannot create domain '{}', already exists", domain),
@@ -71,7 +74,8 @@ impl DomainService {
         if domain.ends_with(&config.main_domain) || domain.ends_with(&config.files_domain)
         {
             error!(
-                "Custom domains cannot be subdomains of the Wikijump main or files domain: {domain}"
+                "Custom domains cannot be subdomains of the Wikijump main domain ('{}') or files domain ('{}'): {}",
+                config.main_domain, config.files_domain, domain,
             );
             bail!(Error::new(
                 format!(

--- a/deepwell/src/services/domain/service.rs
+++ b/deepwell/src/services/domain/service.rs
@@ -253,6 +253,7 @@ fn validate_domain(domain: &str) -> Result<()> {
 
     // Now do more specific domain validation checks
     //
+    // * Domain cannot be an empty string
     // * Isn't ASCII (but we aren't giving the punycode-specific error) (reusing this prior result)
     // * Domains can only be at most 253 bytes long (excludes the trailing null byte / dot)
     // * Domains may only be composed of the limited subset of characters allowed by DNS
@@ -263,6 +264,10 @@ fn validate_domain(domain: &str) -> Result<()> {
             error!("Custom domain verification failed, {message}: {domain}");
             bail!(Error::new(message, ErrorType::InvalidDomainValue { domain: str!(domain) }));
         }};
+    }
+
+    if domain.is_empty() {
+        raise_error!("domain cannot be empty");
     }
 
     if has_unicode {


### PR DESCRIPTION
This adds a check function to `DomainService::create_custom()` to deny invalid domains and those which could be used to inject into the generated Caddyfile. Given that this is a site admin function, this is a lower concern, but it doesn't hurt to have a validation check here.

I based these limitations off of the description of [what consitutes a valid hostname](https://en.wikipedia.org/wiki/Hostname#Syntax). International domains are accepted, but must be passed in punycode format. I added a specific error for this case so the UI can display useful guidance for this (or potentially even offer to convert it?).

This PR also adds unit tests for this change and bumps the crate version.