### PR TITLE
Update node version in actions

### DIFF
--- a/.github/workflows/framerail.yaml
+++ b/.github/workflows/framerail.yaml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/framerail/pnpm-workspace.yaml
+++ b/framerail/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true
+  svelte-preprocess: true


### PR DESCRIPTION
Updating node version in Github Actions to v24, since v20 reached EOL in April 2026 and breaking the framerail lint workflow.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/