### PR TITLE
Permission logic enhancement

### DIFF
--- a/deepwell/migrations/20220906103252_deepwell.sql
+++ b/deepwell/migrations/20220906103252_deepwell.sql
@@ -989,6 +989,8 @@ CREATE TABLE role_permission (
     UNIQUE (site_id, role_id, resource_type, resource_category_id, action)
 );
 
+CREATE INDEX idx_site_perms ON role_permission (site_id, resource_type, resource_category_id, action);
+
 -- User role assignments (many-to-many)
 CREATE TABLE user_role (
     user_id BIGINT NOT NULL REFERENCES known_user(user_id),

--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -32,7 +32,7 @@ use crate::services::file::{
 };
 use crate::services::filter::{CreateFilter, FilterService};
 use crate::services::page::{CreatePage, PageService};
-use crate::services::permission::{PermissionCache, PermissionInput, PermissionService};
+use crate::services::permission::{PermissionInput, PermissionService};
 use crate::services::relation::{
     PageAttributionEntry, PageAttributionKind, PageAttributionMetadata, RelationService,
     SetPageAttributions,
@@ -631,11 +631,6 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                 .or_raise(make_error)?;
             }
         }
-
-        // Trigger building of permission cache after all permissions have been added.
-        PermissionCache::build_permission_cache(&ctx, site_id)
-            .await
-            .or_raise(make_error)?;
     }
 
     txn.commit().await.or_raise(make_error)?;

--- a/deepwell/src/services/permission/cache.rs
+++ b/deepwell/src/services/permission/cache.rs
@@ -42,7 +42,7 @@ impl PermissionCache {
     /// Build Redis cache key to lookup user permissions for a specific site.
     fn site_user_key(site_id: Option<i64>, user_id: Option<i64>) -> String {
         format!(
-            "site:{}:user:{}",
+            "permission:site:{}:user:{}",
             site_id
                 .map(|id| id.to_string())
                 .unwrap_or(SITE_NOT_SET_KEY.to_owned()),
@@ -61,7 +61,10 @@ impl PermissionCache {
         let category_id_str = resource_category_id
             .map(|id| id.to_string())
             .unwrap_or(DEFAULT_CATEGORY_KEY.to_owned());
-        Cow::Owned(format!("{}:{}:{}", resource, category_id_str, action))
+        Cow::Owned(format!(
+            "permission:{}:{}:{}",
+            resource, category_id_str, action
+        ))
     }
 
     /// Check if an action should be cached.
@@ -129,7 +132,7 @@ impl PermissionCache {
     /// Invalidate the cache for a specific site.
     pub async fn invalidate_site(ctx: &ServiceContext<'_>, site_id: i64) -> Result<()> {
         let mut redis = ctx.redis();
-        let pattern = format!("site:{}:*", site_id);
+        let pattern = format!("permission:site:{}:*", site_id);
         let make_error = || {
             Error::new(
                 format!("Failed to invalidate permission cache for site {}", site_id),

--- a/deepwell/src/services/permission/cache.rs
+++ b/deepwell/src/services/permission/cache.rs
@@ -95,10 +95,7 @@ impl PermissionCache {
                 Error::new("Permission cache read error", ErrorType::Permission)
             })?;
 
-        Ok(match has_permission {
-            Some(val) => Some(val == "1"),
-            None => None,
-        })
+        Ok(has_permission.map(|val| val == "1"))
     }
 
     /// Set a user's permission value in the cache.

--- a/deepwell/src/services/permission/cache.rs
+++ b/deepwell/src/services/permission/cache.rs
@@ -31,22 +31,37 @@ use ftml::info;
 use redis::AsyncCommands;
 
 pub const DEFAULT_CATEGORY_KEY: &str = "_default";
+pub const SITE_NOT_SET_KEY: &str = "platform";
+pub const USER_NOT_SET_KEY: &str = "anonymous";
 
 #[derive(Debug, Clone, Copy)]
 pub struct PermissionCache;
 
 #[allow(dead_code)]
 impl PermissionCache {
-    /// Build Redis cache key for a permission hash.
-    fn key(site_id: i64, resource_type: Resource, action: Action) -> String {
-        format!("perm:{}:{}:{}", site_id, resource_type, action)
+    /// Build Redis cache key to lookup user permissions for a specific site.
+    fn site_user_key(site_id: Option<i64>, user_id: Option<i64>) -> String {
+        format!(
+            "site:{}:user:{}",
+            site_id
+                .map(|id| id.to_string())
+                .unwrap_or(SITE_NOT_SET_KEY.to_owned()),
+            user_id
+                .map(|id| id.to_string())
+                .unwrap_or(USER_NOT_SET_KEY.to_owned())
+        )
     }
 
-    /// Build the field key within a permission hash for a specific category.
-    fn category_field(resource_category_id: Option<i64>) -> Cow<'static, str> {
-        resource_category_id
-            .map(|id| Cow::Owned(id.to_string()))
-            .unwrap_or_else(|| Cow::Borrowed(DEFAULT_CATEGORY_KEY))
+    /// Build a hash field key for the permission
+    fn permission_key(
+        resource: Resource,
+        resource_category_id: Option<i64>,
+        action: Action,
+    ) -> Cow<'static, str> {
+        let category_id_str = resource_category_id
+            .map(|id| id.to_string())
+            .unwrap_or(DEFAULT_CATEGORY_KEY.to_owned());
+        Cow::Owned(format!("{}:{}:{}", resource, category_id_str, action))
     }
 
     /// Check if an action should be cached.
@@ -58,97 +73,66 @@ impl PermissionCache {
         }
     }
 
-    /// Fetch cached role IDs for a permission category.
-    pub async fn query_roles_with_permission_cache(
+    /// Check if this user's permission has been cached, and return it.
+    pub async fn check_user_permission(
         ctx: &ServiceContext<'_>,
-        site_id: i64,
+        site_id: Option<i64>,
+        user_id: Option<i64>,
         resource_type: Resource,
         resource_category_id: Option<i64>,
         action: Action,
-    ) -> Result<Option<Vec<i64>>> {
+    ) -> Result<Option<bool>> {
+        let key = Self::site_user_key(site_id, user_id);
+        let field = Self::permission_key(resource_type, resource_category_id, action);
+
         let mut redis = ctx.redis();
-
-        let key = Self::key(site_id, resource_type, action);
-        let field = Self::category_field(resource_category_id);
-        let default_field = Self::category_field(None);
-
-        // Fetch both category-specific and default values in one round trip
-        let values: Vec<Option<String>> = redis
-            .hmget(&key, &[&field, &default_field])
-            .await
-            .or_raise(|| {
+        let has_permission: Option<String> =
+            redis.hget(&key, &field).await.or_raise(|| {
                 warn!(
-                    "Failed to read permission cache key '{}' fields '{}' and '{}'",
-                    key, field, default_field
+                    "Failed to read permission cache key '{}' field '{}'",
+                    key, field
                 );
                 Error::new("Permission cache read error", ErrorType::Permission)
             })?;
 
-        let category_value = values[0].clone();
-        let default_value = values[1].clone();
-
-        // Prefer category-specific value, fall back to default if not found
-        let role_ids_str = if category_value.is_some() {
-            category_value
-        } else {
-            default_value
-        };
-
-        match role_ids_str {
-            None => Ok(None), // Field doesn't exist = cache miss
-            Some(s) => {
-                let parsed = s
-                    .split(',')
-                    .filter_map(|part| part.trim().parse::<i64>().ok())
-                    .collect();
-                Ok(Some(parsed))
-            }
-        }
+        Ok(match has_permission {
+            Some(val) => Some(val == "1"),
+            None => None,
+        })
     }
 
-    pub async fn build_permission_cache(
+    /// Set a user's permission value in the cache.
+    pub async fn set_user_permission(
         ctx: &ServiceContext<'_>,
-        site_id: i64,
+        site_id: Option<i64>,
+        user_id: Option<i64>,
+        resource_type: Resource,
+        resource_category_id: Option<i64>,
+        action: Action,
+        has_permission: bool,
     ) -> Result<()> {
-        let txn = ctx.transaction();
-        let make_error =
-            || Error::new("Error building permission cache", ErrorType::Permission);
-
-        let all_permissions = RolePermission::find()
-            .filter(role_permission::Column::SiteId.eq(site_id))
-            .all(txn)
-            .await
-            .or_raise(make_error)?;
-
-        let mut cache_map: HashMap<(Resource, Option<i64>, Action), Vec<i64>> =
-            HashMap::new();
-        for perm in all_permissions {
-            if !Self::is_cacheable(perm.resource_type, perm.action) {
-                continue;
-            }
-
-            let key = (perm.resource_type, perm.resource_category_id, perm.action);
-            cache_map.entry(key).or_default().push(perm.role_id);
-        }
+        let key = Self::site_user_key(site_id, user_id);
+        let field = Self::permission_key(resource_type, resource_category_id, action);
 
         let mut redis = ctx.redis();
-        for ((resource_type, resource_category_id, action), role_ids) in cache_map {
-            let key = Self::key(site_id, resource_type, action);
-            let field = Self::category_field(resource_category_id);
-            let value = role_ids
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
-            let _: () = redis.hset(&key, &field, value).await.or_raise(make_error)?;
-        }
+        let _: () = redis
+            .hset(&key, &field, if has_permission { "1" } else { "0" })
+            .await
+            .or_raise(|| {
+                warn!(
+                    "Failed to write permission cache key '{}' field '{}'",
+                    key, field
+                );
+                Error::new("Permission cache write error", ErrorType::Permission)
+            })?;
 
         Ok(())
     }
 
+    /// Invalidate the cache for a specific site.
     pub async fn invalidate_site(ctx: &ServiceContext<'_>, site_id: i64) -> Result<()> {
         let mut redis = ctx.redis();
-        let pattern = format!("perm:{}:*", site_id);
+        let pattern = format!("site:{}:*", site_id);
         let make_error = || {
             Error::new(
                 format!("Failed to invalidate permission cache for site {}", site_id),

--- a/deepwell/src/services/permission/resolvers.rs
+++ b/deepwell/src/services/permission/resolvers.rs
@@ -63,7 +63,7 @@ impl CategoryResolver for PageCategoryResolver {
                 let category = CategoryService::get_optional(
                     ctx,
                     site_id,
-                    Reference::Slug(slug.clone()),
+                    Reference::Slug(cow!(&slug)),
                 )
                 .await?;
                 Ok(category.map(|c| c.category_id))

--- a/deepwell/src/services/permission/resolvers.rs
+++ b/deepwell/src/services/permission/resolvers.rs
@@ -35,14 +35,14 @@ pub trait CategoryResolver: Send + Sync {
     fn resolve(
         ctx: &ServiceContext<'_>,
         site_id: i64,
-        reference: Reference<'_>,
+        reference: &Reference<'_>,
     ) -> impl Future<Output = Result<Option<i64>>> + Send;
 
     /// Resolve a category reference to a slug, for human-readable output.
     fn resolve_slug<'slug>(
         ctx: &ServiceContext<'_>,
         site_id: i64,
-        reference: Reference<'slug>,
+        reference: &Reference<'slug>,
     ) -> impl Future<Output = Result<Option<Cow<'slug, str>>>> + Send;
 }
 
@@ -53,16 +53,19 @@ impl CategoryResolver for PageCategoryResolver {
     async fn resolve(
         ctx: &ServiceContext<'_>,
         site_id: i64,
-        reference: Reference<'_>,
+        reference: &Reference<'_>,
     ) -> Result<Option<i64>> {
         use crate::services::CategoryService;
 
         match reference {
-            Reference::Id(id) => Ok(Some(id)),
+            Reference::Id(id) => Ok(Some(*id)),
             Reference::Slug(slug) => {
-                let category =
-                    CategoryService::get_optional(ctx, site_id, Reference::Slug(slug))
-                        .await?;
+                let category = CategoryService::get_optional(
+                    ctx,
+                    site_id,
+                    Reference::Slug(slug.clone()),
+                )
+                .await?;
                 Ok(category.map(|c| c.category_id))
             }
         }
@@ -71,18 +74,18 @@ impl CategoryResolver for PageCategoryResolver {
     async fn resolve_slug<'slug>(
         ctx: &ServiceContext<'_>,
         site_id: i64,
-        reference: Reference<'slug>,
+        reference: &Reference<'slug>,
     ) -> Result<Option<Cow<'slug, str>>> {
         use crate::services::CategoryService;
 
         match reference {
             Reference::Id(id) => {
                 let category =
-                    CategoryService::get_optional(ctx, site_id, Reference::Id(id))
+                    CategoryService::get_optional(ctx, site_id, Reference::Id(*id))
                         .await?;
                 Ok(category.map(|c| Cow::Owned(c.slug)))
             }
-            Reference::Slug(slug) => Ok(Some(slug)),
+            Reference::Slug(slug) => Ok(Some(slug.clone())),
         }
     }
 }
@@ -92,7 +95,7 @@ pub async fn resolve_category_reference(
     ctx: &ServiceContext<'_>,
     site_id: i64,
     resource_type: Resource,
-    reference: Reference<'_>,
+    reference: &Reference<'_>,
 ) -> Result<Option<i64>> {
     match resource_type {
         Resource::Page => PageCategoryResolver::resolve(ctx, site_id, reference).await,
@@ -105,7 +108,7 @@ pub async fn resolve_category_slug<'slug>(
     ctx: &ServiceContext<'_>,
     site_id: i64,
     resource_type: Resource,
-    reference: Reference<'slug>,
+    reference: &Reference<'slug>,
 ) -> Result<Option<Cow<'slug, str>>> {
     match resource_type {
         Resource::Page => {

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -78,7 +78,7 @@ impl PermissionService {
                             ctx,
                             site_id,
                             input.resource_type,
-                            cat_ref,
+                            &cat_ref,
                         )
                         .await?
                     }
@@ -251,9 +251,9 @@ impl PermissionService {
             .or_raise(make_error)?;
         if human_readable_categories {
             for perm in &mut permissions {
-                if let Some(Reference::Id(cat_id)) = perm.resource_category {
+                if let Some(category_ref) = &perm.resource_category {
                     perm.resource_category =
-                        resolve_category_slug(ctx, site_id, perm.resource, cat_id.into())
+                        resolve_category_slug(ctx, site_id, perm.resource, &category_ref)
                             .await
                             .or_raise(make_error)?
                             .map(Reference::Slug);
@@ -358,10 +358,10 @@ impl PermissionService {
 
             // Remap resource category from ID to slug
             if human_readable_categories
-                && let Some(Reference::Id(cat_id)) = perm.resource_category
+                && let Some(category_ref) = &perm.resource_category
             {
                 perm.resource_category =
-                    resolve_category_slug(ctx, site_id, perm.resource, cat_id.into())
+                    resolve_category_slug(ctx, site_id, perm.resource, &category_ref)
                         .await
                         .or_raise(make_error)?
                         .map(Reference::Slug);
@@ -458,6 +458,67 @@ impl PermissionService {
         Ok(result)
     }
 
+    async fn get_permissions_for_user(
+        ctx: &ServiceContext<'_>,
+        user_id: Option<i64>,
+        site_id: i64,
+        page_reference: Option<Reference<'_>>,
+    ) -> Result<HashSet<Permission>> {
+        let make_error = || {
+            Error::new(
+                format!("failed to get permissions for user {:?}", user_id),
+                ErrorType::Permission,
+            )
+        };
+
+        let role_ids: Vec<i64> = RoleService::get_all_roles_for_user_and_site(
+            ctx,
+            GetUserRolesInput {
+                user_id,
+                site_id,
+                page_reference,
+            },
+        )
+        .await
+        .or_raise(make_error)?
+        .into_iter()
+        .map(|r| r.role_id)
+        .collect();
+
+        Ok(RolePermission::find()
+            .filter(role_permission::Column::RoleId.is_in(role_ids))
+            .all(ctx.transaction())
+            .await
+            .or_raise(make_error)?
+            .into_iter()
+            .map(|p| Permission {
+                resource: p.resource_type,
+                resource_category: p.resource_category_id.map(Reference::Id),
+                action: p.action,
+            })
+            .collect())
+    }
+
+    async fn check_category_scoped(
+        ctx: &ServiceContext<'_>,
+        site_id: i64,
+        resource: Resource,
+        resource_category_id: i64,
+        action: Action,
+    ) -> Result<bool> {
+        Ok(RolePermission::find()
+            .filter(role_permission::Column::SiteId.eq(site_id))
+            .filter(role_permission::Column::ResourceType.eq(resource))
+            .filter(role_permission::Column::ResourceCategoryId.eq(resource_category_id))
+            .filter(role_permission::Column::Action.eq(action))
+            .one(ctx.transaction())
+            .await
+            .or_raise(|| {
+                Error::new("Error querying permissions", ErrorType::Permission)
+            })?)
+        .map(|p| p.is_some())
+    }
+
     /// Batch check if a user has the specified permissions.
     ///
     /// Returns an array of booleans corresponding to each permission input.
@@ -474,32 +535,15 @@ impl PermissionService {
         let make_error =
             || Error::new("failed to check permissions", ErrorType::Permission);
 
-        // Get all roles for this user (includes virtual roles)
-        let role_ids: Vec<i64> = RoleService::get_all_roles_for_user_and_site(
-            ctx,
-            GetUserRolesInput {
-                user_id,
-                site_id,
-                page_reference,
-            },
-        )
-        .await
-        .or_raise(make_error)?
-        .into_iter()
-        .map(|r| r.role_id)
-        .collect();
+        let user_permissions =
+            Self::get_permissions_for_user(ctx, user_id, site_id, page_reference)
+                .await
+                .or_raise(make_error)?;
 
-        // Short-circuit: no roles means no permissions.
-        if role_ids.is_empty() {
+        // Short-circuit: no permissions.
+        if user_permissions.is_empty() {
             return Ok([false; N]);
         }
-
-        // Lambda to check if user has any of the specified roles
-        let user_has_any_role = |granted_roles: &[i64]| -> bool {
-            granted_roles
-                .iter()
-                .any(|role_id| role_ids.contains(role_id))
-        };
 
         let mut results = [false; N];
 
@@ -518,7 +562,7 @@ impl PermissionService {
             );
 
             // Resolve category reference to ID for permission checking
-            let resource_category_id = match resource_category {
+            let resource_category_id = match &resource_category {
                 Some(reference) => {
                     resolve_category_reference(ctx, site_id, resource_type, reference)
                         .await?
@@ -526,58 +570,34 @@ impl PermissionService {
                 None => None,
             };
 
-            // Check permission based on category specificity
-            let roles_with_permission =
-                if PermissionCache::is_cacheable(resource_type, action) {
-                    // Try to fetch from cache
-                    let cached_roles =
-                        PermissionCache::query_roles_with_permission_cache(
-                            ctx,
-                            site_id,
-                            resource_type,
-                            resource_category_id,
-                            action,
-                        )
-                        .await
-                        .or_raise(make_error)?;
+            // Does this category have permissions scoped to it?
+            let has_scoped_permissions = match resource_category_id {
+                Some(category_id) => Self::check_category_scoped(
+                    ctx,
+                    site_id,
+                    resource_type,
+                    category_id,
+                    action,
+                )
+                .await
+                .or_raise(make_error)?,
+                None => false,
+            };
 
-                    if let Some(cached) = cached_roles {
-                        info!("Permission cache hit, {} roles found", cached.len());
-                        cached
-                    } else {
-                        info!("Permission cache miss, querying database directly");
-
-                        // If cache miss, rebuild tree async
-                        PermissionCache::build_permission_cache(ctx, site_id)
-                            .await
-                            .or_raise(make_error)?;
-
-                        // fall back to database query
-                        Self::query_roles_with_permission_db(
-                            ctx,
-                            site_id,
-                            resource_type,
-                            resource_category_id,
-                            action,
-                        )
-                        .await
-                        .or_raise(make_error)?
-                    }
-                } else {
-                    info!("Permission not cacheable, querying database directly");
-                    // For non-cacheable permissions, query database directly
-                    Self::query_roles_with_permission_db(
-                        ctx,
-                        site_id,
-                        resource_type,
-                        resource_category_id,
-                        action,
-                    )
-                    .await
-                    .or_raise(make_error)?
-                };
-
-            results[i] = user_has_any_role(&roles_with_permission);
+            if has_scoped_permissions {
+                results[i] = user_permissions.contains(&Permission {
+                    resource: resource_type,
+                    resource_category: resource_category_id.map(Reference::Id),
+                    action,
+                });
+            } else {
+                // If category does not have scoped permissions, fallback to _default
+                results[i] = user_permissions.contains(&Permission {
+                    resource: resource_type,
+                    resource_category: None,
+                    action,
+                });
+            }
         }
 
         Ok(results)

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -253,7 +253,7 @@ impl PermissionService {
             for perm in &mut permissions {
                 if let Some(category_ref) = &perm.resource_category {
                     perm.resource_category =
-                        resolve_category_slug(ctx, site_id, perm.resource, &category_ref)
+                        resolve_category_slug(ctx, site_id, perm.resource, category_ref)
                             .await
                             .or_raise(make_error)?
                             .map(Reference::Slug);
@@ -361,7 +361,7 @@ impl PermissionService {
                 && let Some(category_ref) = &perm.resource_category
             {
                 perm.resource_category =
-                    resolve_category_slug(ctx, site_id, perm.resource, &category_ref)
+                    resolve_category_slug(ctx, site_id, perm.resource, category_ref)
                         .await
                         .or_raise(make_error)?
                         .map(Reference::Slug);

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -429,6 +429,9 @@ impl PermissionService {
                 user_id, site_id, resource_type, resource_category, action,
             );
 
+            // Check if this permission is cacheable
+            let cacheable = PermissionCache::is_cacheable(resource_type, action);
+
             // Resolve category reference to ID for permission checking
             let resource_category_id = match &resource_category {
                 Some(reference) => {
@@ -437,6 +440,28 @@ impl PermissionService {
                 }
                 None => None,
             };
+
+            if cacheable {
+                // Check if this permission has been cached
+                let has_permission = PermissionCache::check_user_permission(
+                    ctx,
+                    Some(site_id),
+                    user_id,
+                    resource_type,
+                    resource_category_id,
+                    action,
+                )
+                .await
+                .or_raise(make_error)?;
+
+                // If we have a cached result, use it
+                if let Some(has_permission) = has_permission {
+                    results[i] = has_permission;
+                    continue;
+                }
+            }
+
+            // If permission is not cacheable, or is not cached, compute it fresh
 
             // Does this category have permissions scoped to it?
             let has_scoped_permissions = match resource_category_id {
@@ -452,20 +477,37 @@ impl PermissionService {
                 None => false,
             };
 
-            if has_scoped_permissions {
-                results[i] = user_permissions.contains(&Permission {
+            let has_permission = if has_scoped_permissions {
+                user_permissions.contains(&Permission {
                     resource: resource_type,
                     resource_category: resource_category_id.map(Reference::Id),
                     action,
-                });
+                })
             } else {
                 // If category does not have scoped permissions, fallback to _default
-                results[i] = user_permissions.contains(&Permission {
+                user_permissions.contains(&Permission {
                     resource: resource_type,
                     resource_category: None,
                     action,
-                });
+                })
+            };
+
+            // Cache result if cacheable
+            if cacheable {
+                PermissionCache::set_user_permission(
+                    ctx,
+                    Some(site_id),
+                    user_id,
+                    resource_type,
+                    resource_category_id,
+                    action,
+                    has_permission,
+                )
+                .await
+                .or_raise(make_error)?;
             }
+
+            results[i] = has_permission;
         }
 
         Ok(results)

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -569,6 +569,7 @@ impl PermissionService {
         site_id: i64,
         page_reference: Option<Reference<'_>>,
     ) -> Result<HashSet<Permission>> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -595,7 +596,7 @@ impl PermissionService {
 
         Ok(RolePermission::find()
             .filter(role_permission::Column::RoleId.is_in(role_ids))
-            .all(ctx.transaction())
+            .all(txn)
             .await
             .or_raise(make_error)?
             .into_iter()
@@ -614,12 +615,19 @@ impl PermissionService {
         resource_category_id: i64,
         action: Action,
     ) -> Result<bool> {
+        let txn = ctx.transaction();
         Ok(RolePermission::find()
-            .filter(role_permission::Column::SiteId.eq(site_id))
-            .filter(role_permission::Column::ResourceType.eq(resource))
-            .filter(role_permission::Column::ResourceCategoryId.eq(resource_category_id))
-            .filter(role_permission::Column::Action.eq(action))
-            .one(ctx.transaction())
+            .filter(
+                Condition::all()
+                    .add(role_permission::Column::SiteId.eq(site_id))
+                    .add(role_permission::Column::ResourceType.eq(resource))
+                    .add(
+                        role_permission::Column::ResourceCategoryId
+                            .eq(resource_category_id),
+                    )
+                    .add(role_permission::Column::Action.eq(action)),
+            )
+            .one(txn)
             .await
             .or_raise(|| {
                 Error::new("Error querying permissions", ErrorType::Permission)

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -456,8 +456,17 @@ impl PermissionService {
 
                 // If we have a cached result, use it
                 if let Some(has_permission) = has_permission {
+                    info!(
+                        "Cache hit for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+                        user_id, site_id, resource_type, resource_category, action,
+                    );
                     results[i] = has_permission;
                     continue;
+                } else {
+                    info!(
+                        "Cache miss for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+                        user_id, site_id, resource_type, resource_category, action,
+                    );
                 }
             }
 

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -378,77 +378,6 @@ impl PermissionService {
         Ok(decorated)
     }
 
-    // Lambda to query roles that have the specified permission, optionally filtered by category
-    async fn query_roles_with_permission(
-        ctx: &ServiceContext<'_>,
-        site_id: i64,
-        resource: Resource,
-        resource_category_id: Option<i64>,
-        action: Action,
-    ) -> Result<Vec<i64>> {
-        let txn = ctx.transaction();
-
-        let category_condition = match resource_category_id {
-            Some(id) => role_permission::Column::ResourceCategoryId.eq(id),
-            None => role_permission::Column::ResourceCategoryId.is_null(),
-        };
-
-        Ok(RolePermission::find()
-            .filter(role_permission::Column::SiteId.eq(site_id))
-            .filter(role_permission::Column::ResourceType.eq(resource))
-            .filter(category_condition)
-            .filter(role_permission::Column::Action.eq(action))
-            .all(txn)
-            .await
-            .or_raise(|| Error::new("Error querying permissions", ErrorType::Permission))?
-            .into_iter()
-            .map(|p| p.role_id)
-            .collect::<Vec<_>>())
-    }
-
-    async fn query_roles_with_permission_db(
-        ctx: &ServiceContext<'_>,
-        site_id: i64,
-        resource_type: Resource,
-        resource_category_id: Option<i64>,
-        action: Action,
-    ) -> Result<Vec<i64>> {
-        let make_error =
-            || Error::new("Error querying permissions", ErrorType::Permission);
-
-        // Check first for presence of scoped permission
-        let specific_roles = match resource_category_id {
-            Some(category_id) => Self::query_roles_with_permission(
-                ctx,
-                site_id,
-                resource_type,
-                Some(category_id),
-                action,
-            )
-            .await
-            .or_raise(make_error)?,
-            None => vec![],
-        };
-
-        let roles_with_permission = if specific_roles.is_empty() {
-            // If no scoped permission, check for _default permission
-            Self::query_roles_with_permission(ctx, site_id, resource_type, None, action)
-                .await
-                .or_raise(make_error)?
-        } else {
-            specific_roles
-        };
-
-        info!(
-            "Queried database for permission '{}:{}:{}', found {} roles",
-            resource_type,
-            resource_category_id.unwrap_or(0),
-            action,
-            roles_with_permission.len()
-        );
-        Ok(roles_with_permission)
-    }
-
     pub async fn check_user_can(
         ctx: &ServiceContext<'_>,
         perm_ctx: &CheckPermissionContext<'_>,
@@ -456,67 +385,6 @@ impl PermissionService {
     ) -> Result<bool> {
         let [result] = Self::batch_check_user_can(ctx, perm_ctx, [input]).await?;
         Ok(result)
-    }
-
-    async fn get_permissions_for_user(
-        ctx: &ServiceContext<'_>,
-        user_id: Option<i64>,
-        site_id: i64,
-        page_reference: Option<Reference<'_>>,
-    ) -> Result<HashSet<Permission>> {
-        let make_error = || {
-            Error::new(
-                format!("failed to get permissions for user {:?}", user_id),
-                ErrorType::Permission,
-            )
-        };
-
-        let role_ids: Vec<i64> = RoleService::get_all_roles_for_user_and_site(
-            ctx,
-            GetUserRolesInput {
-                user_id,
-                site_id,
-                page_reference,
-            },
-        )
-        .await
-        .or_raise(make_error)?
-        .into_iter()
-        .map(|r| r.role_id)
-        .collect();
-
-        Ok(RolePermission::find()
-            .filter(role_permission::Column::RoleId.is_in(role_ids))
-            .all(ctx.transaction())
-            .await
-            .or_raise(make_error)?
-            .into_iter()
-            .map(|p| Permission {
-                resource: p.resource_type,
-                resource_category: p.resource_category_id.map(Reference::Id),
-                action: p.action,
-            })
-            .collect())
-    }
-
-    async fn check_category_scoped(
-        ctx: &ServiceContext<'_>,
-        site_id: i64,
-        resource: Resource,
-        resource_category_id: i64,
-        action: Action,
-    ) -> Result<bool> {
-        Ok(RolePermission::find()
-            .filter(role_permission::Column::SiteId.eq(site_id))
-            .filter(role_permission::Column::ResourceType.eq(resource))
-            .filter(role_permission::Column::ResourceCategoryId.eq(resource_category_id))
-            .filter(role_permission::Column::Action.eq(action))
-            .one(ctx.transaction())
-            .await
-            .or_raise(|| {
-                Error::new("Error querying permissions", ErrorType::Permission)
-            })?)
-        .map(|p| p.is_some())
     }
 
     /// Batch check if a user has the specified permissions.
@@ -603,6 +471,8 @@ impl PermissionService {
         Ok(results)
     }
 
+    /// Fetches permissions for `role_id`.
+    /// This is a separate function that returns Vec to preserve ordering.
     async fn fetch_permissions(
         ctx: &ServiceContext<'_>,
         role_id: i64,
@@ -640,6 +510,70 @@ impl PermissionService {
             .await?
             .into_iter()
             .collect())
+    }
+
+    async fn get_permissions_for_user(
+        ctx: &ServiceContext<'_>,
+        user_id: Option<i64>,
+        site_id: i64,
+        page_reference: Option<Reference<'_>>,
+    ) -> Result<HashSet<Permission>> {
+        let make_error = || {
+            Error::new(
+                format!(
+                    "failed to get permissions for user {:?} in site {:?}",
+                    user_id, site_id
+                ),
+                ErrorType::Permission,
+            )
+        };
+
+        let role_ids: Vec<i64> = RoleService::get_all_roles_for_user_and_site(
+            ctx,
+            GetUserRolesInput {
+                user_id,
+                site_id,
+                page_reference,
+            },
+        )
+        .await
+        .or_raise(make_error)?
+        .into_iter()
+        .map(|r| r.role_id)
+        .collect();
+
+        Ok(RolePermission::find()
+            .filter(role_permission::Column::RoleId.is_in(role_ids))
+            .all(ctx.transaction())
+            .await
+            .or_raise(make_error)?
+            .into_iter()
+            .map(|p| Permission {
+                resource: p.resource_type,
+                resource_category: p.resource_category_id.map(Reference::Id),
+                action: p.action,
+            })
+            .collect())
+    }
+
+    async fn check_category_scoped(
+        ctx: &ServiceContext<'_>,
+        site_id: i64,
+        resource: Resource,
+        resource_category_id: i64,
+        action: Action,
+    ) -> Result<bool> {
+        Ok(RolePermission::find()
+            .filter(role_permission::Column::SiteId.eq(site_id))
+            .filter(role_permission::Column::ResourceType.eq(resource))
+            .filter(role_permission::Column::ResourceCategoryId.eq(resource_category_id))
+            .filter(role_permission::Column::Action.eq(action))
+            .one(ctx.transaction())
+            .await
+            .or_raise(|| {
+                Error::new("Error querying permissions", ErrorType::Permission)
+            })?)
+        .map(|p| p.is_some())
     }
 
     async fn cascade_permission_removals(

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -27,8 +27,7 @@ use deepwell::license::License;
 use deepwell::services::ServiceContext;
 use deepwell::services::category::CategoryService;
 use deepwell::services::permission::{
-    CheckPermissionContext, DecoratedPermission, PermissionInput,
-    PermissionService,
+    CheckPermissionContext, DecoratedPermission, PermissionInput, PermissionService,
 };
 use deepwell::services::role::{
     GrantUserRoleInput, InternalCreateRoleInput, RoleService, UpdateRolePermissionsInput,

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -27,7 +27,7 @@ use deepwell::license::License;
 use deepwell::services::ServiceContext;
 use deepwell::services::category::CategoryService;
 use deepwell::services::permission::{
-    CheckPermissionContext, DecoratedPermission, PermissionCache, PermissionInput,
+    CheckPermissionContext, DecoratedPermission, PermissionInput,
     PermissionService,
 };
 use deepwell::services::role::{
@@ -136,10 +136,6 @@ impl PermissionFixture {
         grant_role(ctx, site_id, user_a, role_a).await;
         grant_role(ctx, site_id, user_b, role_b).await;
         // user_c doesn't have any roles
-
-        PermissionCache::build_permission_cache(ctx, site_id)
-            .await
-            .expect("Failed to build permission cache");
 
         PermissionFixture {
             site_id,


### PR DESCRIPTION
Made some changes to the permission category scoping logic, so it's more intuitive and straightforward.

Before:
- For a category, check if any roles have a permission scoped to that category
- If a list of such roles exists, intersect it with the user's roles
- If no such roles exist, fallback to checking if any roles have the unscoped permission
- Intersect with user's role to check
-> Convoluted, hard to grasp, user permissions is not source of truth

After:
- Get all user roles, then construct a set of all permissions for that user
- Category check: Since RolePermission schema is (site_id, resource_type, resource_category_id, action, ...) we can simplify the category scope check down to an EXIST check
- Check if user has permission with appropriate scope

Also changed cache logic to cache per-user per-permission. Works more intuitively now imo.

