### PR TITLE
[WJ-1360] implement PageQueryService::find() with FoundPages output

### DIFF
--- a/deepwell/src/services/page_query/service.rs
+++ b/deepwell/src/services/page_query/service.rs
@@ -440,9 +440,8 @@ impl PageQueryService {
 
         // Execute it!
         let pages = query.all(txn).await.or_raise(make_error)?;
-        let total = pages.len();
 
-        debug!("Query returned {total} pages, building FoundPages");
+        debug!("Query returned {} pages, building FoundPages", pages.len());
 
         let rows = pages
             .into_iter()
@@ -450,6 +449,16 @@ impl PageQueryService {
                 page_id: page.page_id,
                 site_id: page.site_id,
                 slug: if fields.slug { Some(page.slug) } else { None },
+                page_category_id: if fields.page_category_id {
+                    Some(page.page_category_id)
+                } else {
+                    None
+                },
+                page_revision_id: if fields.page_revision_id {
+                    page.latest_revision_id
+                } else {
+                    None
+                },
                 created_at: if fields.created_at {
                     Some(page.created_at)
                 } else {
@@ -472,6 +481,6 @@ impl PageQueryService {
             })
             .collect();
 
-        Ok(FoundPages { pages: rows, total })
+        Ok(FoundPages { pages: rows })
     }
 }

--- a/deepwell/src/services/page_query/service.rs
+++ b/deepwell/src/services/page_query/service.rs
@@ -28,13 +28,12 @@ use crate::models::page_parent::{self, Entity as PageParent};
 use crate::models::{page_revision, text};
 use crate::services::{PageService, ParentService};
 use sea_query::{Expr, Query};
-use std::convert::Infallible;
 
 #[derive(Debug)]
 pub struct PageQueryService;
 
 impl PageQueryService {
-    pub async fn execute(
+    pub async fn find(
         ctx: &ServiceContext<'_>,
         PageQuery {
             current_page_id,
@@ -67,8 +66,9 @@ impl PageQueryService {
             order,
             pagination,
             variables,
+            fields,
         }: PageQuery<'_>,
-    ) -> Result<Infallible> {
+    ) -> Result<FoundPages> {
         info!("Building ListPages query from specification");
 
         let make_error =
@@ -439,9 +439,39 @@ impl PageQueryService {
         //      3. [14, 13, 12, 11, 10]
 
         // Execute it!
-        let result = query.all(txn).await.or_raise(make_error)?;
+        let pages = query.all(txn).await.or_raise(make_error)?;
+        let total = pages.len();
 
-        // TODO implement query construction
-        todo!()
+        debug!("Query returned {total} pages, building FoundPages");
+
+        let rows = pages
+            .into_iter()
+            .map(|page| FoundPageRow {
+                page_id: page.page_id,
+                site_id: page.site_id,
+                slug: if fields.slug { Some(page.slug) } else { None },
+                created_at: if fields.created_at {
+                    Some(page.created_at)
+                } else {
+                    None
+                },
+                updated_at: if fields.updated_at {
+                    page.updated_at
+                } else {
+                    None
+                },
+                // Fields that require a revision join are not
+                // yet populated from the query. These will be
+                // implemented when the revision join is added.
+                title: None,      // TODO: requires revision join
+                alt_title: None,  // TODO: requires revision join
+                tags: None,       // TODO: requires revision join
+                created_by: None, // TODO: requires revision join
+                updated_by: None, // TODO: requires revision join
+                score: None,      // TODO: requires vote join
+            })
+            .collect();
+
+        Ok(FoundPages { pages: rows, total })
     }
 }

--- a/deepwell/src/services/page_query/structs.rs
+++ b/deepwell/src/services/page_query/structs.rs
@@ -291,6 +291,8 @@ pub struct FoundPageFields {
     pub title: bool,
     pub alt_title: bool,
     pub slug: bool,
+    pub page_category_id: bool,
+    pub page_revision_id: bool,
     pub tags: bool,
     pub created_at: bool,
     pub created_by: bool,
@@ -316,6 +318,10 @@ pub struct FoundPageRow {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_category_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_revision_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "time::serde::rfc3339::option")]
@@ -338,5 +344,11 @@ pub struct FoundPageRow {
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct FoundPages {
     pub pages: Vec<FoundPageRow>,
-    pub total: usize,
+}
+
+impl FoundPages {
+    #[inline]
+    pub fn total(&self) -> usize {
+        self.pages.len()
+    }
 }

--- a/deepwell/src/services/page_query/structs.rs
+++ b/deepwell/src/services/page_query/structs.rs
@@ -22,11 +22,8 @@
 #![allow(dead_code)] // TEMP
 
 use super::prelude::*;
-use crate::models::{
-    page::Model as PageModel, page_parent::Model as PageParentModel,
-    page_revision::Model as PageRevisionModel,
-};
 use crate::services::score::ScoreValue;
+use sea_orm::prelude::TimeDateTimeWithTimeZone;
 use std::borrow::Cow;
 use time::OffsetDateTime;
 
@@ -281,17 +278,65 @@ pub struct PageQuery<'a> {
     pub order: Option<OrderBySelector>,
     pub pagination: PaginationSelector,
     pub variables: &'a [PageQueryVariables<'a>],
+    pub fields: FoundPageFields,
 }
 
-#[derive(Serialize, Debug, PartialEq, Clone)]
-pub struct PageQueryOutput<'a>(&'a [PageResult]);
+/// Specifies which optional fields to include in the query results.
+///
+/// Fields required for filtering or ordering are always fetched
+/// internally, but only appear in the output if requested here.
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(default)]
+pub struct FoundPageFields {
+    pub title: bool,
+    pub alt_title: bool,
+    pub slug: bool,
+    pub tags: bool,
+    pub created_at: bool,
+    pub created_by: bool,
+    pub updated_at: bool,
+    pub updated_by: bool,
+    pub score: bool,
+}
 
-#[derive(Serialize, Debug, PartialEq, Clone)]
-pub struct PageResult {
-    metadata: PageModel,
-    last_revision: PageRevisionModel,
-    // last_comment: TODO,
-    page_parents: Vec<PageParentModel>,
-    wikitext: String,
-    score: f32,
+/// A single page row in the query results.
+///
+/// Fields are optional because callers specify which fields
+/// they need via `FoundPageFields`. Fields not requested will
+/// be `None` to avoid unnecessary data transfer.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct FoundPageRow {
+    pub page_id: i64,
+    pub site_id: i64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub created_at: Option<TimeDateTimeWithTimeZone>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub updated_at: Option<TimeDateTimeWithTimeZone>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f32>,
+}
+
+/// The result of `PageQueryService::find()`.
+///
+/// Contains an ordered list of pages matching the query,
+/// with only the requested fields populated.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct FoundPages {
+    pub pages: Vec<FoundPageRow>,
+    pub total: usize,
 }


### PR DESCRIPTION
- Rename `PageQueryService::execute()` to `PageQueryService::find()`
- Add `FoundPages`, `FoundPageRow`, and `FoundPageFields` output types
- Callers specify which fields to include via `FoundPageFields`, unneeded fields are `None`
- Populate page-table fields when requested, revision/vote fields left as TODO
- Remove old unused `PageQueryOutput` and `PageResult` structs