### PR TITLE
[WJ-1373] Don't use low region for users

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "deepwell"
-version = "2026.3.28"
+version = "2026.4.4"
 dependencies = [
  "argon2",
  "arraystring",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.3.28"
+version = "2026.4.4"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/seeder/users.json
+++ b/deepwell/seeder/users.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": 1,
+        "id": -1,
         "type": "regular",
         "name": "Administrator",
         "slug": "administrator",
@@ -21,7 +21,7 @@
         ]
     },
     {
-        "id": 2,
+        "id": -2,
         "type": "system",
         "name": "System",
         "slug": "system",
@@ -42,7 +42,7 @@
         ]
     },
     {
-        "id": 3,
+        "id": -3,
         "type": "system",
         "name": "Anonymous",
         "slug": "anonymous",
@@ -64,7 +64,7 @@
         ]
     },
     {
-        "id": 4,
+        "id": -4,
         "type": "system",
         "name": "Unknown",
         "slug": "unknown",
@@ -84,7 +84,7 @@
         ]
     },
     {
-        "id": 5,
+        "id": -5,
         "type": "system",
         "name": "User",
         "slug": "user",
@@ -106,7 +106,7 @@
         ]
     },
     {
-        "id": 6,
+        "id": -6,
         "type": "regular",
         "name": "Guest",
         "slug": "guest",

--- a/deepwell/src/constants.rs
+++ b/deepwell/src/constants.rs
@@ -21,7 +21,8 @@
 #![allow(dead_code)]
 
 // See seeder data for these values
-pub const ADMIN_USER_ID: i64 = 1;
-pub const SYSTEM_USER_ID: i64 = 2;
-pub const ANONYMOUS_USER_ID: i64 = 3;
-pub const SAMPLE_USER_ID: i64 = 4;
+pub const ADMIN_USER_ID: i64 = -1;
+pub const SYSTEM_USER_ID: i64 = -2;
+pub const ANONYMOUS_USER_ID: i64 = -3;
+pub const UNKNOWN_USER_ID: i64 = -4;
+pub const SAMPLE_USER_ID: i64 = -5;

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -113,6 +113,11 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     for user in users {
         info!("Creating seed user '{}' (ID {})", user.name, user.id);
 
+        if user.id > 0 {
+            // Specially seeded users should have negative values.
+            panic!("Seed user '{}' has positive ID {}", user.name, user.id);
+        }
+
         // Create users
         let CreateUserOutput { user_id, slug } = UserService::create(
             &ctx,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -83,9 +83,11 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     restart_sequence(&txn, "user_user_id_seq")
         .await
         .or_raise(make_error)?;
+
     restart_sequence(&txn, "page_page_id_seq")
         .await
         .or_raise(make_error)?;
+
     restart_sequence(&txn, "site_site_id_seq")
         .await
         .or_raise(make_error)?;

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -644,26 +644,6 @@ pub async fn seed(state: &ServerState) -> Result<()> {
     Ok(())
 }
 
-async fn restart_sequence(
-    txn: &DatabaseTransaction,
-    sequence_name: &'static str,
-) -> Result<()> {
-    debug!("Restarting sequence {sequence_name}");
-
-    // SAFETY: We cannot parameterize the sequence name here, so we have to use format!()
-    //         However, by requiring that sequence_name be &'static str, we ensure that it
-    //         is only applied to hardcoded values and never used for runtime values
-    //         (such as ones entered by an external, untrusted user).
-    run_query(txn, format!("ALTER SEQUENCE {sequence_name} RESTART"))
-        .await
-        .or_raise(|| {
-            Error::new(
-                format!("failed to restart ID sequence '{sequence_name}'"),
-                ErrorType::DatabaseSeeder,
-            )
-        })
-}
-
 async fn restart_sequence_with(
     txn: &DatabaseTransaction,
     sequence_name: &'static str,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -129,11 +129,17 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                 locales: user.locales,
                 bypass_filter: true,
                 bypass_email_verification: true,
+                override_user_id: Some(user.id),
                 ip_address: SEED_IP_ADDRESS,
             },
         )
         .await
         .or_raise(make_error)?;
+
+        assert_eq!(
+            user_id, user.id,
+            "User ID from newly seeded user does not match",
+        );
 
         UserService::update(
             &ctx,

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -79,16 +79,48 @@ pub async fn seed(state: &ServerState) -> Result<()> {
         return Ok(());
     }
 
-    // Reset sequences so IDs are consistent
-    restart_sequence(&txn, "user_user_id_seq")
+    // Modify ID sequences so that they exhibit Wikidot compatibility.
+    //
+    // This property means that no valid Wikidot ID for a class of object
+    // can ever also be a valid Wikijump ID for that same class of object.
+    // We do this by putting the start ID for new Wikijump IDs well above
+    // what the Wikidot value is likely to reach by the time the project
+    // hits production.
+    //
+    // Some classes of object are not assigned compatibility IDs, either
+    // because the ID value does not matter, is unused, or is not exposed.
+    //
+    // See https://scuttle.atlassian.net/browse/WJ-964
+
+    restart_sequence_with(&txn, "user_user_id_seq", 20000000)
         .await
         .or_raise(make_error)?;
 
-    restart_sequence(&txn, "page_page_id_seq")
+    restart_sequence_with(&txn, "site_site_id_seq", 6000000)
         .await
         .or_raise(make_error)?;
 
-    restart_sequence(&txn, "site_site_id_seq")
+    restart_sequence_with(&txn, "page_page_id_seq", 3000000000)
+        .await
+        .or_raise(make_error)?;
+
+    restart_sequence_with(&txn, "page_revision_revision_id_seq", 3000000000)
+        .await
+        .or_raise(make_error)?;
+
+    restart_sequence_with(&txn, "page_category_category_id_seq", 100000000)
+        .await
+        .or_raise(make_error)?;
+
+    restart_sequence_with(&txn, "forum_category_forum_category_id_seq", 9000000)
+        .await
+        .or_raise(make_error)?;
+
+    restart_sequence_with(&txn, "forum_thread_forum_thread_id_seq", 30000000)
+        .await
+        .or_raise(make_error)?;
+
+    restart_sequence_with(&txn, "forum_post_forum_post_id_seq", 7000000)
         .await
         .or_raise(make_error)?;
 
@@ -606,51 +638,6 @@ pub async fn seed(state: &ServerState) -> Result<()> {
             .await
             .or_raise(make_error)?;
     }
-
-    // After all seeding, modify ID sequences so that they exhibit Wikidot compatibility.
-    //
-    // This property means that no valid Wikidot ID for a class of object
-    // can ever also be a valid Wikijump ID for that same class of object.
-    // We do this by putting the start ID for new Wikijump IDs well above
-    // what the Wikidot value is likely to reach by the time the project
-    // hits production.
-    //
-    // Some classes of object are not assigned compatibility IDs, either
-    // because the ID value does not matter, is unused, or is not exposed.
-    //
-    // See https://scuttle.atlassian.net/browse/WJ-964
-
-    restart_sequence_with(&txn, "user_user_id_seq", 20000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "site_site_id_seq", 6000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "page_page_id_seq", 3000000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "page_revision_revision_id_seq", 3000000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "page_category_category_id_seq", 100000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "forum_category_forum_category_id_seq", 9000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "forum_thread_forum_thread_id_seq", 30000000)
-        .await
-        .or_raise(make_error)?;
-
-    restart_sequence_with(&txn, "forum_post_forum_post_id_seq", 7000000)
-        .await
-        .or_raise(make_error)?;
 
     txn.commit().await.or_raise(make_error)?;
     info!("Finished running seeder.");

--- a/deepwell/src/endpoints/user_bot.rs
+++ b/deepwell/src/endpoints/user_bot.rs
@@ -114,6 +114,7 @@ pub async fn bot_user_create(
             password: String::new(), // TODO configure user-bot password
             bypass_filter,
             bypass_email_verification,
+            override_user_id: None,
             ip_address,
         },
     )

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -106,6 +106,7 @@ impl SiteService {
                 password: String::new(),
                 bypass_filter: false,
                 bypass_email_verification: true,
+                override_user_id: None,
                 ip_address,
             },
         )

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -58,6 +58,7 @@ impl UserService {
             password,
             bypass_filter,
             bypass_email_verification,
+            override_user_id,
             ip_address,
         }: CreateUser,
     ) -> Result<CreateUserOutput> {
@@ -67,7 +68,27 @@ impl UserService {
         debug!("Normalizing user data (name '{name}', slug '{slug}')");
         regex_replace_in_place(&mut name, &LEADING_TRAILING_CHARS, "");
 
-        info!("Attempting to create user '{name}' ('{slug}')");
+        let user_id = match override_user_id {
+            Some(user_id) if user_id == 0 => {
+                error!(
+                    "Caller attempted to create a user with ID 0, which is reserved (never a valid user ID)",
+                );
+                bail!(Error::new(
+                    "cannot create user with ID 0, value is reserved",
+                    ErrorType::BadRequest,
+                ));
+            }
+            Some(user_id) => {
+                info!("Attempting to create user '{name}' ('{slug}', ID {user_id})");
+                ActiveValue::Set(user_id)
+            }
+            None => {
+                info!("Attempting to create user '{name}' ('{slug}')");
+
+                // Use default value, which is set by BIGSERIAL
+                ActiveValue::NotSet
+            }
+        };
 
         check_user_name(ctx.config(), &slug, &name)?;
 
@@ -221,6 +242,7 @@ impl UserService {
 
         // Insert new model
         let user = user::ActiveModel {
+            user_id,
             user_type: Set(user_type),
             name: Set(name),
             slug: Set(slug.clone()),

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -69,7 +69,7 @@ impl UserService {
         regex_replace_in_place(&mut name, &LEADING_TRAILING_CHARS, "");
 
         let user_id = match override_user_id {
-            Some(user_id) if user_id == 0 => {
+            Some(0) => {
                 error!(
                     "Caller attempted to create a user with ID 0, which is reserved (never a valid user ID)",
                 );

--- a/deepwell/src/services/user/structs.rs
+++ b/deepwell/src/services/user/structs.rs
@@ -39,6 +39,9 @@ pub struct CreateUser {
 
     #[serde(default)]
     pub bypass_email_verification: bool,
+
+    #[serde(default)]
+    pub override_user_id: Option<i64>,
     pub ip_address: IpAddr,
 }
 


### PR DESCRIPTION
Since Wikidot uses its compatibility IDs all the way down to 1, we cannot use the low region for our special users. Instead, we will use the negative ID range, since that will never get used by the normal user creation flow.

As part of this, I also ensure that seeding begins at these compatibility IDs:

<img width="503" height="256" alt="image" src="https://github.com/user-attachments/assets/52e7ca59-857d-438e-bca7-78db785994cc" />

I also take the opportunity here to formally enforce in code the 0 ID invariant (user ID 0 is never a valid user).