### PR TITLE
Remove async_trait dependency

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -972,7 +972,6 @@ dependencies = [
  "arraystring",
  "arrayvec",
  "askama",
- "async-trait",
  "built",
  "bytes",
  "cfg-if",

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -19,7 +19,6 @@ watch = ["notify"]
 argon2 = "0.5"
 arraystring = "0.3"
 askama = "0.15"
-async-trait = "0.1"  # remove when trait async fn enhancements land
 bytes = "1"
 cfg-if = "1"
 clap = "4"

--- a/deepwell/src/services/permission/resolvers.rs
+++ b/deepwell/src/services/permission/resolvers.rs
@@ -21,6 +21,7 @@
 use crate::error::Result;
 use crate::services::ServiceContext;
 use crate::types::{Reference, Resource};
+use std::future::Future;
 
 /// Trait for resolving category references (ID or slug) to category IDs.
 ///
@@ -29,20 +30,18 @@ use crate::types::{Reference, Resource};
 ///
 /// For `Reference::Id`, implementations can return the ID directly without a DB lookup.
 /// For `Reference::Slug`, implementations should query the database to resolve the slug.
-#[async_trait::async_trait]
 pub trait CategoryResolver: Send + Sync {
     /// Resolve a category reference to its numeric ID.
-    async fn resolve(
+    fn resolve(
         ctx: &ServiceContext<'_>,
         site_id: i64,
         reference: Reference<'_>,
-    ) -> Result<Option<i64>>;
+    ) -> impl Future<Output = Result<Option<i64>>> + Send;
 }
 
 #[derive(Debug)]
 pub struct PageCategoryResolver;
 
-#[async_trait::async_trait]
 impl CategoryResolver for PageCategoryResolver {
     async fn resolve(
         ctx: &ServiceContext<'_>,

--- a/deepwell/src/services/score/impls/mean.rs
+++ b/deepwell/src/services/score/impls/mean.rs
@@ -68,12 +68,8 @@ impl Scorer for MeanScorer {
             .or_raise(|| make_error("mean"))?
             .expect("No results in aggregate query");
 
-        let score = if count == 0 {
-            0.0
-        } else {
-            (sum / count) as f64
-        };
-
-        Ok(ScoreValue::Float(score))
+        let sum = sum as f64;
+        let count = count as f64;
+        Ok(ScoreValue::Float(sum / count))
     }
 }

--- a/deepwell/src/services/score/impls/mean.rs
+++ b/deepwell/src/services/score/impls/mean.rs
@@ -23,7 +23,6 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct MeanScorer;
 
-#[async_trait]
 impl Scorer for MeanScorer {
     #[inline]
     fn score_type(&self) -> ScoreType {

--- a/deepwell/src/services/score/impls/null.rs
+++ b/deepwell/src/services/score/impls/null.rs
@@ -23,7 +23,6 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct NullScorer;
 
-#[async_trait]
 impl Scorer for NullScorer {
     #[inline]
     fn score_type(&self) -> ScoreType {

--- a/deepwell/src/services/score/impls/percent.rs
+++ b/deepwell/src/services/score/impls/percent.rs
@@ -24,7 +24,6 @@ use crate::services::ScoreService;
 #[derive(Debug)]
 pub struct PercentScorer;
 
-#[async_trait]
 impl Scorer for PercentScorer {
     #[inline]
     fn score_type(&self) -> ScoreType {

--- a/deepwell/src/services/score/impls/sum.rs
+++ b/deepwell/src/services/score/impls/sum.rs
@@ -23,7 +23,6 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct SumScorer;
 
-#[async_trait]
 impl Scorer for SumScorer {
     #[inline]
     fn score_type(&self) -> ScoreType {

--- a/deepwell/src/services/score/impls/test.rs
+++ b/deepwell/src/services/score/impls/test.rs
@@ -24,7 +24,6 @@ use rand::{Rng, thread_rng};
 #[derive(Debug)]
 pub struct TestScorer;
 
-#[async_trait]
 impl Scorer for TestScorer {
     #[inline]
     fn score_type(&self) -> ScoreType {

--- a/deepwell/src/services/score/mod.rs
+++ b/deepwell/src/services/score/mod.rs
@@ -24,9 +24,9 @@ mod prelude {
     pub use super::Scorer;
     pub use super::structs::*;
     pub use crate::models::page_vote::{self, Entity as PageVote};
-    pub use async_trait::async_trait;
     pub use ftml::data::ScoreValue;
     pub use sea_orm::{DatabaseTransaction, FromQueryResult};
+    pub use std::future::Future;
 }
 
 mod impls;

--- a/deepwell/src/services/score/scorer.rs
+++ b/deepwell/src/services/score/scorer.rs
@@ -20,7 +20,6 @@
 
 use super::prelude::*;
 
-#[async_trait]
 pub trait Scorer {
     /// What kind of score this scorer evaluates.
     ///
@@ -47,9 +46,9 @@ pub trait Scorer {
     /// In order to ensure the query is formed correctly, the `Condition` for
     /// querying active votes for a page is passed rather than the page ID.
     /// For reference: `page_id = $1 AND disabled_at IS NULL AND deleted_at IS NULL`.
-    async fn score(
+    fn score(
         &self,
         txn: &DatabaseTransaction,
         condition: Condition,
-    ) -> Result<ScoreValue>;
+    ) -> impl Future<Output = Result<ScoreValue>> + Send;
 }


### PR DESCRIPTION
This is no longer required as of Rust 1.75.0, so we can drop this dependency.