### PR TITLE
Improve automatic dev deployment

### DIFF
--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -64,9 +64,6 @@ services:
       interval: 120s
       timeout: 2s
       retries: 3
-    depends_on:
-      deepwell:
-        condition: service_healthy
 
   wws:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/wws:dev
@@ -89,9 +86,6 @@ services:
       interval: 120s
       timeout: 2s
       retries: 3
-    depends_on:
-      deepwell:
-        condition: service_healthy
 
   caddy:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/caddy:dev

--- a/install/dev/docker-compose.yaml
+++ b/install/dev/docker-compose.yaml
@@ -33,9 +33,6 @@ services:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/deepwell:dev
     ports:
       - "2747:2747"
-    links:
-      - cache
-      - database
     environment:
       - "DATABASE_URL=postgres://wikijump:${POSTGRES_PASSWORD}@database/wikijump"
       - "REDIS_URL=redis://cache"
@@ -59,8 +56,6 @@ services:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/framerail:dev
     ports:
       - "3393:3393"
-    links:
-      - deepwell
     environment:
       - "DEEPWELL_HOST=deepwell"
     restart: unless-stopped
@@ -77,9 +72,6 @@ services:
     image: 575596218155.dkr.ecr.us-east-2.amazonaws.com/wikijump/wws:dev
     ports:
       - "3466:3466"
-    links:
-      - deepwell
-      - cache
     environment:
       - "ADDRESS=[::]:3466"
       - "DEEPWELL_URL=http://deepwell:2747"
@@ -107,10 +99,6 @@ services:
       - "80:80"
       - "443:443"
       - "443:443/udp"
-    links:
-      - deepwell
-      - framerail
-      - wws
     environment:
       - "DIGITALOCEAN_API_TOKEN=${DIGITALOCEAN_API_TOKEN}"
     restart: unless-stopped

--- a/install/dev/komodo/procedures.toml
+++ b/install/dev/komodo/procedures.toml
@@ -1,7 +1,7 @@
 [[procedure]]
 name = "Deploy Dev"
 description = "Automatically deploy Wikijump dev on push"
-tags = ["wikijump", "system"]
+tags = ["wikijump"]
 
 [[procedure.config.stage]]
 name = "Pull Wikijump"

--- a/install/local/docker-compose.yaml
+++ b/install/local/docker-compose.yaml
@@ -54,10 +54,6 @@ services:
       dockerfile: install/local/deepwell/Dockerfile
     ports:
       - "2747:2747"
-    links:
-      - cache
-      - database
-      - files
     environment:
       - "DATABASE_URL=postgres://wikijump:wikijump@database/wikijump"
       - "REDIS_URL=redis://cache"
@@ -90,8 +86,6 @@ services:
       dockerfile: install/local/framerail/Dockerfile
     ports:
       - "3393:3393"
-    links:
-      - deepwell
     environment:
       - "DEEPWELL_HOST=deepwell"
     restart: unless-stopped
@@ -110,10 +104,6 @@ services:
       dockerfile: install/local/wws/Dockerfile
     ports:
       - "3466:3466"
-    links:
-      - deepwell
-      - cache
-      - files
     environment:
       - "ADDRESS=[::]:3466"
       - "DEEPWELL_URL=http://deepwell:2747"
@@ -149,10 +139,6 @@ services:
       - "80:80"
       - "443:443"
       - "443:443/udp"
-    links:
-      - deepwell
-      - framerail
-      - wws
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wikijump-health-check"]


### PR DESCRIPTION
Komodo has had a few issues with not being able to consistently deploy new dev versions without babysitting. On redeploy, it would _create_, but not _run_ `caddy`, `wws`, and `framerail`. If I manually started them, they ran fine.

It seems the issue is how it's handling the `depends_on` section. This requirement seems to make it think it can't ever start the containers for real.

So, I removed those sections from the dev `docker-compose.yaml`. WWS will crash on init if it cannot connect to deepwell - it gets restarted automatically so this will correct itself when deepwell is okay. The other containers don't need deepwell to be ready immediately.

(I'll note that WWS doesn't _require_ this behavior, we could add `--disable-deepwell-check` to the service invocation)

I also removed the `links` section from local and dev, since apparently it is deprecated (connections to containers are instead mediated through the network(s) you connect each container to).

Tested by setting dev to read from this branch instead of `develop` and manually ran deployments.