### PR TITLE
Re-enable wildcard certificates for dev

### DIFF
--- a/install/dev/caddy/request.json
+++ b/install/dev/caddy/request.json
@@ -5,7 +5,7 @@
 	"params": {
 		"debug": false,
 		"local": false,
-		"_wildcard_cert": "digitalocean {env.DIGITALOCEAN_API_TOKEN}",
+		"wildcard_cert": "digitalocean {env.DIGITALOCEAN_API_TOKEN}",
 		"deploy_host": "host.docker.internal:9120",
 		"framerail_host": "framerail:3393",
 		"wws_host": "wws:3466"


### PR DESCRIPTION
DNS for wjfiles.dev should be operating as expected now.

This reverts #2755 

