### PR TITLE
Add "website" field for users

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -44,6 +44,7 @@ CREATE TABLE "user" (
     birthday DATE,
     location TEXT,
     biography TEXT,
+    website TEXT,
     user_page TEXT,
 
     -- Name uniqueness constraints
@@ -67,6 +68,7 @@ CREATE TABLE "user" (
     CHECK (gender IS NULL OR (length(gender) > 0 AND length(gender) < 100)),
     CHECK (location IS NULL OR (length(location) > 0 AND length(location) < 100)),
     CHECK (biography IS NULL OR (length(biography) > 0 AND length(biography) < 4000)),
+    CHECK (website IS NULL OR (length(website) > 0 AND length(website) < 100)),
     CHECK (user_page IS NULL OR (length(user_page) > 0 AND length(user_page) < 100)),
 
     CHECK (name_changes_left >= 0),                                 -- Value cannot be negative

--- a/deepwell/src/models/user.rs
+++ b/deepwell/src/models/user.rs
@@ -50,6 +50,8 @@ pub struct Model {
     #[sea_orm(column_type = "Text", nullable)]
     pub biography: Option<String>,
     #[sea_orm(column_type = "Text", nullable)]
+    pub website: Option<String>,
+    #[sea_orm(column_type = "Text", nullable)]
     pub user_page: Option<String>,
 }
 

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -539,6 +539,8 @@ pub struct UserFields<'a> {
     #[serde(skip_serializing_if = "Maybe::is_unset")]
     pub biography: Maybe<Option<&'a str>>,
     #[serde(skip_serializing_if = "Maybe::is_unset")]
+    pub website: Maybe<Option<&'a str>>,
+    #[serde(skip_serializing_if = "Maybe::is_unset")]
     pub user_page: Maybe<Option<&'a str>>,
 }
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -279,6 +279,7 @@ impl UserService {
             gender: Set(None),
             birthday: Set(None),
             biography: Set(None),
+            website: Set(None),
             user_page: Set(None),
             created_at: Set(now()),
             updated_at: Set(None),
@@ -433,6 +434,7 @@ impl UserService {
             add_changed_field!(move birthday);
             add_changed_field!(ref location);
             add_changed_field!(ref biography);
+            add_changed_field!(ref website);
             add_changed_field!(ref user_page);
 
             if let Maybe::Set(name) = &input.name {
@@ -542,6 +544,10 @@ impl UserService {
 
         if let Maybe::Set(biography) = input.biography {
             model.biography = Set(biography);
+        }
+
+        if let Maybe::Set(website) = input.website {
+            model.website = Set(website);
         }
 
         if let Maybe::Set(user_page) = input.user_page {

--- a/deepwell/src/services/user/structs.rs
+++ b/deepwell/src/services/user/structs.rs
@@ -93,6 +93,7 @@ pub struct UpdateUserBody {
     pub birthday: Maybe<Option<Date>>,
     pub location: Maybe<Option<String>>,
     pub biography: Maybe<Option<String>>,
+    pub website: Maybe<Option<String>>,
     pub user_page: Maybe<Option<String>>,
 
     #[serde(default)]

--- a/framerail/src/lib/server/deepwell/user.ts
+++ b/framerail/src/lib/server/deepwell/user.ts
@@ -41,6 +41,7 @@ interface UserEditParams {
   birthday?: Optional<Nullable<string>>
   location?: Optional<Nullable<string>>
   biography?: Optional<Nullable<string>>
+  website?: Optional<Nullable<string>>
   userPage?: Optional<Nullable<string>>
   bypassFilter?: boolean
 }
@@ -76,6 +77,10 @@ export async function userEdit(
   if (params.biography !== undefined && typeof params.biography === "string") {
     if (params.biography) data.biography = params.biography
     else data.biography = null
+  }
+  if (params.website !== undefined && typeof params.website === "string") {
+    if (params.website) data.website = params.website
+    else data.website = null
   }
   if (params.userPage !== undefined && typeof params.userPage === "string") {
     if (params.userPage) data.user_page = params.userPage

--- a/framerail/src/lib/server/load/user.ts
+++ b/framerail/src/lib/server/load/user.ts
@@ -105,6 +105,7 @@ export async function loadUser(
       "user-profile-info.birthday": {},
       "user-profile-info.location": {},
       "user-profile-info.biography": {},
+      "user-profile-info.website": {},
       "user-profile-info.user-page": {},
       "user-profile-info.locales": {}
     }
@@ -135,6 +136,7 @@ export function sanitizeUserData(
     "name",
     "slug",
     "avatar_s3_hash",
+    "website",
     "user_page"
   ]
   if (isViewingAnotherUser) {
@@ -191,6 +193,7 @@ export async function userEditAction({
       birthday,
       location,
       biography,
+      website,
       userPage,
       locales
     } = form.data
@@ -209,6 +212,7 @@ export async function userEditAction({
       birthday,
       location,
       biography,
+      website,
       userPage,
       bypassFilter: false
     })
@@ -232,6 +236,7 @@ export const userEditSchema = object({
   gender: optional(string()),
   birthday: optional(string()),
   location: optional(string()),
+  website: optional(string()),
   userPage: optional(string()),
   biography: optional(string()),
   locales: optional(string())

--- a/framerail/src/lib/types.ts
+++ b/framerail/src/lib/types.ts
@@ -70,6 +70,7 @@ export interface UserModel {
   birthday: Nullable<string>
   location: Nullable<string>
   biography: Nullable<string>
+  website: Nullable<string>
   user_page: Nullable<string>
 }
 

--- a/framerail/src/routes/[x+2d]/user/+page.svelte
+++ b/framerail/src/routes/[x+2d]/user/+page.svelte
@@ -142,8 +142,7 @@
       type="text"
       bind:value={$form.location}
     />
-    <label for="website"
-      >{data.internationalization?.["user-profile-info.website"]}</label
+    <label for="website">{data.internationalization?.["user-profile-info.website"]}</label
     >
     <input
       name="website"

--- a/framerail/src/routes/[x+2d]/user/+page.svelte
+++ b/framerail/src/routes/[x+2d]/user/+page.svelte
@@ -24,6 +24,7 @@
     gender: untrack(() => data.user?.gender ?? ""),
     birthday: untrack(() => data.user?.birthday ?? ""),
     location: untrack(() => data.user?.location ?? ""),
+    website: untrack(() => data.user?.website ?? ""),
     userPage: untrack(() => data.user?.user_page ?? ""),
     biography: untrack(() => data.user?.biography ?? ""),
     locales: untrack(() => data.user?.locales?.join(" ") ?? "")
@@ -140,6 +141,15 @@
       class="user-attribute location"
       type="text"
       bind:value={$form.location}
+    />
+    <label for="website"
+      >{data.internationalization?.["user-profile-info.website"]}</label
+    >
+    <input
+      name="website"
+      class="user-attribute website"
+      type="text"
+      bind:value={$form.website}
     />
     <label for="user-page"
       >{data.internationalization?.["user-profile-info.user-page"]}</label

--- a/framerail/src/routes/[x+2d]/user/[slug]/page.svelte
+++ b/framerail/src/routes/[x+2d]/user/[slug]/page.svelte
@@ -90,6 +90,15 @@
     </div>
   {/if}
 
+  {#if userData?.website}
+    <div class="user-attribute website">
+      <span class="user-attribute-label"
+        >{data.internationalization?.["user-profile-info.website"]}</span
+      >
+      <span class="user-attribute-value">{userData.website}</span>
+    </div>
+  {/if}
+
   {#if userData?.userPage}
     <div class="user-attribute user-page">
       <span class="user-attribute-label"

--- a/framerail/src/types/index.ts
+++ b/framerail/src/types/index.ts
@@ -316,6 +316,7 @@ export interface Locales {
   "user-profile-info.since": string
   "user-profile-info.biography": string
   "user-profile-info.gender": string
+  "user-profile-info.website": string
   "user-profile-info.user-page": string
   "user-profile-info.locales": string
   "user-not-exist": string

--- a/locales/fluent/user-profile/en.ftl
+++ b/locales/fluent/user-profile/en.ftl
@@ -9,6 +9,7 @@ user-profile-info =
   .since = Member since:
   .biography = Biography:
   .gender = Gender:
+  .website = Website:
   .user-page = User page:
   .locales = Locales:
 


### PR DESCRIPTION
This is to distinguish between a general website field (like on most social platforms) and the more write-focused "user page" (which could be an artist page, author page, etc) which is more for our use case.

Ran locally:
```py
$ scripts/request.py user_edit '{"user": 20000005, "website": "https://example.com", "user_page": "https://scpwiki.com/bob", "ip_address": "10.0.0.1"}'
OK  
{
    "user_id": 20000005,
    "user_type": "regular",
    "created_at": "2026-04-28T17:47:49.64684Z",
    "updated_at": "2026-04-28T17:55:03.037025Z",
    "deleted_at": null,
    "name": "some dude",
    "slug": "some-dude",
    ...snip...
    "avatar_s3_hash": null,
    "real_name": null,
    "gender": "neutral",
    "birthday": null,
    "location": null,
    "biography": null,
    "website": "https://example.com",
    "user_page": "https://scpwiki.com/bob"
}
```