### PR TITLE
Add assert_exists() methods

### DIFF
--- a/deepwell/src/services/forum_post_revision/service.rs
+++ b/deepwell/src/services/forum_post_revision/service.rs
@@ -235,7 +235,7 @@ impl ForumPostRevisionService {
             )
         };
 
-        let _revision = Self::get_direct(ctx, forum_post_revision_id)
+        Self::assert_exists_direct(ctx, forum_post_revision_id)
             .await
             .or_raise(make_error)?;
 
@@ -352,6 +352,15 @@ impl ForumPostRevisionService {
                 ErrorType::ForumPostRevisionNotFound,
             )
         })?)
+    }
+
+    #[inline]
+    pub async fn assert_exists_direct(
+        ctx: &ServiceContext<'_>,
+        forum_post_revision_id: i64,
+    ) -> Result<()> {
+        let _ = Self::get_direct(ctx, forum_post_revision_id).await?;
+        Ok(())
     }
 
     pub async fn count(ctx: &ServiceContext<'_>, forum_post_id: i64) -> Result<u64> {

--- a/deepwell/src/services/role/service.rs
+++ b/deepwell/src/services/role/service.rs
@@ -73,7 +73,7 @@ impl RoleService {
 
         // Validate parent role (if specified) exists
         if let Some(parent_id) = parent_role_id {
-            let _parent_role = Self::get(ctx, site_id, parent_id.into())
+            Self::assert_exists(ctx, site_id, parent_id.into())
                 .await
                 .or_raise(make_error)?;
         }
@@ -323,6 +323,16 @@ impl RoleService {
         reference: Reference<'_>,
     ) -> Result<RoleModel> {
         find_or_error!(Self::get_optional(ctx, site_id, reference), "role", Role)
+    }
+
+    #[inline]
+    pub async fn assert_exists(
+        ctx: &ServiceContext<'_>,
+        site_id: i64,
+        reference: Reference<'_>,
+    ) -> Result<()> {
+        let _ = Self::get(ctx, site_id, reference).await?;
+        Ok(())
     }
 
     pub async fn grant_role_to_user(

--- a/deepwell/src/services/role/service.rs
+++ b/deepwell/src/services/role/service.rs
@@ -132,7 +132,7 @@ impl RoleService {
         };
 
         // Validate that the role belongs to the site
-        let _role = Self::get(ctx, site_id, role_id.into())
+        Self::assert_exists(ctx, site_id, role_id.into())
             .await
             .or_raise(make_error)?;
 
@@ -517,7 +517,7 @@ impl RoleService {
             }
 
             // Validate that the new parent role exists
-            Self::get(ctx, site_id, parent_id.into())
+            Self::assert_exists(ctx, site_id, parent_id.into())
                 .await
                 .or_raise(make_error)?;
 


### PR DESCRIPTION
For each of the cases where we currently fetch an object, not for the sake of getting it but verifying that it exists (and returning an error if not).

I only added it for cases where we currently use this pattern.