### PR TITLE
Reformat rust imports by module

### DIFF
--- a/deepwell/.rustfmt.toml
+++ b/deepwell/.rustfmt.toml
@@ -5,3 +5,6 @@ edition = "2024"
 max_width = 90
 use_field_init_shorthand = true
 use_try_shorthand = true
+
+# Enable when stabilized:
+# imports_granularity = "Module"

--- a/deepwell/src/config/secrets.rs
+++ b/deepwell/src/config/secrets.rs
@@ -20,7 +20,8 @@
 
 use dotenvy::dotenv;
 use ref_map::*;
-use s3::{creds::Credentials, region::Region};
+use s3::creds::Credentials;
+use s3::region::Region;
 use std::env::VarError;
 use std::{env, process};
 

--- a/deepwell/src/endpoints/mod.rs
+++ b/deepwell/src/endpoints/mod.rs
@@ -47,12 +47,33 @@ mod prelude {
 }
 
 pub mod all {
-    pub use super::{
-        auth::*, basic_error::*, blob::*, category::*, domain::*, email::*, file::*,
-        file_revision::*, health::*, info::*, link::*, locale::*, message::*, misc::*,
-        page::*, page_attribution::*, page_revision::*, parent::*, routing::*, site::*,
-        site_member::*, text::*, text_block::*, user::*, user_bot::*, view::*, vote::*,
-    };
+    pub use super::auth::*;
+    pub use super::basic_error::*;
+    pub use super::blob::*;
+    pub use super::category::*;
+    pub use super::domain::*;
+    pub use super::email::*;
+    pub use super::file::*;
+    pub use super::file_revision::*;
+    pub use super::health::*;
+    pub use super::info::*;
+    pub use super::link::*;
+    pub use super::locale::*;
+    pub use super::message::*;
+    pub use super::misc::*;
+    pub use super::page::*;
+    pub use super::page_attribution::*;
+    pub use super::page_revision::*;
+    pub use super::parent::*;
+    pub use super::routing::*;
+    pub use super::site::*;
+    pub use super::site_member::*;
+    pub use super::text::*;
+    pub use super::text_block::*;
+    pub use super::user::*;
+    pub use super::user_bot::*;
+    pub use super::view::*;
+    pub use super::vote::*;
 }
 
 pub mod auth;

--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -42,9 +42,10 @@ use futures::TryStreamExt;
 use rand::distr::{Alphanumeric, SampleString};
 use s3::request::request_trait::ResponseData;
 use s3::serde_types::HeadObjectResult;
+use sea_orm::prelude::*;
 use sea_orm::{
     DatabaseBackend, FromQueryResult, Statement, StreamTrait, TransactionTrait,
-    UpdateResult, prelude::*,
+    UpdateResult,
 };
 use sea_query::value::ArrayType;
 use std::collections::{HashMap, HashSet};

--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -27,7 +27,8 @@ use crate::models::{file, page, site};
 use crate::services::blob::{EMPTY_BLOB_HASH, EMPTY_BLOB_MIME, FinalizeBlobUploadOutput};
 use crate::services::{BlobService, OutdateService, PageService};
 use crate::types::{Bytes, FetchDirection, RerenderDepth};
-use sea_orm::{FromQueryResult, prelude::*};
+use sea_orm::FromQueryResult;
+use sea_orm::prelude::*;
 use std::num::NonZeroI32;
 use std::sync::LazyLock;
 

--- a/deepwell/src/services/forum/service.rs
+++ b/deepwell/src/services/forum/service.rs
@@ -25,9 +25,7 @@ use crate::models::forum_category::{
     self, Entity as ForumCategory, Model as ForumCategoryModel,
 };
 use crate::models::forum_group::{self, Entity as ForumGroup, Model as ForumGroupModel};
-use crate::models::forum_post;
-use crate::models::forum_post_revision;
-use crate::models::forum_thread;
+use crate::models::{forum_post, forum_post_revision, forum_thread};
 use std::collections::BTreeMap;
 
 #[derive(Debug)]

--- a/deepwell/src/services/forum_thread/service.rs
+++ b/deepwell/src/services/forum_thread/service.rs
@@ -21,11 +21,10 @@
 #![allow(dead_code)] // TEMP
 
 use super::prelude::*;
-use crate::models::forum_post;
-use crate::models::forum_post_revision;
 use crate::models::forum_thread::{
     self, Entity as ForumThread, Model as ForumThreadModel,
 };
+use crate::models::{forum_post, forum_post_revision};
 use crate::services::ForumService;
 
 #[derive(Debug)]
@@ -340,7 +339,8 @@ impl ForumThreadService {
         }: GetForumThreads,
     ) -> Result<Vec<ForumThreadModel>> {
         use sea_orm::query::Order;
-        use sea_query::{Expr, SimpleExpr, func::Func};
+        use sea_query::func::Func;
+        use sea_query::{Expr, SimpleExpr};
 
         let txn = ctx.transaction();
 

--- a/deepwell/src/services/page_query/service.rs
+++ b/deepwell/src/services/page_query/service.rs
@@ -340,7 +340,8 @@ impl PageQueryService {
         // Add on at the query-level (ORDER BY, LIMIT)
         {
             use sea_orm::query::Order;
-            use sea_query::{SimpleExpr, func::Func};
+            use sea_query::SimpleExpr;
+            use sea_query::func::Func;
 
             let OrderBySelector {
                 property,

--- a/deepwell/src/services/render/mod.rs
+++ b/deepwell/src/services/render/mod.rs
@@ -22,15 +22,13 @@
 mod prelude {
     pub use super::super::prelude::*;
     pub use super::structs::*;
-    pub use ftml::{
-        self,
-        data::PageInfo,
-        info::VERSION as FTML_VERSION,
-        parsing::ParseError,
-        render::Render,
-        render::html::{HtmlOutput, HtmlRender},
-        settings::WikitextSettings,
-    };
+    pub use ftml::data::PageInfo;
+    pub use ftml::info::VERSION as FTML_VERSION;
+    pub use ftml::parsing::ParseError;
+    pub use ftml::render::Render;
+    pub use ftml::render::html::{HtmlOutput, HtmlRender};
+    pub use ftml::settings::WikitextSettings;
+    pub use ftml::{self};
 }
 
 mod service;

--- a/deepwell/src/services/render/service.rs
+++ b/deepwell/src/services/render/service.rs
@@ -26,7 +26,8 @@ use crate::services::text_block::{
     MIME_HTML, TextBlock, TextBlockService, mime_for_language,
 };
 use crate::types::{PageId, TextBlockType};
-use ftml::{prelude::*, tree::CodeBlock};
+use ftml::prelude::*;
+use ftml::tree::CodeBlock;
 use tokio::time::timeout;
 
 #[derive(Debug)]

--- a/deepwell/tests/common/mod.rs
+++ b/deepwell/tests/common/mod.rs
@@ -36,7 +36,6 @@ mod runner;
 pub use self::error::extract_error;
 pub use self::params::*;
 pub use self::runner::TestRunner;
-
 use std::net::{IpAddr, Ipv4Addr};
 
 #[allow(dead_code)]

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -21,9 +21,6 @@
 #[macro_use]
 mod common;
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use str_macro::str;
-
 use self::common::TestRunner;
 use deepwell::constants::SYSTEM_USER_ID;
 use deepwell::license::License;
@@ -39,6 +36,8 @@ use deepwell::services::site::{CreateSite, SiteService};
 use deepwell::services::user::{CreateUser, UserService};
 use deepwell::types::{Action, Reference, Resource, UserType};
 use serde_json::json;
+use std::sync::atomic::{AtomicU64, Ordering};
+use str_macro::str;
 
 static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
 const TEST_CATEGORY_NAME: &str = "test-category";

--- a/wws/.rustfmt.toml
+++ b/wws/.rustfmt.toml
@@ -5,3 +5,6 @@ edition = "2024"
 max_width = 90
 use_field_init_shorthand = true
 use_try_shorthand = true
+
+# Enable when stabilized:
+# imports_granularity = "Module"

--- a/wws/src/cache.rs
+++ b/wws/src/cache.rs
@@ -23,8 +23,10 @@
 //! Whenever you make changes to this module, make sure that the code is
 //! compatible with DEEPWELL's Redis code.
 
-use crate::{deepwell::FileData, error::Result};
-use redis::{AsyncCommands, aio::MultiplexedConnection};
+use crate::deepwell::FileData;
+use crate::error::Result;
+use redis::AsyncCommands;
+use redis::aio::MultiplexedConnection;
 
 macro_rules! get_connection {
     ($client:expr) => {

--- a/wws/src/config/mod.rs
+++ b/wws/src/config/mod.rs
@@ -28,7 +28,8 @@ pub use self::secrets::Secrets;
 use self::args::Arguments;
 use dotenvy::dotenv;
 use ref_map::*;
-use s3::{creds::Credentials, region::Region};
+use s3::creds::Credentials;
+use s3::region::Region;
 use std::path::PathBuf;
 use std::{env, process};
 

--- a/wws/src/config/secrets.rs
+++ b/wws/src/config/secrets.rs
@@ -18,7 +18,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use s3::{creds::Credentials, region::Region};
+use s3::creds::Credentials;
+use s3::region::Region;
 
 #[derive(Debug, Clone)]
 pub struct Secrets {

--- a/wws/src/deepwell.rs
+++ b/wws/src/deepwell.rs
@@ -19,9 +19,12 @@
  */
 
 use crate::error::{Result, TextBlockErrorReason};
-use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::rpc_params;
 use serde::Deserialize;
-use std::{num::NonZeroU16, time::Duration};
+use std::num::NonZeroU16;
+use std::time::Duration;
 
 const JSONRPC_MAX_REQUEST: u32 = 16 * 1024;
 const JSONRPC_TIMEOUT: Duration = Duration::from_millis(200);

--- a/wws/src/error/basic.rs
+++ b/wws/src/error/basic.rs
@@ -20,18 +20,14 @@
 
 //! See the `BasicErrorService` in DEEPWELL for information.
 
-use crate::{
-    deepwell::TextBlockType, error::FallbackError, language::parse_accept_language,
-    state::ServerStateInner,
-};
-use axum::{
-    body::Body,
-    http::{
-        header::{self, HeaderMap},
-        status::StatusCode,
-    },
-    response::{IntoResponse, Response},
-};
+use crate::deepwell::TextBlockType;
+use crate::error::FallbackError;
+use crate::language::parse_accept_language;
+use crate::state::ServerStateInner;
+use axum::body::Body;
+use axum::http::header::{self, HeaderMap};
+use axum::http::status::StatusCode;
+use axum::response::{IntoResponse, Response};
 use paste::paste;
 
 pub use crate::deepwell::BasicErrorHtml;

--- a/wws/src/error/fallback.rs
+++ b/wws/src/error/fallback.rs
@@ -42,10 +42,8 @@
 //! In this sense, fallback errors are "more primordial" than basic errors,
 //! since one cause is WWS failing to look up a basic error from DEEPWELL.
 
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FallbackError {

--- a/wws/src/fetch.rs
+++ b/wws/src/fetch.rs
@@ -18,13 +18,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::{
-    deepwell::FileData,
-    error::{BasicError, ResponseResult, build_basic_error_response},
-    range::ByteRange,
-    state::ServerState,
-};
-use axum::{body::Body, http::header::HeaderMap};
+use crate::deepwell::FileData;
+use crate::error::{BasicError, ResponseResult, build_basic_error_response};
+use crate::range::ByteRange;
+use crate::state::ServerState;
+use axum::body::Body;
+use axum::http::header::HeaderMap;
 use s3::request::request_trait::ResponseDataStream;
 use wikidot_normalize::normalize;
 

--- a/wws/src/handler/basic_error.rs
+++ b/wws/src/handler/basic_error.rs
@@ -22,15 +22,11 @@ use super::{
     HEADER_BASIC_ERROR, HEADER_FILENAME, HEADER_PAGE_SLUG, get_header, get_site_id,
     get_site_slug,
 };
-use crate::{
-    error::{BasicError, FallbackError, build_basic_error_response},
-    state::ServerState,
-};
-use axum::{
-    extract::{Path, State},
-    http::header::HeaderMap,
-    response::{IntoResponse, Response},
-};
+use crate::error::{BasicError, FallbackError, build_basic_error_response};
+use crate::state::ServerState;
+use axum::extract::{Path, State};
+use axum::http::header::HeaderMap;
+use axum::response::{IntoResponse, Response};
 use axum_extra::TypedHeader;
 use headers::Host;
 

--- a/wws/src/handler/file.rs
+++ b/wws/src/handler/file.rs
@@ -19,22 +19,18 @@
  */
 
 use super::get_site_id;
-use crate::{
-    attachment::content_disposition_attachment,
-    deepwell::FileData,
-    fetch::{fetch_file_info, fetch_full_body, fetch_range_bytes, fetch_range_stream},
-    range::{ByteRange, ParsedRange, evaluate_range},
-    state::ServerState,
+use crate::attachment::content_disposition_attachment;
+use crate::deepwell::FileData;
+use crate::fetch::{
+    fetch_file_info, fetch_full_body, fetch_range_bytes, fetch_range_stream,
 };
-use axum::{
-    body::Body,
-    extract::{Path, State},
-    http::{
-        Method, StatusCode,
-        header::{self, HeaderMap},
-    },
-    response::{IntoResponse, Response},
-};
+use crate::range::{ByteRange, ParsedRange, evaluate_range};
+use crate::state::ServerState;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::header::{self, HeaderMap};
+use axum::http::{Method, StatusCode};
+use axum::response::{IntoResponse, Response};
 use rand::distr::{Alphanumeric, SampleString};
 use std::fmt::Write;
 

--- a/wws/src/handler/misc.rs
+++ b/wws/src/handler/misc.rs
@@ -19,12 +19,11 @@
  */
 
 use crate::state::ServerState;
-use axum::{
-    body::Body,
-    extract::State,
-    http::{header, status::StatusCode},
-    response::Response,
-};
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::header;
+use axum::http::status::StatusCode;
+use axum::response::Response;
 
 fn text_response(body: &'static str, status: StatusCode) -> Response {
     Response::builder()

--- a/wws/src/handler/redirect.rs
+++ b/wws/src/handler/redirect.rs
@@ -19,12 +19,12 @@
  */
 
 use super::get_site_id;
-use crate::{path::get_path, state::ServerState};
-use axum::{
-    extract::{Path, State},
-    http::{Uri, header::HeaderMap},
-    response::{IntoResponse, Redirect, Response},
-};
+use crate::path::get_path;
+use crate::state::ServerState;
+use axum::extract::{Path, State};
+use axum::http::Uri;
+use axum::http::header::HeaderMap;
+use axum::response::{IntoResponse, Redirect, Response};
 
 pub async fn redirect_to_main(
     State(state): State<ServerState>,

--- a/wws/src/handler/robots.rs
+++ b/wws/src/handler/robots.rs
@@ -21,7 +21,8 @@
 //! Handling for the `robots.txt` file.
 
 use super::get_target_server;
-use axum::http::{header::HeaderMap, status::StatusCode};
+use axum::http::header::HeaderMap;
+use axum::http::status::StatusCode;
 
 // TODO
 

--- a/wws/src/handler/text_block.rs
+++ b/wws/src/handler/text_block.rs
@@ -19,23 +19,18 @@
  */
 
 use super::get_site_id;
-use crate::{
-    deepwell::{TextBlockIndex, TextBlockType},
-    error::{
-        BasicError, FallbackError, TextBlockErrorReason, build_basic_error_response,
-    },
-    state::ServerState,
+use crate::deepwell::{TextBlockIndex, TextBlockType};
+use crate::error::{
+    BasicError, FallbackError, TextBlockErrorReason, build_basic_error_response,
 };
-use axum::{
-    body::Body,
-    extract::{Path, State},
-    http::{
-        header::{self, HeaderMap},
-        status::StatusCode,
-    },
-    response::{IntoResponse, Response},
-};
-use std::{collections::HashMap, num::NonZeroU16};
+use crate::state::ServerState;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::header::{self, HeaderMap};
+use axum::http::status::StatusCode;
+use axum::response::{IntoResponse, Response};
+use std::collections::HashMap;
+use std::num::NonZeroU16;
 
 pub async fn handle_html_block(
     State(state): State<ServerState>,

--- a/wws/src/handler/well_known.rs
+++ b/wws/src/handler/well_known.rs
@@ -24,7 +24,8 @@
 //! should be implemented as a separate handler.
 
 use super::get_target_server;
-use axum::http::{header::HeaderMap, status::StatusCode};
+use axum::http::header::HeaderMap;
+use axum::http::status::StatusCode;
 
 // TODO
 

--- a/wws/src/route.rs
+++ b/wws/src/route.rs
@@ -18,16 +18,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::{handler::*, state::ServerState};
-use axum::{
-    Router,
-    http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue},
-    routing::{any, get},
-};
-use tower_http::{
-    compression::CompressionLayer, normalize_path::NormalizePathLayer,
-    set_header::SetResponseHeaderLayer, trace::TraceLayer,
-};
+use crate::handler::*;
+use crate::state::ServerState;
+use axum::Router;
+use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue};
+use axum::routing::{any, get};
+use tower_http::compression::CompressionLayer;
+use tower_http::normalize_path::NormalizePathLayer;
+use tower_http::set_header::SetResponseHeaderLayer;
+use tower_http::trace::TraceLayer;
 
 pub fn build_router(state: ServerState) -> Router {
     // NOTE: For all GET routes, axum automatically handles HEAD requests.

--- a/wws/src/state.rs
+++ b/wws/src/state.rs
@@ -18,15 +18,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::{
-    cache::Cache,
-    config::Secrets,
-    deepwell::{Deepwell, FileData, PageData},
-    error::{
-        BasicError, FallbackError, ResponseResult, Result, build_basic_error_response,
-    },
+use crate::cache::Cache;
+use crate::config::Secrets;
+use crate::deepwell::{Deepwell, FileData, PageData};
+use crate::error::{
+    BasicError, FallbackError, ResponseResult, Result, build_basic_error_response,
 };
-use axum::{http::HeaderMap, response::IntoResponse};
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
 use s3::bucket::Bucket;
 use std::sync::Arc;
 use std::time::Duration;

--- a/wws/src/trace.rs
+++ b/wws/src/trace.rs
@@ -18,9 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use tracing_subscriber::{
-    EnvFilter, fmt, layer::SubscriberExt, registry, util::SubscriberInitExt,
-};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, fmt, registry};
 
 pub fn setup_tracing() {
     registry()


### PR DESCRIPTION
Compare with #2868 

This changes the import style in deepwell and wws to be by module.

I'm not sure which style of imports is better for us to use going forward. I see reasons to use either, and I think I lean towards per-crate, but I wanted feedback on what people prefer.