### PR TITLE
[WJ-1367] Migrate existing UserPermissions stubs to new permission system

### DIFF
--- a/deepwell/seeder/roles.json
+++ b/deepwell/seeder/roles.json
@@ -30,7 +30,8 @@
             "page:delete",
             "page:rename",
             "role:view",
-            "role:assign"
+            "role:assign",
+            "site:edit"
         ]
     },
     {

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -230,44 +230,27 @@ impl PermissionService {
     pub async fn check_user_can(
         ctx: &ServiceContext<'_>,
         perm_ctx: &CheckPermissionContext<'_>,
-        PermissionInput {
-            resource_type,
-            resource_category,
-            action,
-        }: PermissionInput<'_>,
+        input: PermissionInput<'_>,
     ) -> Result<bool> {
+        let [result] = Self::batch_check_user_can(ctx, perm_ctx, [input]).await?;
+        Ok(result)
+    }
+
+    /// Batch check if a user has the specified permissions.
+    ///
+    /// Returns an array of booleans corresponding to each permission input.
+    /// Results are returned in the same order as the input array, best used with destructuring.
+    pub async fn batch_check_user_can<const N: usize>(
+        ctx: &ServiceContext<'_>,
+        perm_ctx: &CheckPermissionContext<'_>,
+        permissions: [PermissionInput<'_>; N],
+    ) -> Result<[bool; N]> {
         let user_id = perm_ctx.user_id;
         let site_id = perm_ctx.site_id;
         let page_reference = perm_ctx.page_reference.clone();
 
-        // Resolve category reference to ID for permission checking
-        let resource_category_id = match resource_category {
-            Some(reference) => {
-                resolve_category_reference(ctx, site_id, resource_type, reference).await?
-            }
-            None => None,
-        };
-
-        info!(
-            "Checking permission for user ID {:?} on site ID {} for resource {} of category {} with action {}",
-            user_id,
-            site_id,
-            resource_type,
-            resource_category_id.unwrap_or(0),
-            action
-        );
-
-        let make_error = || {
-            Error::new(
-                format!(
-                    "failed to check permission on resource {}:{} with action {}",
-                    resource_type,
-                    resource_category_id.unwrap_or(0),
-                    action
-                ),
-                ErrorType::Permission,
-            )
-        };
+        let make_error =
+            || Error::new("failed to check permissions", ErrorType::Permission);
 
         // Get all roles for this user (includes virtual roles)
         let role_ids: Vec<i64> = RoleService::get_all_roles_for_user_and_site(
@@ -284,8 +267,9 @@ impl PermissionService {
         .map(|r| r.role_id)
         .collect();
 
+        // Short-circuit: no roles means no permissions.
         if role_ids.is_empty() {
-            return Ok(false);
+            return Ok([false; N]);
         }
 
         // Lambda to check if user has any of the specified roles
@@ -295,32 +279,71 @@ impl PermissionService {
                 .any(|role_id| role_ids.contains(role_id))
         };
 
-        // Check permission based on category specificity
-        let roles_with_permission = {
-            if PermissionCache::is_cacheable(resource_type, action) {
-                // Try to fetch from cache
-                let cached_roles = PermissionCache::query_roles_with_permission_cache(
-                    ctx,
-                    site_id,
-                    resource_type,
-                    resource_category_id,
-                    action,
-                )
-                .await
-                .or_raise(make_error)?;
+        let mut results = [false; N];
 
-                if let Some(cached) = cached_roles {
-                    info!("Permission cache hit, {} roles found", cached.len());
-                    cached
-                } else {
-                    info!("Permission cache miss, querying database directly");
+        for (
+            i,
+            PermissionInput {
+                resource_type,
+                resource_category,
+                action,
+            },
+        ) in permissions.into_iter().enumerate()
+        {
+            info!(
+                "Checking permission for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+                user_id, site_id, resource_type, resource_category, action,
+            );
 
-                    // If cache miss, rebuild tree async
-                    PermissionCache::build_permission_cache(ctx, site_id)
+            // Resolve category reference to ID for permission checking
+            let resource_category_id = match resource_category {
+                Some(reference) => {
+                    resolve_category_reference(ctx, site_id, resource_type, reference)
+                        .await?
+                }
+                None => None,
+            };
+
+            // Check permission based on category specificity
+            let roles_with_permission =
+                if PermissionCache::is_cacheable(resource_type, action) {
+                    // Try to fetch from cache
+                    let cached_roles =
+                        PermissionCache::query_roles_with_permission_cache(
+                            ctx,
+                            site_id,
+                            resource_type,
+                            resource_category_id,
+                            action,
+                        )
                         .await
                         .or_raise(make_error)?;
 
-                    // fall back to database query
+                    if let Some(cached) = cached_roles {
+                        info!("Permission cache hit, {} roles found", cached.len());
+                        cached
+                    } else {
+                        info!("Permission cache miss, querying database directly");
+
+                        // If cache miss, rebuild tree async
+                        PermissionCache::build_permission_cache(ctx, site_id)
+                            .await
+                            .or_raise(make_error)?;
+
+                        // fall back to database query
+                        Self::query_roles_with_permission_db(
+                            ctx,
+                            site_id,
+                            resource_type,
+                            resource_category_id,
+                            action,
+                        )
+                        .await
+                        .or_raise(make_error)?
+                    }
+                } else {
+                    info!("Permission not cacheable, querying database directly");
+                    // For non-cacheable permissions, query database directly
                     Self::query_roles_with_permission_db(
                         ctx,
                         site_id,
@@ -330,22 +353,11 @@ impl PermissionService {
                     )
                     .await
                     .or_raise(make_error)?
-                }
-            } else {
-                info!("Permission not cacheable, querying database directly");
-                // For non-cacheable permissions, query database directly
-                Self::query_roles_with_permission_db(
-                    ctx,
-                    site_id,
-                    resource_type,
-                    resource_category_id,
-                    action,
-                )
-                .await
-                .or_raise(make_error)?
-            }
-        };
+                };
 
-        Ok(user_has_any_role(&roles_with_permission))
+            results[i] = user_has_any_role(&roles_with_permission);
+        }
+
+        Ok(results)
     }
 }

--- a/deepwell/src/services/role/mod.rs
+++ b/deepwell/src/services/role/mod.rs
@@ -37,20 +37,7 @@ pub enum SystemRole {
     Anonymous,
     Everyone,
     PageAuthor,
-}
-
-impl SystemRole {
-    pub fn name(self) -> &'static str {
-        match self {
-            SystemRole::Root => "root",
-            SystemRole::Member => "member",
-            SystemRole::Guest => "guest",
-            SystemRole::Registered => "registered",
-            SystemRole::Anonymous => "anonymous",
-            SystemRole::Everyone => "everyone",
-            SystemRole::PageAuthor => "page-author",
-        }
-    }
+    Banned,
 }
 
 mod service;

--- a/deepwell/src/services/role/service.rs
+++ b/deepwell/src/services/role/service.rs
@@ -30,7 +30,9 @@ use crate::services::audit::{AuditEvent, AuditService};
 use crate::services::permission::{
     CheckPermissionContext, PermissionService, resolve_category_reference,
 };
-use crate::services::relation::{GetPageAttributions, GetSiteMember, SiteMemberAccepted};
+use crate::services::relation::{
+    GetPageAttributions, GetSiteBan, GetSiteMember, SiteMemberAccepted,
+};
 use crate::services::role::SystemRole;
 use crate::services::{PageService, RelationService, ServiceContext};
 use crate::types::{Action, Permission, Reference, Resource};
@@ -524,22 +526,39 @@ impl RoleService {
         } else {
             false
         };
+        let is_banned = if is_logged_in {
+            RelationService::site_ban_exists(
+                ctx,
+                GetSiteBan {
+                    site_id: input.site_id,
+                    user_id: input.user_id.unwrap(),
+                },
+            )
+            .await
+            .or_raise(make_error)?
+        } else {
+            false
+        };
 
         // Collect virtual roles to apply based on flags
         let mut applied_virtual_roles = Vec::with_capacity(4); // At most 4 virtual roles at a time
         if is_logged_in {
             applied_virtual_roles.push(SystemRole::Registered);
-        }
-        if is_member {
-            applied_virtual_roles.push(SystemRole::Member);
-        }
-        if is_page_author {
-            applied_virtual_roles.push(SystemRole::PageAuthor);
-        }
-        if !is_logged_in {
+            if is_banned {
+                // If user is banned, skip any other site roles
+                applied_virtual_roles.push(SystemRole::Banned);
+            } else {
+                if is_member {
+                    applied_virtual_roles.push(SystemRole::Member);
+                } else {
+                    applied_virtual_roles.push(SystemRole::Guest);
+                }
+                if is_page_author {
+                    applied_virtual_roles.push(SystemRole::PageAuthor);
+                }
+            }
+        } else {
             applied_virtual_roles.push(SystemRole::Anonymous);
-            applied_virtual_roles.push(SystemRole::Guest);
-        } else if !is_member {
             applied_virtual_roles.push(SystemRole::Guest);
         }
         applied_virtual_roles.push(SystemRole::Everyone);

--- a/deepwell/src/services/view/service.rs
+++ b/deepwell/src/services/view/service.rs
@@ -288,6 +288,9 @@ impl ViewService {
                         )
                         .await
                         .or_raise(make_error)?,
+
+                        // TODO: This will need to change when IP bans are implemented.
+                        // For now, if user is not logged in, consider them not banned.
                         None => false,
                     };
 

--- a/deepwell/src/services/view/service.rs
+++ b/deepwell/src/services/view/service.rs
@@ -35,7 +35,12 @@ use crate::models::page_revision::Model as PageRevisionModel;
 use crate::models::site::Model as SiteModel;
 use crate::services::blueprint::{BlueprintPageType, GetBlueprintPageOutput};
 use crate::services::page_revision::RerenderType;
-use crate::services::relation::{GetPageAttributions, PageAttribution, RelationService};
+use crate::services::permission::{
+    CheckPermissionContext, PermissionInput, PermissionService,
+};
+use crate::services::relation::{
+    GetPageAttributions, GetSiteBan, PageAttribution, RelationService,
+};
 use crate::services::render::RenderOutput;
 use crate::services::settings::{NavigationPageHtml, SettingsService};
 use crate::services::view::ViewType;
@@ -43,7 +48,7 @@ use crate::services::{
     BlueprintPageService, CategoryService, DomainService, PageRevisionService,
     PageService, SessionService, SiteService, TextService, UserService,
 };
-use crate::types::{PageId, RerenderDepth};
+use crate::types::{Action, PageId, RerenderDepth, Resource};
 use crate::utils::{parse_locales, split_category};
 use ftml::prelude::*;
 use ftml::render::html::HtmlOutput;
@@ -109,6 +114,9 @@ impl ViewService {
 
         // Get page, revision, and text fields
         let (category_slug, page_only_slug) = split_category(page_full_slug);
+        let category_id = Self::get_category_id(ctx, site_id, category_slug)
+            .await
+            .or_raise(make_error)?;
         let page_info = PageInfo {
             page: cow!(page_only_slug),
             category: cow_opt!(category_slug),
@@ -173,32 +181,39 @@ impl ViewService {
                         .or_raise(make_error)?;
 
                 // Check user access to page
-                let user_permissions = match user_session {
-                    Some(ref session) => session.user_permissions,
-                    None => {
-                        debug!("No user for session, getting guest permission scheme");
-
-                        // TODO get permissions from service
-                        UserPermissions
-                    }
-                };
+                let [user_can_access_page, user_can_edit_page] =
+                    PermissionService::batch_check_user_can(
+                        ctx,
+                        &CheckPermissionContext {
+                            user_id: user_session.as_ref().map(|s| s.user.user_id),
+                            site_id,
+                            page_reference: None,
+                        },
+                        [
+                            PermissionInput {
+                                resource_type: Resource::Page,
+                                resource_category: category_id.map(Reference::Id),
+                                action: Action::View,
+                            },
+                            PermissionInput {
+                                resource_type: Resource::Page,
+                                resource_category: category_id.map(Reference::Id),
+                                action: Action::Edit,
+                            },
+                        ],
+                    )
+                    .await
+                    .or_raise(make_error)?;
 
                 // Determine whether to return the actual page contents,
                 // or the "private page" data (_public).
                 //
                 // This returns false if the user is banned *and* the site
                 // disallows banned viewing.
-                if Self::can_access_page(ctx, user_permissions)
-                    .await
-                    .or_raise(make_error)?
-                {
+                if user_can_access_page {
                     debug!("User has page access, return text data");
 
-                    if options.rerender
-                        && Self::can_edit_page(ctx, user_permissions)
-                            .await
-                            .or_raise(make_error)?
-                    {
+                    if options.rerender && user_can_edit_page {
                         let depth = RerenderDepth::default();
                         info!(
                             "Re-rendering revision: site ID {} page ID {} revision ID {} (depth {})",
@@ -263,7 +278,20 @@ impl ViewService {
                 } else {
                     warn!("User doesn't have page access, returning permission page");
 
-                    let (page_status, page_type) = if user_permissions.is_banned() {
+                    let user_is_banned = match user_session {
+                        Some(ref session) => RelationService::site_ban_exists(
+                            ctx,
+                            GetSiteBan {
+                                site_id,
+                                user_id: session.user.user_id,
+                            },
+                        )
+                        .await
+                        .or_raise(make_error)?,
+                        None => false,
+                    };
+
+                    let (page_status, page_type) = if user_is_banned {
                         (PageStatus::Banned, BlueprintPageType::Banned)
                     } else {
                         (PageStatus::Private, BlueprintPageType::Private)
@@ -340,10 +368,6 @@ impl ViewService {
                         },
                     ..
                 } = render_output;
-
-                let category_id = Self::get_category_id(ctx, site_id, category_slug)
-                    .await
-                    .or_raise(make_error)?;
 
                 let NavigationPageHtml {
                     compiled_top_bar_html,
@@ -544,8 +568,8 @@ impl ViewService {
         } = render_output;
 
         // Check user access to site settings
-        let user_permissions = match viewer.user_session {
-            Some(ref session) => session.user_permissions,
+        let user_id = match viewer.user_session {
+            Some(ref session) => Some(session.user.user_id),
             None => {
                 debug!("No user for session, disallow admin access");
                 return Ok(GetAdminViewOutput::AdminPermissions {
@@ -555,11 +579,24 @@ impl ViewService {
             }
         };
 
+        let user_can_access_admin = PermissionService::check_user_can(
+            ctx,
+            &CheckPermissionContext {
+                user_id,
+                site_id,
+                page_reference: None,
+            },
+            PermissionInput {
+                resource_type: Resource::Site,
+                resource_category: None,
+                action: Action::Edit,
+            },
+        )
+        .await
+        .or_raise(make_error)?;
+
         // Determine whether to return the actual admin panel content
-        let output = if Self::can_access_admin(ctx, user_permissions)
-            .await
-            .or_raise(make_error)?
-        {
+        let output = if user_can_access_admin {
             debug!("User has admin access, return data");
             GetAdminViewOutput::SiteFound { viewer }
         } else {
@@ -638,11 +675,7 @@ impl ViewService {
                     debug_assert!(user_locales.is_empty());
                 }
 
-                Some(UserSession {
-                    session,
-                    user,
-                    user_permissions: UserPermissions, // TODO add user permissions, get scheme for user and site
-                })
+                Some(UserSession { session, user })
             }
         };
 
@@ -672,36 +705,6 @@ impl ViewService {
             license_url,
             user_session,
         })
-    }
-
-    async fn can_access_page(
-        _ctx: &ServiceContext<'_>,
-        permissions: UserPermissions,
-    ) -> Result<bool> {
-        info!("Checking page access: {permissions:?}");
-        debug!("TODO: stub");
-        // TODO perform permission checks
-        Ok(true)
-    }
-
-    async fn can_edit_page(
-        _ctx: &ServiceContext<'_>,
-        permissions: UserPermissions,
-    ) -> Result<bool> {
-        info!("Checking page access: {permissions:?}");
-        debug!("TODO: stub");
-        // TODO perform permission checks
-        Ok(true)
-    }
-
-    async fn can_access_admin(
-        _ctx: &ServiceContext<'_>,
-        permissions: UserPermissions,
-    ) -> Result<bool> {
-        info!("Checking admin access: {permissions:?}");
-        debug!("TODO: stub");
-        // TODO perform permission checks
-        Ok(true)
     }
 
     fn should_redirect_page(slug: &str) -> Option<String> {

--- a/deepwell/src/services/view/structs.rs
+++ b/deepwell/src/services/view/structs.rs
@@ -30,17 +30,6 @@ use crate::services::relation::PageAttribution;
 // NOTE: Any changes to the output structures here, including the variant names,
 //       MUST be reflected in framerail!
 
-// TODO replace with actual user permissions type
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
-pub struct UserPermissions;
-
-impl UserPermissions {
-    pub fn is_banned(self) -> bool {
-        // TODO value from struct
-        false
-    }
-}
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct GetPageView {
     pub site_id: i64,
@@ -163,7 +152,6 @@ pub struct Viewer {
 pub struct UserSession {
     pub session: SessionModel,
     pub user: UserModel,
-    pub user_permissions: UserPermissions,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]

--- a/deepwell/src/types/enums/permission.rs
+++ b/deepwell/src/types/enums/permission.rs
@@ -40,6 +40,7 @@ use strum_macros::{Display, EnumString};
 pub enum Resource {
     Page,
     Role,
+    Site,
 }
 
 #[derive(

--- a/deepwell/tests/common/error.rs
+++ b/deepwell/tests/common/error.rs
@@ -25,6 +25,7 @@
 use deepwell::error::prelude::*;
 use exn::{Exn, Frame};
 
+#[allow(dead_code)] // TEMP
 /// Extract the deepwell error from the `Exn<Error>` which matches a condition.
 ///
 /// This walks the error tree until it finds the first `Error` type which

--- a/deepwell/tests/common/mod.rs
+++ b/deepwell/tests/common/mod.rs
@@ -32,6 +32,7 @@ mod error;
 mod params;
 mod runner;
 
+#[allow(unused_imports)]
 pub use self::error::extract_error;
 pub use self::params::*;
 pub use self::runner::TestRunner;

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -1,0 +1,375 @@
+/*
+ * tests/permission.rs
+ *
+ * DEEPWELL - Wikijump API provider and database manager
+ * Copyright (C) 2019-2026 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#[macro_use]
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use self::common::TestRunner;
+use deepwell::constants::SYSTEM_USER_ID;
+use deepwell::license::License;
+use deepwell::services::ServiceContext;
+use deepwell::services::category::CategoryService;
+use deepwell::services::permission::{
+    CheckPermissionContext, PermissionCache, PermissionInput, PermissionService,
+};
+use deepwell::services::role::{CreateRoleInput, GrantUserRoleInput, RoleService};
+use deepwell::services::site::{CreateSite, SiteService};
+use deepwell::services::user::{CreateUser, UserService};
+use deepwell::types::{Action, Reference, Resource, UserType};
+use serde_json::json;
+
+static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+const TEST_CATEGORY_NAME: &str = "test-category";
+
+fn next_n() -> u64 {
+    FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+struct PermissionFixture {
+    site_id: i64,
+    // A page category to use for testing category-scoped permissions
+    category_id: i64,
+    user_a: i64,
+    user_b: i64,
+    user_c: i64,
+}
+
+impl PermissionFixture {
+    async fn setup(runner: &TestRunner) -> Self {
+        let ctx = runner.context();
+        let n = next_n();
+
+        let site = SiteService::create(
+            ctx,
+            CreateSite {
+                slug: format!("perm-test-{n}"),
+                name: format!("Permission test site {n}"),
+                tagline: String::new(),
+                description: format!("Permission test site {n}"),
+                default_page: None,
+                layout: None,
+                license: License::CcBySa40,
+                locale: String::from("en"),
+                ip_address: common::IP_ADDRESS,
+            },
+        )
+        .await
+        .expect("Failed to create test site");
+        let site_id = site.site_id;
+
+        // Page category for scoped permission tests
+        let category = CategoryService::get_or_create(ctx, site_id, TEST_CATEGORY_NAME)
+            .await
+            .expect("Failed to create page category");
+        let category_id = category.category_id;
+
+        // RoleA: page:view + page:edit, both unscoped
+        let role_a = create_role(ctx, site_id, "RoleA").await;
+        add_perm_to_role(ctx, site_id, role_a, Resource::Page, None, Action::View).await;
+        add_perm_to_role(ctx, site_id, role_a, Resource::Page, None, Action::Edit).await;
+
+        // RoleB: page:edit scoped to test-category only
+        let role_b = create_role(ctx, site_id, "RoleB").await;
+        add_perm_to_role(
+            ctx,
+            site_id,
+            role_b,
+            Resource::Page,
+            Some(category_id),
+            Action::Edit,
+        )
+        .await;
+
+        let user_a = create_user(ctx, n, "a").await;
+        let user_b = create_user(ctx, n, "b").await;
+        let user_c = create_user(ctx, n, "c").await;
+
+        grant_role(ctx, site_id, user_a, role_a).await;
+        grant_role(ctx, site_id, user_b, role_b).await;
+        // user_c doesn't have any roles
+
+        PermissionCache::build_permission_cache(ctx, site_id)
+            .await
+            .expect("Failed to build permission cache");
+
+        PermissionFixture {
+            site_id,
+            category_id,
+            user_a,
+            user_b,
+            user_c,
+        }
+    }
+}
+
+// Test helpers
+
+async fn create_role(ctx: &ServiceContext<'_>, site_id: i64, name: &str) -> i64 {
+    RoleService::create(
+        ctx,
+        CreateRoleInput {
+            site_id,
+            name: name.to_owned(),
+            description: None,
+            is_virtual: false,
+            level: 1,
+        },
+        common::IP_ADDRESS,
+    )
+    .await
+    .expect("Failed to create role")
+    .role_id
+}
+
+async fn add_perm_to_role(
+    ctx: &ServiceContext<'_>,
+    site_id: i64,
+    role_id: i64,
+    resource: Resource,
+    category_id: Option<i64>,
+    action: Action,
+) {
+    PermissionService::add_permission_to_role(
+        ctx,
+        site_id,
+        role_id,
+        PermissionInput {
+            resource_type: resource,
+            resource_category: category_id.map(Reference::Id),
+            action,
+        },
+    )
+    .await
+    .expect("Failed to add permission to role");
+}
+
+async fn grant_role(ctx: &ServiceContext<'_>, site_id: i64, user_id: i64, role_id: i64) {
+    RoleService::grant_role_to_user(
+        ctx,
+        site_id,
+        GrantUserRoleInput {
+            user_id,
+            role_id,
+            assigning_user_id: SYSTEM_USER_ID,
+            expires_at: None,
+        },
+        common::IP_ADDRESS,
+    )
+    .await
+    .expect("Failed to grant role to user");
+}
+
+async fn create_user(ctx: &ServiceContext<'_>, fixture_n: u64, label: &str) -> i64 {
+    UserService::create(
+        ctx,
+        CreateUser {
+            user_type: UserType::Regular,
+            name: format!("Perm Test {fixture_n} {label}"),
+            email: format!("perm-{fixture_n}-{label}@email.com"),
+            locales: vec!["en".to_string()],
+            password: String::from("password"),
+            bypass_filter: true,
+            bypass_email_verification: true,
+            override_user_id: None,
+            ip_address: common::IP_ADDRESS,
+        },
+    )
+    .await
+    .expect("Failed to create test user")
+    .user_id
+}
+
+async fn check(
+    runner: &TestRunner,
+    user_id: Option<i64>,
+    site_id: i64,
+    resource: Resource,
+    category_id: Option<i64>,
+    action: Action,
+) -> bool {
+    PermissionService::check_user_can(
+        runner.context(),
+        &CheckPermissionContext {
+            user_id,
+            site_id,
+            page_reference: None,
+        },
+        PermissionInput {
+            resource_type: resource,
+            resource_category: category_id.map(Reference::Id),
+            action,
+        },
+    )
+    .await
+    .expect("Permission check returned an error")
+}
+
+#[tokio::test]
+async fn check_user_can() {
+    let runner = TestRunner::setup().await;
+    let f = PermissionFixture::setup(&runner).await;
+
+    let a = Some(f.user_a);
+    let b = Some(f.user_b);
+    let c = Some(f.user_c);
+    let cat = Some(f.category_id);
+
+    // Case: User with a role that grants the permission can exercise it
+
+    // RoleA grants page:view and page:edit unscoped
+    assert!(
+        check(&runner, a, f.site_id, Resource::Page, None, Action::View).await,
+        "user_a should pass page:view check"
+    );
+    assert!(
+        check(&runner, a, f.site_id, Resource::Page, None, Action::Edit).await,
+        "user_a should pass page:edit check"
+    );
+
+    // Case: User with no roles that grant a permission cannot exercise it
+
+    // user_c has no roles at all
+    assert!(
+        !check(&runner, c, f.site_id, Resource::Page, None, Action::View).await,
+        "user_c should fail page:view check"
+    );
+    assert!(
+        !check(&runner, c, f.site_id, Resource::Page, None, Action::Edit).await,
+        "user_c should fail page:edit check"
+    );
+
+    // user_b no view permission
+    assert!(
+        !check(&runner, b, f.site_id, Resource::Page, None, Action::View).await,
+        "user_b should fail page:view check"
+    );
+
+    // Case: Permissions scoped to a category only apply within that category
+
+    // user_b has page:edit permission scoped to the test category
+    assert!(
+        check(&runner, b, f.site_id, Resource::Page, cat, Action::Edit).await,
+        "user_b: should pass page:edit check in test-category"
+    );
+    // unscoped edit should fail
+    assert!(
+        !check(&runner, b, f.site_id, Resource::Page, None, Action::Edit).await,
+        "user_b: should fail page:edit without category"
+    );
+    // edit in other category should fail
+    let other_cat = Some(f.category_id + 9999);
+    assert!(
+        !check(
+            &runner,
+            b,
+            f.site_id,
+            Resource::Page,
+            other_cat,
+            Action::Edit
+        )
+        .await,
+        "user_b: should fail page:edit in other category"
+    );
+
+    // Since test category has scoped edit permission, user_a cannot edit it with _default edit permission
+    assert!(
+        !check(&runner, a, f.site_id, Resource::Page, cat, Action::Edit).await,
+        "user_a: should fail page:edit check in test-category"
+    );
+}
+
+#[tokio::test]
+async fn check_category_resolution() {
+    let runner = TestRunner::setup().await;
+    let f = PermissionFixture::setup(&runner).await;
+
+    // Permission check should be able to resolve category name to ID
+    assert!(
+        PermissionService::check_user_can(
+            runner.context(),
+            &CheckPermissionContext {
+                user_id: Some(f.user_b),
+                site_id: f.site_id,
+                page_reference: None
+            },
+            PermissionInput {
+                resource_type: Resource::Page,
+                resource_category: Some(Reference::from(TEST_CATEGORY_NAME)),
+                action: Action::Edit,
+            },
+        )
+        .await
+        .expect("Permission check returned an error"),
+        "user_b should have page:edit permission for test-category"
+    )
+}
+
+#[tokio::test]
+async fn check_permission_endpoint() {
+    let runner = TestRunner::setup().await;
+    let f = PermissionFixture::setup(&runner).await;
+
+    let page = run_endpoint!(
+        runner,
+        page_create,
+        json!({
+            "site_id": f.site_id,
+            "wikitext": "Test",
+            "title": "Test Page",
+            "alt_title": null,
+            "slug": "test-category:test-page",
+            "layout": null,
+            "revision_comments": "",
+            "user_id": SYSTEM_USER_ID,
+            "ip_address": common::IP_ADDRESS,
+        }),
+    );
+
+    // Check permissions for user_b via the endpoint, should allow
+    assert!(
+        run_endpoint!(
+            runner,
+            page_edit_permission,
+            json!({
+                "user_id": f.user_b,
+                "site_id": f.site_id,
+                "page": page.page_id,
+            }),
+        )
+        .can_edit,
+        "user_b should have edit permission for page in test-category"
+    );
+
+    // Check permissions for user_a via the endpoint, should deny due to category-scoped permission
+    assert!(
+        !run_endpoint!(
+            runner,
+            page_edit_permission,
+            json!({
+                "user_id": f.user_a,
+                "site_id": f.site_id,
+                "page": page.page_id,
+            }),
+        )
+        .can_edit,
+        "user_a should NOT have edit permission for page in test-category"
+    );
+}

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -222,6 +222,30 @@ async fn check(
     .expect("Permission check returned an error")
 }
 
+async fn batch_check<const N: usize>(
+    runner: &TestRunner,
+    user_id: Option<i64>,
+    site_id: i64,
+    perms: [(Resource, Option<i64>, Action); N],
+) -> [bool; N] {
+    let inputs = perms.map(|(resource, category_id, action)| PermissionInput {
+        resource_type: resource,
+        resource_category: category_id.map(Reference::Id),
+        action,
+    });
+    PermissionService::batch_check_user_can(
+        runner.context(),
+        &CheckPermissionContext {
+            user_id,
+            site_id,
+            page_reference: None,
+        },
+        inputs,
+    )
+    .await
+    .expect("Batch permission check returned an error")
+}
+
 #[tokio::test]
 async fn check_user_can() {
     let runner = TestRunner::setup().await;
@@ -293,6 +317,87 @@ async fn check_user_can() {
     assert!(
         !check(&runner, a, f.site_id, Resource::Page, cat, Action::Edit).await,
         "user_a: should fail page:edit check in test-category"
+    );
+}
+
+#[tokio::test]
+async fn batch_check_user_can() {
+    let runner = TestRunner::setup().await;
+    let f = PermissionFixture::setup(&runner).await;
+
+    let a = Some(f.user_a);
+    let b = Some(f.user_b);
+    let c = Some(f.user_c);
+    let cat = Some(f.category_id);
+
+    // Case: user_a has both view and edit unscoped
+    let [can_view, can_edit] = batch_check(
+        &runner,
+        a,
+        f.site_id,
+        [
+            (Resource::Page, None, Action::View),
+            (Resource::Page, None, Action::Edit),
+        ],
+    )
+    .await;
+    assert!(can_view, "user_a: batch should pass page:view");
+    assert!(can_edit, "user_a: batch should pass page:edit");
+
+    // Case: user_b has scoped edit but no view
+    let [can_view, can_edit] = batch_check(
+        &runner,
+        b,
+        f.site_id,
+        [
+            (Resource::Page, cat, Action::View),
+            (Resource::Page, cat, Action::Edit),
+        ],
+    )
+    .await;
+    assert!(
+        !can_view,
+        "user_b: batch should fail page:view in test-category"
+    );
+    assert!(
+        can_edit,
+        "user_b: batch should pass page:edit in test-category"
+    );
+
+    // Case: User with no roles — all denied
+    let [can_view, can_edit] = batch_check(
+        &runner,
+        c,
+        f.site_id,
+        [
+            (Resource::Page, None, Action::View),
+            (Resource::Page, None, Action::Edit),
+        ],
+    )
+    .await;
+    assert!(!can_view, "user_c: batch should fail page:view");
+    assert!(!can_edit, "user_c: batch should fail page:edit");
+
+    // Case: Batch and single check should return the same results
+    let [batch_view, batch_edit] = batch_check(
+        &runner,
+        a,
+        f.site_id,
+        [
+            (Resource::Page, None, Action::View),
+            (Resource::Page, None, Action::Edit),
+        ],
+    )
+    .await;
+    assert_eq!(
+        batch_view,
+        check(&runner, a, f.site_id, Resource::Page, None, Action::View).await,
+        "batch and single check differ on page:view"
+    );
+    assert_eq!(
+        batch_edit,
+        check(&runner, a, f.site_id, Resource::Page, None, Action::Edit).await,
+        "batch and single check differ on page:edit"
     );
 }
 

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -22,6 +22,7 @@
 mod common;
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use str_macro::str;
 
 use self::common::TestRunner;
 use deepwell::constants::SYSTEM_USER_ID;
@@ -39,6 +40,7 @@ use serde_json::json;
 
 static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
 const TEST_CATEGORY_NAME: &str = "test-category";
+const OTHER_CATEGORY_NAME: &str = "other-category";
 
 fn next_n() -> u64 {
     FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed)
@@ -47,6 +49,7 @@ struct PermissionFixture {
     site_id: i64,
     // A page category to use for testing category-scoped permissions
     category_id: i64,
+    other_category_id: i64,
     user_a: i64,
     user_b: i64,
     user_c: i64,
@@ -76,10 +79,18 @@ impl PermissionFixture {
         let site_id = site.site_id;
 
         // Page category for scoped permission tests
-        let category = CategoryService::get_or_create(ctx, site_id, TEST_CATEGORY_NAME)
-            .await
-            .expect("Failed to create page category");
-        let category_id = category.category_id;
+        let category_id =
+            CategoryService::get_or_create(ctx, site_id, TEST_CATEGORY_NAME)
+                .await
+                .expect("Failed to create page category")
+                .category_id;
+
+        // Another category to test that scoped permissions don't apply to other categories
+        let other_category_id =
+            CategoryService::get_or_create(ctx, site_id, OTHER_CATEGORY_NAME)
+                .await
+                .expect("Failed to create other page category")
+                .category_id;
 
         // RoleA: page:view + page:edit, both unscoped
         let role_a = create_role(ctx, site_id, "RoleA").await;
@@ -113,6 +124,7 @@ impl PermissionFixture {
         PermissionFixture {
             site_id,
             category_id,
+            other_category_id,
             user_a,
             user_b,
             user_c,
@@ -184,7 +196,7 @@ async fn create_user(ctx: &ServiceContext<'_>, fixture_n: u64, label: &str) -> i
             user_type: UserType::Regular,
             name: format!("Perm Test {fixture_n} {label}"),
             email: format!("perm-{fixture_n}-{label}@email.com"),
-            locales: vec!["en".to_string()],
+            locales: vec![str!("en")],
             password: String::from("password"),
             bypass_filter: true,
             bypass_email_verification: true,
@@ -197,6 +209,7 @@ async fn create_user(ctx: &ServiceContext<'_>, fixture_n: u64, label: &str) -> i
     .user_id
 }
 
+#[must_use]
 async fn check(
     runner: &TestRunner,
     user_id: Option<i64>,
@@ -222,6 +235,7 @@ async fn check(
     .expect("Permission check returned an error")
 }
 
+#[must_use]
 async fn batch_check<const N: usize>(
     runner: &TestRunner,
     user_id: Option<i64>,
@@ -299,7 +313,7 @@ async fn check_user_can() {
         "user_b: should fail page:edit without category"
     );
     // edit in other category should fail
-    let other_cat = Some(f.category_id + 9999);
+    let other_cat = Some(f.other_category_id);
     assert!(
         !check(
             &runner,
@@ -463,6 +477,21 @@ async fn check_permission_endpoint() {
         "user_b should have edit permission for page in test-category"
     );
 
+    // Same test but with slug instead of page_id, should still work
+    assert!(
+        run_endpoint!(
+            runner,
+            page_edit_permission,
+            json!({
+                "user_id": f.user_b,
+                "site_id": f.site_id,
+                "page": page.slug,
+            }),
+        )
+        .can_edit,
+        "user_b should have edit permission for page in test-category"
+    );
+
     // Check permissions for user_a via the endpoint, should deny due to category-scoped permission
     assert!(
         !run_endpoint!(
@@ -472,6 +501,21 @@ async fn check_permission_endpoint() {
                 "user_id": f.user_a,
                 "site_id": f.site_id,
                 "page": page.page_id,
+            }),
+        )
+        .can_edit,
+        "user_a should NOT have edit permission for page in test-category"
+    );
+
+    // Same test but with slug instead of page_id, should still work
+    assert!(
+        !run_endpoint!(
+            runner,
+            page_edit_permission,
+            json!({
+                "user_id": f.user_a,
+                "site_id": f.site_id,
+                "page": page.slug,
             }),
         )
         .can_edit,

--- a/framerail/src/lib/server/deepwell/views.ts
+++ b/framerail/src/lib/server/deepwell/views.ts
@@ -84,11 +84,7 @@ interface AdminViewAdminPermissions {
 interface UserSession {
   session: SessionModel
   user: UserModel
-  user_permissions: UserPermissions
 }
-// Not implemented yet
-// See also deepwell src/services/view/structs.rs
-type UserPermissions = null
 
 export async function adminView(
   siteId: number,


### PR DESCRIPTION
Cleaned up the existing UserPermissions stubs to use PermissionService instead. Additionally, implemented a batch permission check to query multiple permissions at once.

Closes [WJ-1367](https://scuttle.atlassian.net/browse/WJ-1366)

[WJ-1367]: https://scuttle.atlassian.net/browse/WJ-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ