### PR TITLE
Add wws badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
          alt="DEEPWELL build status">
   </a>
 
+  <a href="https://github.com/scpwiki/wikijump/actions?query=workflow%3A%22%5Bwws%5D+Rust%22">
+    <img src="https://github.com/scpwiki/wikijump/workflows/%5Bwws%5D%20Rust/badge.svg"
+         alt="WWS build status">
+  </a>
+
   <a href="https://github.com/scpwiki/wikijump/actions?query=workflow%3A%22%5Bframerail%5D+Typescript%22">
     <img src="https://github.com/scpwiki/wikijump/workflows/%5Bframerail%5D%20Typescript/badge.svg"
          alt="Framerail build status">


### PR DESCRIPTION
WWS did not have a badge on the README, this fixes that:

<img width="1069" height="307" alt="image" src="https://github.com/user-attachments/assets/3527dc4c-3899-4fb3-aa9f-308c46005a1d" />
