### PR TITLE
Deployment improvements for caddy

### DIFF
--- a/install/common/caddy/start.sh
+++ b/install/common/caddy/start.sh
@@ -5,7 +5,7 @@
 # and a web server is running.
 #
 # Note that the caddy health check will return failure during that time.
-if [ nc -z deepwell 2747 ] && wikijump-generate-caddyfile; then
+if nc -z deepwell 2747 && wikijump-generate-caddyfile; then
 	echo 'Installing generated Caddyfile...'
 	mv /tmp/Caddyfile /etc/caddy/Caddyfile
 else

--- a/install/common/caddy/start.sh
+++ b/install/common/caddy/start.sh
@@ -9,7 +9,7 @@ if nc -z deepwell 2747 && wikijump-generate-caddyfile; then
 	echo 'Installing generated Caddyfile...'
 	mv /tmp/Caddyfile /etc/caddy/Caddyfile
 else
-	echo 'Cannot reach DEEPWELL, using provisional Caddyfile'
+	echo 'Cannot reach DEEPWELL, using provisional Caddyfile to start'
 	# Template for the provisional Caddyfile is already installed in the container
 	deploy_host="$(jq -r .params.deploy_host /etc/caddy-request.json)"
 	sed -i "s/<<DEPLOY_HOST>>/$deploy_host/" /etc/caddy/Caddyfile

--- a/install/common/caddy/start.sh
+++ b/install/common/caddy/start.sh
@@ -10,9 +10,6 @@ if nc -z deepwell 2747 && wikijump-generate-caddyfile; then
 	mv /tmp/Caddyfile /etc/caddy/Caddyfile
 else
 	echo 'Cannot reach DEEPWELL, using provisional Caddyfile to start'
-	# Template for the provisional Caddyfile is already installed in the container
-	deploy_host="$(jq -r .params.deploy_host /etc/caddy-request.json)"
-	sed -i "s/<<DEPLOY_HOST>>/$deploy_host/" /etc/caddy/Caddyfile
 fi
 
 # It'll fork off and the child process will be tracked

--- a/install/dev/caddy/Dockerfile
+++ b/install/dev/caddy/Dockerfile
@@ -18,6 +18,10 @@ COPY ./install/dev/caddy/generate-caddyfile.sh /usr/local/bin/wikijump-generate-
 COPY ./install/dev/caddy/update-caddyfile.sh /usr/local/bin/wikijump-update-caddyfile
 COPY ./install/dev/caddy/request.json /etc/caddy-request.json
 
+# Set up provisional Caddyfile
+# Ensure deploy host matches with request.json
+RUN sed -i "s/<<DEPLOY_HOST>>/$(jq -r .params.deploy_host /etc/caddy-request.json)/" /etc/caddy/Caddyfile
+
 # Set up cron
 COPY ./install/dev/caddy/crontab /etc/caddy/crontab
 RUN crontab -u daemon /etc/caddy/crontab && \

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -108,6 +108,7 @@ services:
       - "443:443"
       - "443:443/udp"
     links:
+      - deepwell
       - framerail
       - wws
     environment:

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -118,9 +118,6 @@ services:
       interval: 30s
       timeout: 2s
       retries: 3
-    depends_on:
-      deepwell:
-        condition: service_healthy
     volumes:
       - caddy:/data/caddy
     extra_hosts:

--- a/install/local/caddy/Caddyfile
+++ b/install/local/caddy/Caddyfile
@@ -6,15 +6,11 @@
 #
 # This enables minimum caddy function until a later Caddyfile
 # update cronjob succeeds or the issue can be fixed manually.
-#
-# Variables (denoted by '<<NAME>>') are replaced in the image build.
 
-deploy.wikijump.dev {
-	reverse_proxy <<DEPLOY_HOST>>
-}
-
-deploy.wjfiles.dev {
-	redir https://deploy.wikijump.dev
+{
+	debug
+	local_certs
+	skip_install_trust
 }
 
 # Display fallback error

--- a/install/local/caddy/Dockerfile
+++ b/install/local/caddy/Dockerfile
@@ -4,6 +4,7 @@ FROM caddy:alpine
 RUN apk add --no-cache curl jq
 
 # Install files
+COPY ./install/local/caddy/Caddyfile /etc/caddy/Caddyfile
 COPY ./install/local/caddy/start.sh /usr/local/bin/wikijump-start-caddy
 COPY ./install/local/caddy/health-check.sh /usr/local/bin/wikijump-health-check
 COPY ./install/local/caddy/generate-caddyfile.sh /usr/local/bin/wikijump-generate-caddyfile

--- a/install/local/deploy.py
+++ b/install/local/deploy.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Do not change directory before attempting to run docker-compose",
     )
-    argparser.add_argument("action", nargs=argparse.REMAINDER)
+    argparser.add_argument("command", nargs=argparse.REMAINDER)
     args = argparser.parse_args()
 
     # Get into the right context
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     if not args.no_dev:
         cmdline.extend(("-f", "docker-compose.dev.yaml"))
 
-    cmdline.extend(args.action)
+    cmdline.extend(args.command)
 
     # We use exec instead of subprocess since this is just a launch script,
     # it doesn't need to do any work after starting docker-compose.

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -158,6 +158,3 @@ services:
       interval: 30s
       timeout: 2s
       retries: 3
-    depends_on:
-      deepwell:
-        condition: service_healthy

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -150,6 +150,7 @@ services:
       - "443:443"
       - "443:443/udp"
     links:
+      - deepwell
       - framerail
       - wws
     restart: unless-stopped

--- a/install/prod/caddy/Caddyfile
+++ b/install/prod/caddy/Caddyfile
@@ -7,7 +7,7 @@
 # This enables minimum caddy function until a later Caddyfile
 # update cronjob succeeds or the issue can be fixed manually.
 #
-# Variables (denoted by '<<NAME>>') are replaced in wikijump-start-caddy.
+# Variables (denoted by '<<NAME>>') are replaced in the image build.
 
 deploy.wikijump.com {
 	reverse_proxy <<DEPLOY_HOST>>
@@ -18,10 +18,13 @@ deploy.wjfiles.com {
 }
 
 # Display fallback error
-http://,
-https:// {
+http:// {
 	respond 502 {
-		body "ERROR XF-1005\nBackend still starting up or fatal error"
+		body <<EOF
+		ERROR XF-1005
+		Backend still starting up or fatal error
+		EOF
+
 		close
 	}
 }


### PR DESCRIPTION
This fixes some things regarding how caddy works in our dev deployment:

* Caddy no longer depends on deepwell starting up first. Instead, it uses a provisional Caddyfile to serve traffic until it can get a real one from deepwell.
  * This way the web server is operational much quicker.
  * It also continually ensures `deploy.wikijump.dev` is available, avoiding disruption to deployments and infrastructure while starting up (or if deepwell has failed).
* Move `deploy_host` population in docker image build. (No need for it to be at runtime)
* Fix deepwell/caddy link:
  * Fixes the initial deepwell health check in the start script.
  * Links deepwell and caddy (for configuration updates in cron) (should've been linked already).
* Fix newline in XF-1005 error display.

I was not able to get Caddy to agnostically listen on HTTPS for all hosts, I assume this is because TLS depends on host verification via certificate. I set it to catch-all `http://` instead (except the deploy subdomain which can have a certificate fetched for it).