### PR TITLE
[chore] Upgrade rand and argon2 in deepwell

### DIFF
--- a/deepwell/Cargo.lock
+++ b/deepwell/Cargo.lock
@@ -144,13 +144,13 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "password-hash",
 ]
 
@@ -465,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -632,6 +632,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "color-backtrace"
@@ -883,6 +889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "cuid-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,7 +1011,7 @@ dependencies = [
  "notify",
  "paste",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.9.2",
  "redis",
  "ref-map 0.2.0",
  "regex",
@@ -1097,6 +1112,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -3006,13 +3022,12 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "getrandom 0.4.2",
+ "phc",
 ]
 
 [[package]]
@@ -3098,6 +3113,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.2",
 ]
 
 [[package]]

--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 watch = ["notify"]
 
 [dependencies]
-argon2 = "0.5"
+argon2 = "0.6.0-rc.8"
 arraystring = "0.3"
 askama = "0.15"
 bytes = "1"
@@ -40,7 +40,7 @@ jsonrpsee = { version = "0.24", features = ["macros", "server"] }
 log = "0.4"
 notify = { version = "8", optional = true }
 paste = "1"
-rand = "0.8"
+rand = "0.9"
 redis = { version = "1", features = ["aio", "connection-manager", "tokio-comp", "tokio-rustls-comp"] }
 ref-map = "0.2"
 regex = "1"

--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -39,8 +39,7 @@ use crate::utils::assert_is_csprng;
 use bytes::Bytes;
 use cuid2::cuid;
 use futures::TryStreamExt;
-use rand::distributions::{Alphanumeric, DistString};
-use rand::thread_rng;
+use rand::distr::{Alphanumeric, SampleString};
 use s3::request::request_trait::ResponseData;
 use s3::serde_types::HeadObjectResult;
 use sea_orm::{
@@ -133,7 +132,7 @@ impl BlobService {
             let mut path = format!("{PRESIGN_DIRECTORY}/");
 
             {
-                let mut rng = thread_rng();
+                let mut rng = rand::rng();
                 assert_is_csprng(&rng);
                 Alphanumeric.append_string(
                     &mut rng,

--- a/deepwell/src/services/mfa/structs.rs
+++ b/deepwell/src/services/mfa/structs.rs
@@ -22,13 +22,13 @@ use super::prelude::*;
 use crate::services::PasswordService;
 use crate::utils::assert_is_csprng;
 use data_encoding::BASE32_NOPAD;
-use rand::distributions::{Alphanumeric, DistString};
-use rand::{Rng, thread_rng};
+use rand::Rng;
+use rand::distr::{Alphanumeric, SampleString};
 use std::iter;
 use std::net::IpAddr;
 
 pub fn generate_totp_secret() -> String {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
     assert_is_csprng(&rng);
 
     // TOTP secret is any sufficiently-long random base32 string
@@ -57,7 +57,7 @@ impl RecoveryCodes {
             )
         };
 
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         assert_is_csprng(&rng);
 
         // Recovery codes are any randomly-generated codes which the application

--- a/deepwell/src/services/password.rs
+++ b/deepwell/src/services/password.rs
@@ -20,10 +20,7 @@
 
 use super::prelude::*;
 use crate::utils::assert_is_csprng;
-use argon2::{
-    Argon2, PasswordHash, PasswordHasher, PasswordVerifier, password_hash::SaltString,
-};
-use rand::thread_rng;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
 use tokio::time;
 
 #[derive(Debug)]
@@ -35,15 +32,9 @@ impl PasswordService {
     /// Generates a salt securely and performs Argon-2 hashing
     /// and yields a string in PHC format.
     pub fn new_hash(password: &str) -> Result<String> {
-        // Create and verify CSPRNG
-        let mut rng = thread_rng();
-        assert_is_csprng(&rng);
-
-        // Create Argon-2 context, salt, and then hash the password
         let argon2 = Argon2::default();
-        let salt = SaltString::generate(&mut rng);
         let hash = argon2
-            .hash_password(password.as_bytes(), &salt)
+            .hash_password(password.as_bytes())
             .map_err(convert_argon_error)?
             .to_string();
 
@@ -109,13 +100,9 @@ impl PasswordService {
     }
 
     fn verify_internal(password: &str, hash: &str) -> Result<()> {
-        // Parse PHC string
-        let hash = PasswordHash::new(hash).map_err(convert_argon_error)?;
-
-        // Create Argon-2 context, then verify the password
         let argon2 = Argon2::default();
         argon2
-            .verify_password(password.as_bytes(), &hash)
+            .verify_password(password.as_bytes(), hash)
             .map_err(convert_argon_error)?;
 
         Ok(())

--- a/deepwell/src/services/score/impls/test.rs
+++ b/deepwell/src/services/score/impls/test.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use rand::{Rng, thread_rng};
+use rand::Rng;
 
 #[derive(Debug)]
 pub struct TestScorer;
@@ -37,8 +37,8 @@ impl Scorer for TestScorer {
 
     #[inline]
     async fn score(&self, _: &DatabaseTransaction, _: Condition) -> Result<ScoreValue> {
-        let mut rng = thread_rng();
-        let value = rng.gen_range(-100..100);
+        let mut rng = rand::rng();
+        let value = rng.random_range(-100..100);
         Ok(ScoreValue::Integer(value))
     }
 }

--- a/deepwell/src/services/session/service.rs
+++ b/deepwell/src/services/session/service.rs
@@ -34,8 +34,7 @@ use super::prelude::*;
 use crate::models::session::{self, Entity as Session, Model as SessionModel};
 use crate::models::user::{self, Entity as User, Model as UserModel};
 use crate::utils::assert_is_csprng;
-use rand::distributions::{Alphanumeric, DistString};
-use rand::thread_rng;
+use rand::distr::{Alphanumeric, SampleString};
 
 #[derive(Debug)]
 pub struct SessionService;
@@ -98,7 +97,7 @@ impl SessionService {
     /// Example generated token: `wj:T9iF6vfjoYYE20QzrybV2C1V4K0LchHXsNVipX8G1GZ9vSJf0rvQpJ4YC8c8MAQ3`.
     fn new_token(config: &Config) -> String {
         debug!("Generating a new session token");
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         assert_is_csprng(&rng);
 
         let mut token = Alphanumeric.sample_string(&mut rng, config.session_token_length);


### PR DESCRIPTION
Companion to #2849 

I'm using a release candidate version of `argon2` since `0.6.0` is needed for upgrading `rand` but it's not fully out yet.