### PR TITLE
Allow caddy to start even if deepwell is unhealthy

### DIFF
--- a/install/common/caddy/start.sh
+++ b/install/common/caddy/start.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 
+# If deepwell isn't available yet, or is failing for an unknown reason,
+# then use the provisional Caddyfile so at least Komodo is reachable
+# and a web server is running.
+#
+# Note that the caddy health check will return failure during that time.
+if [ nc -z deepwell 2747 ] && wikijump-generate-caddyfile; then
+	echo 'Installing generated Caddyfile...'
+	mv /tmp/Caddyfile /etc/caddy/Caddyfile
+else
+	echo 'Cannot reach DEEPWELL, using provisional Caddyfile'
+	# Template for the provisional Caddyfile is already installed in the container
+	deploy_host="$(jq -r .params.deploy_host /etc/caddy-request.json)"
+	sed -i "s/<<DEPLOY_HOST>>/$deploy_host/" /etc/caddy/Caddyfile
+fi
+
 # It'll fork off and the child process will be tracked
 echo 'Starting cron...'
 crond
-
-# Then we need to get the Caddyfile
-echo 'Generating Caddyfile...'
-wikijump-generate-caddyfile
-mv /tmp/Caddyfile /etc/caddy/Caddyfile
 
 echo 'Starting caddy...'
 exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/install/dev/caddy/Caddyfile
+++ b/install/dev/caddy/Caddyfile
@@ -1,0 +1,27 @@
+# Provisional Caddyfile
+#
+# This is meant to be used as a default in the case
+# where DEEPWELL cannot be reached yet (or is erroring
+# for reasons unknown).
+#
+# This enables minimum caddy function until a later Caddyfile
+# update cronjob succeeds or the issue can be fixed manually.
+#
+# Variables (denoted by '<<NAME>>') are replaced in wikijump-start-caddy.
+
+deploy.wikijump.dev {
+	reverse_proxy <<DEPLOY_HOST>>
+}
+
+deploy.wjfiles.dev {
+	redir https://deploy.wikijump.dev
+}
+
+# Display fallback error
+http://,
+https:// {
+	respond 502 {
+		body "ERROR XF-1005"
+		close
+	}
+}

--- a/install/dev/caddy/Caddyfile
+++ b/install/dev/caddy/Caddyfile
@@ -21,7 +21,7 @@ deploy.wjfiles.dev {
 http://,
 https:// {
 	respond 502 {
-		body "ERROR XF-1005"
+		body "ERROR XF-1005\nBackend still starting up or fatal error"
 		close
 	}
 }

--- a/install/dev/caddy/Dockerfile
+++ b/install/dev/caddy/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 RUN apk add --no-cache curl jq
 
 # Install files
+COPY ./install/dev/caddy/Caddyfile /etc/caddy/Caddyfile
 COPY ./install/dev/caddy/start.sh /usr/local/bin/wikijump-start-caddy
 COPY ./install/dev/caddy/health-check.sh /usr/local/bin/wikijump-health-check
 COPY ./install/dev/caddy/generate-caddyfile.sh /usr/local/bin/wikijump-generate-caddyfile

--- a/install/prod/caddy/Caddyfile
+++ b/install/prod/caddy/Caddyfile
@@ -1,0 +1,27 @@
+# Provisional Caddyfile
+#
+# This is meant to be used as a default in the case
+# where DEEPWELL cannot be reached yet (or is erroring
+# for reasons unknown).
+#
+# This enables minimum caddy function until a later Caddyfile
+# update cronjob succeeds or the issue can be fixed manually.
+#
+# Variables (denoted by '<<NAME>>') are replaced in wikijump-start-caddy.
+
+deploy.wikijump.com {
+	reverse_proxy <<DEPLOY_HOST>>
+}
+
+deploy.wjfiles.com {
+	redir https://deploy.wikijump.com
+}
+
+# Display fallback error
+http://,
+https:// {
+	respond 502 {
+		body "ERROR XF-1005"
+		close
+	}
+}

--- a/install/prod/caddy/Caddyfile
+++ b/install/prod/caddy/Caddyfile
@@ -21,7 +21,7 @@ deploy.wjfiles.com {
 http://,
 https:// {
 	respond 502 {
-		body "ERROR XF-1005"
+		body "ERROR XF-1005\nBackend still starting up or fatal error"
 		close
 	}
 }

--- a/install/prod/caddy/Dockerfile
+++ b/install/prod/caddy/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 RUN apk add --no-cache curl jq
 
 # Install files
+COPY ./install/prod/caddy/Caddyfile /etc/caddy/Caddyfile
 COPY ./install/prod/caddy/start.sh /usr/local/bin/wikijump-start-caddy
 COPY ./install/prod/caddy/health-check.sh /usr/local/bin/wikijump-health-check
 COPY ./install/prod/caddy/generate-caddyfile.sh /usr/local/bin/wikijump-generate-caddyfile

--- a/wws/Cargo.lock
+++ b/wws/Cargo.lock
@@ -3153,7 +3153,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wws"
-version = "2026.1.8"
+version = "2026.3.21"
 dependencies = [
  "accept-language",
  "anyhow",

--- a/wws/Cargo.toml
+++ b/wws/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "caching", "web-programming::http-server"]
 exclude = [".gitignore"]
 
-version = "2026.1.8"
+version = "2026.3.21"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/wws/src/error/fallback.rs
+++ b/wws/src/error/fallback.rs
@@ -64,6 +64,15 @@ pub enum FallbackError {
 
     /// Unable to fetch a hosted text block from S3.
     TextBlockS3Fetch,
+
+    /// Unable to generate the initial Caddyfile.
+    ///
+    /// NOTE: This enum variant is never used in wws.
+    /// This is because it is used by caddy when it cannot reach DEEPWELL
+    /// to generate its initial Caddyfile (which is a pre-requisite to ever
+    /// routing any requests to wws, which in this scenario is probably down too).
+    #[allow(dead_code)]
+    CannotGenerateCaddyfile,
 }
 
 impl FallbackError {
@@ -78,6 +87,7 @@ impl FallbackError {
             FallbackError::BasicErrorDirect => 1002,
             FallbackError::RedirectMain => 1003,
             FallbackError::TextBlockS3Fetch => 1004,
+            FallbackError::CannotGenerateCaddyfile => 1005,
         }
     }
 
@@ -89,6 +99,7 @@ impl FallbackError {
                 StatusCode::GATEWAY_TIMEOUT
             }
             FallbackError::TextBlockS3Fetch => StatusCode::INTERNAL_SERVER_ERROR,
+            FallbackError::CannotGenerateCaddyfile => StatusCode::BAD_GATEWAY,
         }
     }
 }


### PR DESCRIPTION
A problem we have seen in a few of our recent deployments is that there is some issue with deepwell (or even, it hasn't started up yet), and then because caddy isn't running, we don't get reverse proxying to Komodo to check out what the issue actually is.

This PR attempts to fix this by providing a fallback Caddyfile in the image.

Currently the logic is to query DEEPWELL to generate the Caddyfile to use. However, if this request fails the whole container cannot start. So instead, we change the start script to *attempt* this request, and if it fails, then use a fallback Caddyfile which only has two rules:

1. Route to Komodo
2. Display a fallback error for this situation (XF-1005)

I've added the fallback error to wws for documentation purposes, and included a secondary line to provide a little information about the issue.