### PR TITLE
Minor Permission cleanups.

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -32,7 +32,7 @@ use crate::services::file::{
 };
 use crate::services::filter::{CreateFilter, FilterService};
 use crate::services::page::{CreatePage, PageService};
-use crate::services::permission::{PermissionInput, PermissionService};
+use crate::services::permission::PermissionService;
 use crate::services::relation::{
     PageAttributionEntry, PageAttributionKind, PageAttributionMetadata, RelationService,
     SetPageAttributions,
@@ -42,7 +42,7 @@ use crate::services::role::{
 };
 use crate::services::site::{CreateSite, CreateSiteOutput, SiteService, UpdateSiteBody};
 use crate::services::user::{CreateUser, CreateUserOutput, UpdateUserBody, UserService};
-use crate::types::{Action, AliasType, Maybe, Reference, Resource};
+use crate::types::{Action, AliasType, Maybe, Permission, Reference, Resource};
 use crate::utils::now;
 use arrayvec::ArrayVec;
 use sea_orm::{
@@ -574,14 +574,16 @@ pub async fn seed(state: &ServerState) -> Result<()> {
             for perm_spec in &role_template.permissions {
                 let parts = perm_spec.split(':').collect::<ArrayVec<_, 3>>();
                 let input = match parts.as_slice() {
-                    [resource, action] => PermissionInput {
+                    [resource, action] => Permission {
                         resource_type: parse_or_raise!(resource, Resource, make_error),
                         resource_category: None,
                         action: parse_or_raise!(action, Action, make_error),
                     },
-                    [resource, category_slug, action] => PermissionInput {
+                    [resource, category_slug, action] => Permission {
                         resource_type: parse_or_raise!(resource, Resource, make_error),
-                        resource_category: Some(Reference::from(*category_slug)),
+                        resource_category: Some(Reference::Slug(Cow::Borrowed(
+                            category_slug,
+                        ))),
                         action: parse_or_raise!(action, Action, make_error),
                     },
                     _ => {

--- a/deepwell/src/endpoints/role.rs
+++ b/deepwell/src/endpoints/role.rs
@@ -156,7 +156,7 @@ pub async fn role_update_permissions(
 pub async fn get_role_permissions(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
-) -> Result<Vec<Permission>> {
+) -> Result<Vec<Permission<'static>>> {
     let input: GetRolePermissionsInput = parse!(params, Role);
     info!(
         "Getting permissions for role {:?} in site ID {}",
@@ -171,7 +171,7 @@ pub async fn get_role_permissions(
 pub async fn get_decorated_role_permissions(
     ctx: &ServiceContext<'_>,
     params: Params<'static>,
-) -> Result<Vec<DecoratedPermission>> {
+) -> Result<Vec<DecoratedPermission<'static>>> {
     let input: GetRolePermissionsInput = parse!(params, Role);
     info!(
         "Getting permissions for role {:?} in site ID {}",

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -139,8 +139,8 @@ pub enum AuditEvent<'a> {
     UpdatePermissions {
         role_id: i64,
         updating_user_id: i64,
-        old_permissions: Vec<Permission>,
-        new_permissions: Vec<Permission>,
+        old_permissions: Vec<Permission<'static>>,
+        new_permissions: Vec<Permission<'static>>,
     },
 }
 

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -29,14 +29,14 @@ use crate::services::page_revision::{
     CreatePageRevisionBody, CreatePageRevisionOutput, CreateResurrectionPageRevision,
     CreateTombstonePageRevision,
 };
-use crate::services::permission::{
-    CheckPermissionContext, PermissionInput, PermissionService,
-};
+use crate::services::permission::{CheckPermissionContext, PermissionService};
 use crate::services::{
     CategoryService, FilterService, PageRevisionService, SiteService, TextBlockService,
     TextService,
 };
-use crate::types::{Action, PageId, PageOrder, PageRevisionType, Reference, Resource};
+use crate::types::{
+    Action, PageId, PageOrder, PageRevisionType, Permission, Reference, Resource,
+};
 use crate::utils::{get_category_name, trim_default};
 use ftml::layout::Layout;
 use ref_map::*;
@@ -1263,7 +1263,7 @@ impl PageService {
         PermissionService::check_user_can(
             ctx,
             permission_context,
-            PermissionInput {
+            Permission {
                 resource_type: Resource::Page,
                 resource_category: Some(Reference::Id(page_model.page_category_id)),
                 action,

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -28,7 +28,7 @@ use crate::services::ServiceContext;
 use crate::services::audit::{AuditEvent, AuditService};
 use crate::services::permission::resolvers::resolve_category_slug;
 use crate::services::permission::{
-    CheckPermissionContext, PermissionCache, PermissionInput, resolve_category_reference,
+    CheckPermissionContext, PermissionCache, resolve_category_reference,
 };
 use crate::services::role::{
     GetRolePermissionsInput, GetUserRolesInput, RoleService, UpdateRolePermissionsInput,
@@ -71,7 +71,7 @@ impl PermissionService {
         };
 
         // Resolve all category references concurrently before any DB writes.
-        let resolved_permissions: HashSet<Permission> =
+        let resolved_permissions: HashSet<Permission<'static>> =
             try_join_all(new_permissions.into_iter().map(|input| async move {
                 let resource_category_id = match input.resource_category {
                     Some(cat_ref) => {
@@ -86,7 +86,7 @@ impl PermissionService {
                     None => None,
                 };
                 Ok::<_, ExnError>(Permission {
-                    resource: input.resource_type,
+                    resource_type: input.resource_type,
                     resource_category: resource_category_id.map(Reference::Id),
                     action: input.action,
                 })
@@ -183,7 +183,7 @@ impl PermissionService {
                     role_permission::ActiveModel {
                         role_id: Set(role.role_id),
                         site_id: Set(site_id),
-                        resource_type: Set(perm.resource),
+                        resource_type: Set(perm.resource_type),
                         resource_category_id: Set(resource_category_id),
                         action: Set(perm.action),
                         ..Default::default()
@@ -206,7 +206,7 @@ impl PermissionService {
                 old_permissions: deleted_permissions
                     .into_iter()
                     .map(|p| Permission {
-                        resource: p.resource_type,
+                        resource_type: p.resource_type,
                         resource_category: p.resource_category_id.map(Reference::Id),
                         action: p.action,
                     })
@@ -230,7 +230,7 @@ impl PermissionService {
             role_reference,
             human_readable_categories,
         }: GetRolePermissionsInput<'_>,
-    ) -> Result<Vec<Permission>> {
+    ) -> Result<Vec<Permission<'static>>> {
         let role_id = match role_reference {
             Reference::Id(id) => id,
             Reference::Slug(_) => {
@@ -255,11 +255,15 @@ impl PermissionService {
         if human_readable_categories {
             for perm in &mut permissions {
                 if let Some(category_ref) = &perm.resource_category {
-                    perm.resource_category =
-                        resolve_category_slug(ctx, site_id, perm.resource, category_ref)
-                            .await
-                            .or_raise(make_error)?
-                            .map(Reference::Slug);
+                    perm.resource_category = resolve_category_slug(
+                        ctx,
+                        site_id,
+                        perm.resource_type,
+                        category_ref,
+                    )
+                    .await
+                    .or_raise(make_error)?
+                    .map(Reference::Slug);
                 }
             }
         }
@@ -273,7 +277,7 @@ impl PermissionService {
             role_reference,
             human_readable_categories,
         }: GetRolePermissionsInput<'_>,
-    ) -> Result<Vec<DecoratedPermission>> {
+    ) -> Result<Vec<DecoratedPermission<'static>>> {
         let txn = ctx.transaction();
 
         let role = RoleService::get(ctx, site_id, role_reference)
@@ -337,7 +341,7 @@ impl PermissionService {
         };
 
         // Construct universe set from base permissions and optionally scoped permissions
-        let universe: HashSet<Permission> = Permission::ALL
+        let universe: HashSet<Permission<'static>> = Permission::ALL
             .iter()
             .cloned()
             .chain(active_permissions)
@@ -364,7 +368,7 @@ impl PermissionService {
                 && let Some(category_ref) = &perm.resource_category
             {
                 perm.resource_category =
-                    resolve_category_slug(ctx, site_id, perm.resource, category_ref)
+                    resolve_category_slug(ctx, site_id, perm.resource_type, category_ref)
                         .await
                         .or_raise(make_error)?
                         .map(Reference::Slug);
@@ -381,10 +385,10 @@ impl PermissionService {
         Ok(decorated)
     }
 
-    pub async fn check_user_can(
+    pub async fn check_user_can<'a>(
         ctx: &ServiceContext<'_>,
         perm_ctx: &CheckPermissionContext<'_>,
-        input: PermissionInput<'_>,
+        input: Permission<'a>,
     ) -> Result<bool> {
         let [result] = Self::batch_check_user_can(ctx, perm_ctx, [input]).await?;
         Ok(result)
@@ -394,10 +398,10 @@ impl PermissionService {
     ///
     /// Returns an array of booleans corresponding to each permission input.
     /// Results are returned in the same order as the input array, best used with destructuring.
-    pub async fn batch_check_user_can<const N: usize>(
+    pub async fn batch_check_user_can<'a, const N: usize>(
         ctx: &ServiceContext<'_>,
         perm_ctx: &CheckPermissionContext<'_>,
-        permissions: [PermissionInput<'_>; N],
+        permissions: [Permission<'a>; N],
     ) -> Result<[bool; N]> {
         let user_id = perm_ctx.user_id;
         let site_id = perm_ctx.site_id;
@@ -420,8 +424,8 @@ impl PermissionService {
 
         for (
             i,
-            PermissionInput {
-                resource_type,
+            Permission {
+                resource_type: resource,
                 resource_category,
                 action,
             },
@@ -429,17 +433,16 @@ impl PermissionService {
         {
             info!(
                 "Checking permission for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                user_id, site_id, resource_type, resource_category, action,
+                user_id, site_id, resource, resource_category, action,
             );
 
             // Check if this permission is cacheable
-            let cacheable = PermissionCache::is_cacheable(resource_type, action);
+            let cacheable = PermissionCache::is_cacheable(resource, action);
 
             // Resolve category reference to ID for permission checking
             let resource_category_id = match &resource_category {
                 Some(reference) => {
-                    resolve_category_reference(ctx, site_id, resource_type, reference)
-                        .await?
+                    resolve_category_reference(ctx, site_id, resource, reference).await?
                 }
                 None => None,
             };
@@ -450,7 +453,7 @@ impl PermissionService {
                     ctx,
                     Some(site_id),
                     user_id,
-                    resource_type,
+                    resource,
                     resource_category_id,
                     action,
                 )
@@ -461,14 +464,14 @@ impl PermissionService {
                 if let Some(has_permission) = has_permission {
                     info!(
                         "Cache hit for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                        user_id, site_id, resource_type, resource_category, action,
+                        user_id, site_id, resource, resource_category, action,
                     );
                     results[i] = has_permission;
                     continue;
                 } else {
                     info!(
                         "Cache miss for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                        user_id, site_id, resource_type, resource_category, action,
+                        user_id, site_id, resource, resource_category, action,
                     );
                 }
             }
@@ -480,7 +483,7 @@ impl PermissionService {
                 Some(category_id) => Self::check_category_scoped(
                     ctx,
                     site_id,
-                    resource_type,
+                    resource,
                     category_id,
                     action,
                 )
@@ -491,14 +494,14 @@ impl PermissionService {
 
             let has_permission = if has_scoped_permissions {
                 user_permissions.contains(&Permission {
-                    resource: resource_type,
+                    resource_type: resource,
                     resource_category: resource_category_id.map(Reference::Id),
                     action,
                 })
             } else {
                 // If category does not have scoped permissions, fallback to _default
                 user_permissions.contains(&Permission {
-                    resource: resource_type,
+                    resource_type: resource,
                     resource_category: None,
                     action,
                 })
@@ -510,7 +513,7 @@ impl PermissionService {
                     ctx,
                     Some(site_id),
                     user_id,
-                    resource_type,
+                    resource,
                     resource_category_id,
                     action,
                     has_permission,
@@ -530,7 +533,7 @@ impl PermissionService {
     async fn fetch_permissions(
         ctx: &ServiceContext<'_>,
         role_id: i64,
-    ) -> Result<Vec<Permission>> {
+    ) -> Result<Vec<Permission<'static>>> {
         let txn = ctx.transaction();
         let make_error = || {
             Error::new(
@@ -548,7 +551,7 @@ impl PermissionService {
             .or_raise(make_error)?
             .into_iter()
             .map(|p| Permission {
-                resource: p.resource_type,
+                resource_type: p.resource_type,
                 resource_category: p.resource_category_id.map(Reference::Id),
                 action: p.action,
             })
@@ -559,7 +562,7 @@ impl PermissionService {
     pub async fn permissions_as_set(
         ctx: &ServiceContext<'_>,
         role_id: i64,
-    ) -> Result<HashSet<Permission>> {
+    ) -> Result<HashSet<Permission<'static>>> {
         Ok(Self::fetch_permissions(ctx, role_id)
             .await?
             .into_iter()
@@ -571,7 +574,7 @@ impl PermissionService {
         user_id: Option<i64>,
         site_id: i64,
         page_reference: Option<Reference<'_>>,
-    ) -> Result<HashSet<Permission>> {
+    ) -> Result<HashSet<Permission<'static>>> {
         let txn = ctx.transaction();
         let make_error = || {
             Error::new(
@@ -604,7 +607,7 @@ impl PermissionService {
             .or_raise(make_error)?
             .into_iter()
             .map(|p| Permission {
-                resource: p.resource_type,
+                resource_type: p.resource_type,
                 resource_category: p.resource_category_id.map(Reference::Id),
                 action: p.action,
             })
@@ -642,7 +645,7 @@ impl PermissionService {
         ctx: &ServiceContext<'_>,
         site_id: i64,
         child_role_id: i64,
-        removed_permissions: &HashSet<Permission>,
+        removed_permissions: &HashSet<Permission<'static>>,
     ) -> Result<()> {
         let txn = ctx.transaction();
 
@@ -659,7 +662,7 @@ impl PermissionService {
         let child_perms = Self::permissions_as_set(ctx, child_role_id)
             .await
             .or_raise(make_error)?;
-        let to_remove: HashSet<Permission> = child_perms
+        let to_remove: HashSet<Permission<'static>> = child_perms
             .intersection(removed_permissions)
             .cloned()
             .collect();
@@ -680,7 +683,7 @@ impl PermissionService {
                 .filter(
                     Condition::all()
                         .add(role_permission::Column::RoleId.eq(child_role_id))
-                        .add(role_permission::Column::ResourceType.eq(perm.resource))
+                        .add(role_permission::Column::ResourceType.eq(perm.resource_type))
                         .add(resource_condition)
                         .add(role_permission::Column::Action.eq(perm.action)),
                 )

--- a/deepwell/src/services/permission/structs.rs
+++ b/deepwell/src/services/permission/structs.rs
@@ -20,16 +20,9 @@
 
 use crate::types::{Action, Permission, Reference, Resource};
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct PermissionInput<'a> {
-    pub resource_type: Resource,
-    pub resource_category: Option<Reference<'a>>,
-    pub action: Action,
-}
-
 #[derive(Serialize, Debug, Clone)]
-pub struct DecoratedPermission {
-    pub permission: Permission,
+pub struct DecoratedPermission<'a> {
+    pub permission: Permission<'a>,
     pub active: bool,
     pub addable: bool,
     pub removable: bool,

--- a/deepwell/src/services/role/service.rs
+++ b/deepwell/src/services/role/service.rs
@@ -457,7 +457,12 @@ impl RoleService {
                         .add(user_role::Column::UserId.eq(id))
                         .add(role::Column::SiteId.eq(input.site_id))
                         .add(role::Column::DeletedAt.is_null())
-                        .add(user_role::Column::DeletedAt.is_null()),
+                        .add(user_role::Column::DeletedAt.is_null())
+                        .add(
+                            Condition::any()
+                                .add(user_role::Column::ExpiresAt.is_null())
+                                .add(user_role::Column::ExpiresAt.gt(now())),
+                        ),
                 )
                 .all(txn)
                 .await

--- a/deepwell/src/services/role/structs.rs
+++ b/deepwell/src/services/role/structs.rs
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-use crate::services::permission::PermissionInput;
 use crate::types::{Maybe, Permission, Reference};
 use std::net::IpAddr;
 use time::OffsetDateTime;
@@ -65,7 +64,7 @@ pub struct UpdateRoleInput {
 pub struct UpdateRolePermissionsInput<'a> {
     pub site_id: i64,
     pub role_reference: Reference<'a>,
-    pub new_permissions: Vec<PermissionInput<'a>>,
+    pub new_permissions: Vec<Permission<'a>>,
     pub cascade_removals: bool,
     pub updating_user_id: i64,
     pub ip_address: IpAddr,

--- a/deepwell/src/services/view/service.rs
+++ b/deepwell/src/services/view/service.rs
@@ -35,9 +35,7 @@ use crate::models::page_revision::Model as PageRevisionModel;
 use crate::models::site::Model as SiteModel;
 use crate::services::blueprint::{BlueprintPageType, GetBlueprintPageOutput};
 use crate::services::page_revision::RerenderType;
-use crate::services::permission::{
-    CheckPermissionContext, PermissionInput, PermissionService,
-};
+use crate::services::permission::{CheckPermissionContext, PermissionService};
 use crate::services::relation::{
     GetPageAttributions, GetSiteBan, PageAttribution, RelationService,
 };
@@ -48,7 +46,7 @@ use crate::services::{
     BlueprintPageService, CategoryService, DomainService, PageRevisionService,
     PageService, SessionService, SiteService, TextService, UserService,
 };
-use crate::types::{Action, PageId, RerenderDepth, Resource};
+use crate::types::{Action, PageId, Permission, RerenderDepth, Resource};
 use crate::utils::{parse_locales, split_category};
 use ftml::prelude::*;
 use ftml::render::html::HtmlOutput;
@@ -218,12 +216,12 @@ impl ViewService {
                             page_reference: None,
                         },
                         [
-                            PermissionInput {
+                            Permission {
                                 resource_type: Resource::Page,
                                 resource_category: category_id.map(Reference::Id),
                                 action: Action::View,
                             },
-                            PermissionInput {
+                            Permission {
                                 resource_type: Resource::Page,
                                 resource_category: category_id.map(Reference::Id),
                                 action: Action::Edit,
@@ -595,7 +593,7 @@ impl ViewService {
                 site_id,
                 page_reference: None,
             },
-            PermissionInput {
+            Permission {
                 resource_type: Resource::Site,
                 resource_category: None,
                 action: Action::Edit,

--- a/deepwell/src/types/permissions.rs
+++ b/deepwell/src/types/permissions.rs
@@ -36,13 +36,13 @@ impl std::fmt::Display for PermissionParseError {
 impl std::error::Error for PermissionParseError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub struct Permission {
-    pub resource: Resource,
-    pub resource_category: Option<Reference<'static>>,
+pub struct Permission<'a> {
+    pub resource_type: Resource,
+    pub resource_category: Option<Reference<'a>>,
     pub action: Action,
 }
 
-impl FromStr for Permission {
+impl FromStr for Permission<'static> {
     type Err = PermissionParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -67,8 +67,10 @@ impl FromStr for Permission {
         };
 
         Ok(Self {
-            resource: Resource::from_str(resource).map_err(|_| PermissionParseError {
-                message: format!("invalid resource type: '{}'", resource),
+            resource_type: Resource::from_str(resource).map_err(|_| {
+                PermissionParseError {
+                    message: format!("invalid resource type: '{}'", resource),
+                }
             })?,
             resource_category,
             action: Action::from_str(action).map_err(|_| PermissionParseError {
@@ -81,18 +83,18 @@ impl FromStr for Permission {
 /// Macro for generating a list of all valid Permission types, for iteration/validation purposes.
 macro_rules! define_permission_types {
     ( $( $resource:ident => [ $($action:ident),+ $(,)? ] ),+ $(,)? ) => {
-        impl Permission {
-            pub const ALL: &[Permission] = &[
+        impl Permission<'static> {
+            pub const ALL: &[Permission<'static>] = &[
                 $($(
-                    Permission { resource: Resource::$resource, resource_category: None, action: Action::$action },
+                    Permission { resource_type: Resource::$resource, resource_category: None, action: Action::$action },
                 )+)+
             ];
 
-            pub const fn new(resource: Resource, action: Action) -> Option<Permission> {
+            pub const fn new(resource: Resource, action: Action) -> Option<Permission<'static>> {
                 match (resource, action) {
                     $($(
                         (Resource::$resource, Action::$action) => {
-                            Some(Permission { resource, resource_category: None, action })
+                            Some(Permission { resource_type: Resource::$resource, resource_category: None, action })
                         }
                     )+)+
                     _ => None,

--- a/deepwell/tests/permission.rs
+++ b/deepwell/tests/permission.rs
@@ -27,14 +27,14 @@ use deepwell::license::License;
 use deepwell::services::ServiceContext;
 use deepwell::services::category::CategoryService;
 use deepwell::services::permission::{
-    CheckPermissionContext, DecoratedPermission, PermissionInput, PermissionService,
+    CheckPermissionContext, DecoratedPermission, PermissionService,
 };
 use deepwell::services::role::{
     GrantUserRoleInput, InternalCreateRoleInput, RoleService, UpdateRolePermissionsInput,
 };
 use deepwell::services::site::{CreateSite, SiteService};
 use deepwell::services::user::{CreateUser, UserService};
-use deepwell::types::{Action, Reference, Resource, UserType};
+use deepwell::types::{Action, Permission, Reference, Resource, UserType};
 use serde_json::json;
 use std::sync::atomic::{AtomicU64, Ordering};
 use str_macro::str;
@@ -100,12 +100,12 @@ impl PermissionFixture {
             site_id,
             role_a,
             vec![
-                PermissionInput {
+                Permission {
                     resource_type: Resource::Page,
                     resource_category: None,
                     action: Action::View,
                 },
-                PermissionInput {
+                Permission {
                     resource_type: Resource::Page,
                     resource_category: None,
                     action: Action::Edit,
@@ -120,7 +120,7 @@ impl PermissionFixture {
             ctx,
             site_id,
             role_b,
-            vec![PermissionInput {
+            vec![Permission {
                 resource_type: Resource::Page,
                 resource_category: Some(Reference::Id(category_id)),
                 action: Action::Edit,
@@ -176,7 +176,7 @@ async fn add_perms_to_role(
     ctx: &ServiceContext<'_>,
     site_id: i64,
     role_id: i64,
-    permissions: Vec<PermissionInput<'static>>,
+    permissions: Vec<Permission<'static>>,
 ) {
     PermissionService::update_permissions_for_role(
         ctx,
@@ -245,7 +245,7 @@ async fn check(
             site_id,
             page_reference: None,
         },
-        PermissionInput {
+        Permission {
             resource_type: resource,
             resource_category: category_id.map(Reference::Id),
             action,
@@ -262,7 +262,7 @@ async fn batch_check<const N: usize>(
     site_id: i64,
     perms: [(Resource, Option<i64>, Action); N],
 ) -> [bool; N] {
-    let inputs = perms.map(|(resource, category_id, action)| PermissionInput {
+    let inputs = perms.map(|(resource, category_id, action)| Permission {
         resource_type: resource,
         resource_category: category_id.map(Reference::Id),
         action,
@@ -449,7 +449,7 @@ async fn check_category_resolution() {
                 site_id: f.site_id,
                 page_reference: None
             },
-            PermissionInput {
+            Permission {
                 resource_type: Resource::Page,
                 resource_category: Some(Reference::from(TEST_CATEGORY_NAME)),
                 action: Action::Edit,
@@ -587,12 +587,12 @@ async fn role_update_permissions_and_get() {
             site_id: f.site_id,
             role_reference: Reference::Id(role.role_id),
             new_permissions: vec![
-                PermissionInput {
+                Permission {
                     resource_type: Resource::Page,
                     resource_category: Some(Reference::Slug(CATEGORY_NAME.into())),
                     action: Action::View,
                 },
-                PermissionInput {
+                Permission {
                     resource_type: Resource::Page,
                     resource_category: Some(Reference::Slug(OTHER_CATEGORY_NAME.into())),
                     action: Action::Edit,
@@ -682,12 +682,12 @@ async fn get_decorated_permissions_for_role() {
         f.site_id,
         parent_id,
         vec![
-            PermissionInput {
+            Permission {
                 resource_type: Resource::Page,
                 resource_category: None,
                 action: Action::View,
             },
-            PermissionInput {
+            Permission {
                 resource_type: Resource::Page,
                 resource_category: None,
                 action: Action::Edit,
@@ -702,7 +702,7 @@ async fn get_decorated_permissions_for_role() {
         ctx,
         f.site_id,
         child_id,
-        vec![PermissionInput {
+        vec![Permission {
             resource_type: Resource::Page,
             resource_category: None,
             action: Action::View,
@@ -711,9 +711,13 @@ async fn get_decorated_permissions_for_role() {
     .await;
 
     // Helper to find a permission in the list
-    let find = |list: &Vec<DecoratedPermission>, resource: Resource, action: Action| {
+    let find = |list: &Vec<DecoratedPermission<'static>>,
+                resource: Resource,
+                action: Action| {
         list.iter()
-            .find(|d| d.permission.resource == resource && d.permission.action == action)
+            .find(|d| {
+                d.permission.resource_type == resource && d.permission.action == action
+            })
             .unwrap_or_else(|| panic!("Permission {resource}:{action} not found"))
             .clone()
     };

--- a/deepwell/tests/role.rs
+++ b/deepwell/tests/role.rs
@@ -22,6 +22,7 @@
 mod common;
 
 use deepwell::services::role::{InternalCreateRoleInput, RoleService};
+use deepwell::utils::now;
 use std::sync::atomic::{AtomicU64, Ordering};
 use str_macro::str;
 
@@ -463,6 +464,48 @@ async fn grant_and_revoke_role() {
         user_roles.len(),
         0,
         "User should have no roles after revocation"
+    );
+}
+
+#[tokio::test]
+async fn role_grant_expiration() {
+    let runner = TestRunner::setup().await;
+    let f = RoleFixture::setup(&runner).await;
+
+    let role = create_role(&runner, f.site_id, "Member", None).await;
+
+    // Grant the role with expired date
+    let expired = run_endpoint!(
+        runner,
+        grant_role_to_user,
+        json!({
+            "site_id": f.site_id,
+            "user_id": f.user_id,
+            "role_id": role.role_id,
+            "assigning_user_id": SYSTEM_USER_ID,
+            "expires_at": now().to_string(),
+            "ip_address": common::IP_ADDRESS,
+        }),
+    );
+
+    assert!(
+        expired.expires_at.is_some(),
+        "Expired role should have expires_at timestamp set"
+    );
+
+    // Verify that the expired role does not show up in the user's roles
+    let user_roles = run_endpoint!(
+        runner,
+        get_user_roles,
+        json!({
+            "site_id": f.site_id,
+            "user_id": f.user_id,
+        }),
+    );
+    assert_eq!(
+        user_roles.len(),
+        0,
+        "Expired role should not show up in user's roles"
     );
 }
 


### PR DESCRIPTION
Some minor cleanups. Consolidated `Permission` and `PermissionInput` since their shapes have pretty much converged.

Also add a check in fetching `UserRole`s to skip expired role grants, added test.