### PR TITLE
Minor SQL-related format consistency

### DIFF
--- a/deepwell/src/services/forum/service.rs
+++ b/deepwell/src/services/forum/service.rs
@@ -92,6 +92,7 @@ impl ForumService {
                 },
         }: UpdateForumGroup,
     ) -> Result<ForumGroupModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -130,7 +131,7 @@ impl ForumService {
             model.sort_index = Set(sort_index);
         }
 
-        let group = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let group = model.update(txn).await.or_raise(make_error)?;
         Ok(group)
     }
 
@@ -141,6 +142,7 @@ impl ForumService {
             user_id,
         }: DeleteForumGroup,
     ) -> Result<ForumGroupModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -162,7 +164,7 @@ impl ForumService {
             ..Default::default()
         };
 
-        let group = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let group = model.update(txn).await.or_raise(make_error)?;
         Ok(group)
     }
 
@@ -354,6 +356,7 @@ impl ForumService {
                 },
         }: UpdateForumCategory,
     ) -> Result<ForumCategoryModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -435,7 +438,7 @@ impl ForumService {
             model.layout = Set(layout);
         }
 
-        let category = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let category = model.update(txn).await.or_raise(make_error)?;
 
         if moved_group {
             // Keep denormalized group/site fields in sync for all descendants.
@@ -450,7 +453,7 @@ impl ForumService {
                 .filter(
                     forum_thread::Column::ForumCategoryId.eq(category.forum_category_id),
                 )
-                .exec(ctx.transaction())
+                .exec(txn)
                 .await
                 .or_raise(make_error)?;
 
@@ -465,7 +468,7 @@ impl ForumService {
                 .filter(
                     forum_post::Column::ForumCategoryId.eq(category.forum_category_id),
                 )
-                .exec(ctx.transaction())
+                .exec(txn)
                 .await
                 .or_raise(make_error)?;
 
@@ -481,7 +484,7 @@ impl ForumService {
                     forum_post_revision::Column::ForumCategoryId
                         .eq(category.forum_category_id),
                 )
-                .exec(ctx.transaction())
+                .exec(txn)
                 .await
                 .or_raise(make_error)?;
         }
@@ -496,6 +499,7 @@ impl ForumService {
             user_id,
         }: DeleteForumCategory,
     ) -> Result<ForumCategoryModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -517,7 +521,7 @@ impl ForumService {
             ..Default::default()
         };
 
-        let category = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let category = model.update(txn).await.or_raise(make_error)?;
         Ok(category)
     }
 

--- a/deepwell/src/services/forum_post/service.rs
+++ b/deepwell/src/services/forum_post/service.rs
@@ -51,6 +51,7 @@ impl ForumPostService {
             from_wikidot,
         }: CreateForumPost,
     ) -> Result<CreateForumPostOutput> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -124,7 +125,7 @@ impl ForumPostService {
             from_wikidot: Set(from_wikidot),
             ..Default::default()
         }
-        .insert(ctx.transaction())
+        .insert(txn)
         .await
         .or_raise(make_error)?;
 
@@ -150,7 +151,7 @@ impl ForumPostService {
             latest_revision_id: Set(Some(forum_post_revision_id)),
             ..Default::default()
         }
-        .update(ctx.transaction())
+        .update(txn)
         .await
         .or_raise(make_error)?;
 
@@ -186,6 +187,7 @@ impl ForumPostService {
             body: UpdateForumPostBody { title, wikitext },
         }: UpdateForumPost,
     ) -> Result<Option<UpdateForumPostOutput>> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -235,7 +237,7 @@ impl ForumPostService {
             updated_at: Set(Some(now())),
             ..Default::default()
         }
-        .update(ctx.transaction())
+        .update(txn)
         .await
         .or_raise(make_error)?;
 
@@ -273,6 +275,7 @@ impl ForumPostService {
             user_id,
         }: DeleteForumPost,
     ) -> Result<ForumPostModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -301,7 +304,7 @@ impl ForumPostService {
             ..Default::default()
         };
 
-        let post = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let post = model.update(txn).await.or_raise(make_error)?;
 
         ForumThreadService::touch_activity(
             ctx,
@@ -323,6 +326,7 @@ impl ForumPostService {
             user_id,
         }: RestoreForumPost,
     ) -> Result<ForumPostModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -361,7 +365,7 @@ impl ForumPostService {
             ..Default::default()
         };
 
-        let post = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let post = model.update(txn).await.or_raise(make_error)?;
 
         ForumThreadService::touch_activity(
             ctx,
@@ -465,6 +469,7 @@ impl ForumPostService {
             max_depth,
         }: GetStructuredForumPosts,
     ) -> Result<Vec<ForumPostNode>> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -504,7 +509,7 @@ impl ForumPostService {
                 .filter(
                     forum_post_revision::Column::ForumPostRevisionId.is_in(revision_ids),
                 )
-                .all(ctx.transaction())
+                .all(txn)
                 .await
                 .or_raise(make_error)?
         };

--- a/deepwell/src/services/forum_post_revision/service.rs
+++ b/deepwell/src/services/forum_post_revision/service.rs
@@ -48,6 +48,7 @@ impl ForumPostRevisionService {
             wikitext,
         }: CreateFirstForumPostRevision,
     ) -> Result<CreateFirstForumPostRevisionOutput> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -93,7 +94,7 @@ impl ForumPostRevisionService {
             forum_post_revision_id,
             revision_number,
             ..
-        } = model.insert(ctx.transaction()).await.or_raise(make_error)?;
+        } = model.insert(txn).await.or_raise(make_error)?;
 
         Ok(CreateFirstForumPostRevisionOutput {
             forum_post_revision_id,
@@ -112,6 +113,7 @@ impl ForumPostRevisionService {
         }: CreateForumPostRevision,
         previous: ForumPostRevisionModel,
     ) -> Result<Option<CreateForumPostRevisionOutput>> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -208,7 +210,7 @@ impl ForumPostRevisionService {
             forum_post_revision_id,
             revision_number,
             ..
-        } = model.insert(ctx.transaction()).await.or_raise(make_error)?;
+        } = model.insert(txn).await.or_raise(make_error)?;
 
         Ok(Some(CreateForumPostRevisionOutput {
             forum_post_revision_id,
@@ -225,6 +227,7 @@ impl ForumPostRevisionService {
             comments,
         }: UpdateForumPostRevision,
     ) -> Result<ForumPostRevisionModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -249,7 +252,7 @@ impl ForumPostRevisionService {
             model.comments = Set(comments);
         }
 
-        let revision = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let revision = model.update(txn).await.or_raise(make_error)?;
         Ok(revision)
     }
 
@@ -391,6 +394,7 @@ impl ForumPostRevisionService {
             limit,
         }: GetForumPostRevisionRange,
     ) -> Result<Vec<ForumPostRevisionModel>> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -436,11 +440,7 @@ impl ForumPostRevisionService {
                     .order_by(forum_post_revision::Column::RevisionNumber, Order::Asc),
             };
 
-        let revisions = query
-            .limit(limit)
-            .all(ctx.transaction())
-            .await
-            .or_raise(make_error)?;
+        let revisions = query.limit(limit).all(txn).await.or_raise(make_error)?;
         Ok(revisions)
     }
 

--- a/deepwell/src/services/forum_thread/service.rs
+++ b/deepwell/src/services/forum_thread/service.rs
@@ -98,6 +98,7 @@ impl ForumThreadService {
                 },
         }: UpdateForumThread,
     ) -> Result<ForumThreadModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -167,7 +168,7 @@ impl ForumThreadService {
             model.sticky = Set(sticky);
         }
 
-        let thread = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let thread = model.update(txn).await.or_raise(make_error)?;
 
         if moved_category {
             // Keep denormalized category/group/site fields in sync for thread descendants.
@@ -181,7 +182,7 @@ impl ForumThreadService {
             forum_post::Entity::update_many()
                 .set(post_model)
                 .filter(forum_post::Column::ForumThreadId.eq(thread.forum_thread_id))
-                .exec(ctx.transaction())
+                .exec(txn)
                 .await
                 .or_raise(make_error)?;
 
@@ -197,7 +198,7 @@ impl ForumThreadService {
                 .filter(
                     forum_post_revision::Column::ForumThreadId.eq(thread.forum_thread_id),
                 )
-                .exec(ctx.transaction())
+                .exec(txn)
                 .await
                 .or_raise(make_error)?;
 
@@ -214,6 +215,7 @@ impl ForumThreadService {
             user_id,
         }: DeleteForumThread,
     ) -> Result<ForumThreadModel> {
+        let txn = ctx.transaction();
         let make_error = || {
             Error::new(
                 format!(
@@ -243,7 +245,7 @@ impl ForumThreadService {
             ..Default::default()
         };
 
-        let thread = model.update(ctx.transaction()).await.or_raise(make_error)?;
+        let thread = model.update(txn).await.or_raise(make_error)?;
         Ok(thread)
     }
 
@@ -272,6 +274,7 @@ impl ForumThreadService {
             )
         })?;
 
+        let txn = ctx.transaction();
         let model = forum_thread::ActiveModel {
             forum_thread_id: Set(thread.forum_thread_id),
             updated_by: Set(user_id),
@@ -279,7 +282,7 @@ impl ForumThreadService {
             ..Default::default()
         };
 
-        let thread = model.update(ctx.transaction()).await.or_raise(|| {
+        let thread = model.update(txn).await.or_raise(|| {
             Error::new(
                 format!(
                     "failed to touch activity for forum thread ID {}",

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
 use super::prelude::*;
 use crate::endpoints::{parent, site};
 use crate::error::{Error, ErrorType};
@@ -117,10 +118,10 @@ impl PermissionService {
         // Validate that the new permission set is a superset of each child's permissions.
         let children = Role::find()
             .filter(
-                role::Column::ParentRoleId
-                    .eq(role.role_id)
-                    .and(role::Column::SiteId.eq(site_id))
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::ParentRoleId.eq(role.role_id))
+                    .add(role::Column::SiteId.eq(site_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await
@@ -130,6 +131,7 @@ impl PermissionService {
             let child_perms = Self::permissions_as_set(ctx, child.role_id)
                 .await
                 .or_raise(make_error)?;
+
             if !child_perms.is_subset(&resolved_permissions) {
                 if !cascade_removals {
                     bail!(Error::new(
@@ -145,7 +147,7 @@ impl PermissionService {
                 } else {
                     info!(
                         "Cascading permission removals to child role ID {} to maintain hierarchy consistency",
-                        child.role_id
+                        child.role_id,
                     );
                     Self::cascade_permission_removals(
                         ctx,
@@ -249,6 +251,7 @@ impl PermissionService {
         let mut permissions = Self::fetch_permissions(ctx, role_id)
             .await
             .or_raise(make_error)?;
+
         if human_readable_categories {
             for perm in &mut permissions {
                 if let Some(Reference::Id(cat_id)) = perm.resource_category {
@@ -310,10 +313,10 @@ impl PermissionService {
         // Get combined permissions for child roles
         let children_roles = Role::find()
             .filter(
-                role::Column::ParentRoleId
-                    .eq(role.role_id)
-                    .and(role::Column::SiteId.eq(site_id))
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::ParentRoleId.eq(role.role_id))
+                    .add(role::Column::SiteId.eq(site_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await
@@ -394,10 +397,13 @@ impl PermissionService {
         };
 
         Ok(RolePermission::find()
-            .filter(role_permission::Column::SiteId.eq(site_id))
-            .filter(role_permission::Column::ResourceType.eq(resource))
-            .filter(category_condition)
-            .filter(role_permission::Column::Action.eq(action))
+            .filter(
+                Condition::all()
+                    .add(role_permission::Column::SiteId.eq(site_id))
+                    .add(role_permission::Column::ResourceType.eq(resource))
+                    .add(category_condition)
+                    .add(role_permission::Column::Action.eq(action)),
+            )
             .all(txn)
             .await
             .or_raise(|| Error::new("Error querying permissions", ErrorType::Permission))?
@@ -655,14 +661,19 @@ impl PermissionService {
                     Reference::Id(id) => Some(*id),
                     _ => None,
                 });
+            let resource_condition = match resource_category_id {
+                Some(id) => role_permission::Column::ResourceCategoryId.eq(id),
+                None => role_permission::Column::ResourceCategoryId.is_null(),
+            };
+
             RolePermission::delete_many()
-                .filter(role_permission::Column::RoleId.eq(child_role_id))
-                .filter(role_permission::Column::ResourceType.eq(perm.resource))
-                .filter(match resource_category_id {
-                    Some(id) => role_permission::Column::ResourceCategoryId.eq(id),
-                    None => role_permission::Column::ResourceCategoryId.is_null(),
-                })
-                .filter(role_permission::Column::Action.eq(perm.action))
+                .filter(
+                    Condition::all()
+                        .add(role_permission::Column::RoleId.eq(child_role_id))
+                        .add(role_permission::Column::ResourceType.eq(perm.resource))
+                        .add(resource_condition)
+                        .add(role_permission::Column::Action.eq(perm.action)),
+                )
                 .exec(txn)
                 .await
                 .or_raise(make_error)?;
@@ -671,10 +682,10 @@ impl PermissionService {
         // Recursively cascade to grandchildren
         let grandchildren = Role::find()
             .filter(
-                role::Column::ParentRoleId
-                    .eq(child_role_id)
-                    .and(role::Column::SiteId.eq(site_id))
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::ParentRoleId.eq(child_role_id))
+                    .add(role::Column::SiteId.eq(site_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await

--- a/deepwell/src/services/role/service.rs
+++ b/deepwell/src/services/role/service.rs
@@ -198,9 +198,9 @@ impl RoleService {
         // Check for child roles
         let child_roles = Role::find()
             .filter(
-                role::Column::ParentRoleId
-                    .eq(role.role_id)
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::ParentRoleId.eq(role.role_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await
@@ -453,11 +453,11 @@ impl RoleService {
             Some(id) => Role::find()
                 .join(JoinType::InnerJoin, role::Relation::UserRole.def())
                 .filter(
-                    user_role::Column::UserId
-                        .eq(id)
-                        .and(role::Column::SiteId.eq(input.site_id))
-                        .and(role::Column::DeletedAt.is_null())
-                        .and(user_role::Column::DeletedAt.is_null()),
+                    Condition::all()
+                        .add(user_role::Column::UserId.eq(id))
+                        .add(role::Column::SiteId.eq(input.site_id))
+                        .add(role::Column::DeletedAt.is_null())
+                        .add(user_role::Column::DeletedAt.is_null()),
                 )
                 .all(txn)
                 .await
@@ -641,9 +641,9 @@ impl RoleService {
         // TODO: Figure out a more efficient way to do this
         let roles: Vec<RoleModel> = Role::find()
             .filter(
-                role::Column::SiteId
-                    .eq(site_id)
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::SiteId.eq(site_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await
@@ -691,9 +691,9 @@ impl RoleService {
 
         let roles = Role::find()
             .filter(
-                role::Column::SiteId
-                    .eq(site_id)
-                    .and(role::Column::DeletedAt.is_null()),
+                Condition::all()
+                    .add(role::Column::SiteId.eq(site_id))
+                    .add(role::Column::DeletedAt.is_null()),
             )
             .all(txn)
             .await


### PR DESCRIPTION
Two formatting changes to how we make Sea-ORM calls for consistency with the rest of the crate:

* Use of `Condition::all()` (`AND`) and `Condition::any` (`OR`) explicitly for `WHERE` clauses.
* Local `txn` variable for getting the transaction.