### PR TITLE
[Enhancement] Consolidating request context propagation

### DIFF
--- a/deepwell/src/endpoints/page.rs
+++ b/deepwell/src/endpoints/page.rs
@@ -235,31 +235,19 @@ pub async fn page_edit_permission(
     ctx: &ServiceContext<'_>,
     _params: Params<'static>,
 ) -> Result<PageEditPermissionOutput> {
-    let request_ctx = ctx.request();
-    let make_error =
-        || Error::new("failed to check page edit permission", ErrorType::Page);
-
-    // Extract necessary fields from request context.
-    let user_id = request_ctx.user_id().ok();
-    let page_reference = request_ctx.page_reference().ok();
-    let site_id = request_ctx.site_id().or_raise(make_error)?;
-
-    info!(
-        "Checking edit permission for page {:?} in site ID {:?}",
-        page_reference, site_id
-    );
-
     let can_edit = PageService::check_user_permission(
         ctx,
+        // TODO: Permission context is no longer used, just left here to not break other functions.
+        // Remove this when it's removed from the function signature.
         &CheckPermissionContext {
-            user_id,
-            site_id,
-            page_reference: page_reference.cloned(),
+            user_id: None,
+            site_id: -1,
+            page_reference: None,
         },
         Action::Edit,
     )
     .await
-    .or_raise(make_error)?;
+    .or_raise(|| Error::new("failed to check page edit permission", ErrorType::Page))?;
 
     Ok(PageEditPermissionOutput { can_edit })
 }

--- a/deepwell/src/middleware.rs
+++ b/deepwell/src/middleware.rs
@@ -80,6 +80,7 @@ where
             .get("X-Deepwell-Page")
             .and_then(|v| v.to_str().ok())
             .map(|s| {
+                // TODO: Figure out if this can cause a bug: if the slug is a number, it will be parsed as an ID instead of a slug.
                 s.parse::<i64>()
                     .map(Reference::Id)
                     .unwrap_or_else(|_| Reference::Slug(Cow::Owned(s.to_owned())))

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -111,7 +111,7 @@ impl<'txn> ServiceContext<'txn> {
 
     #[inline]
     /// Internal method to update the request context, for use in testing only.
-    pub fn _set_request(&mut self, request_ctx: RequestContext) {
+    pub fn set_request_for_test(&mut self, request_ctx: RequestContext) {
         self.request_ctx = request_ctx;
 
         // Clear cached permissions since the user context has changed.
@@ -198,8 +198,10 @@ impl<'txn> ServiceContext<'txn> {
             || Error::new("Failed to check user permissions", ErrorType::Permission);
 
         let perms = self.user_permissions().await.or_raise(make_error)?;
-        PermissionService::_has_permission(self, user_id, perms, site_id, permission)
-            .await
-            .or_raise(make_error)
+        PermissionService::permission_in_set_helper(
+            self, user_id, perms, site_id, permission,
+        )
+        .await
+        .or_raise(make_error)
     }
 }

--- a/deepwell/src/services/context.rs
+++ b/deepwell/src/services/context.rs
@@ -24,12 +24,15 @@ use crate::error::prelude::*;
 use crate::locales::Localizations;
 use crate::models::session::Model as SessionModel;
 use crate::services::blob::MimeAnalyzer;
-use crate::types::Reference;
+use crate::services::permission::PermissionService;
+use crate::types::{Permission, Reference};
 use redis::aio::MultiplexedConnection as RedisMultiplexedConnection;
 use rsmq_async::Rsmq;
 use s3::bucket::Bucket;
 use sea_orm::DatabaseTransaction;
+use std::collections::HashSet;
 use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 /// Per-request context derived from HTTP headers by the middleware layer.
 #[derive(Debug, Clone, Default)]
@@ -76,11 +79,12 @@ impl RequestContext {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ServiceContext<'txn> {
     state: ServerState,
     transaction: &'txn DatabaseTransaction,
     request_ctx: RequestContext,
+    user_permissions: OnceCell<HashSet<Permission<'static>>>,
 }
 
 impl<'txn> ServiceContext<'txn> {
@@ -93,6 +97,7 @@ impl<'txn> ServiceContext<'txn> {
             state: Arc::clone(state),
             transaction,
             request_ctx: RequestContext::default(),
+            user_permissions: OnceCell::new(),
         }
     }
 
@@ -105,8 +110,12 @@ impl<'txn> ServiceContext<'txn> {
     }
 
     #[inline]
-    pub fn set_request(&mut self, request_ctx: RequestContext) {
+    /// Internal method to update the request context, for use in testing only.
+    pub fn _set_request(&mut self, request_ctx: RequestContext) {
         self.request_ctx = request_ctx;
+
+        // Clear cached permissions since the user context has changed.
+        self.user_permissions = OnceCell::new();
     }
 
     // Getters
@@ -158,5 +167,39 @@ impl<'txn> ServiceContext<'txn> {
     #[inline]
     pub fn request(&self) -> &RequestContext {
         &self.request_ctx
+    }
+
+    pub async fn user_permissions(&self) -> Result<&HashSet<Permission<'static>>> {
+        // Lazily fetch and cache user permissions for the duration of the request.
+        self.user_permissions
+            .get_or_try_init(|| async {
+                let user_id = self.request_ctx.user_id;
+                let site_id = self.request_ctx.site_id()?;
+                let page_reference = self.request_ctx.page_reference.clone();
+
+                PermissionService::get_permissions_for_user(
+                    self,
+                    user_id,
+                    site_id,
+                    page_reference,
+                )
+                .await
+                .or_raise(|| {
+                    Error::new("Failed to fetch user permissions", ErrorType::Permission)
+                })
+            })
+            .await
+    }
+
+    pub async fn user_has_permission(&self, permission: Permission<'_>) -> Result<bool> {
+        let user_id = self.request_ctx.user_id;
+        let site_id = self.request_ctx.site_id()?;
+        let make_error =
+            || Error::new("Failed to check user permissions", ErrorType::Permission);
+
+        let perms = self.user_permissions().await.or_raise(make_error)?;
+        PermissionService::_has_permission(self, user_id, perms, site_id, permission)
+            .await
+            .or_raise(make_error)
     }
 }

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -1243,32 +1243,29 @@ impl PageService {
 
     pub async fn check_user_permission(
         ctx: &ServiceContext<'_>,
-        permission_context: &CheckPermissionContext<'_>,
+        _permission_context: &CheckPermissionContext<'_>,
         action: Action,
     ) -> Result<bool> {
         let make_error =
             || Error::new("failed to check user permissions for page", ErrorType::Page);
 
-        let page_ref = match permission_context.page_reference {
-            Some(ref page_reference) => page_reference,
-            None => {
-                bail!(make_error());
-            }
-        };
+        let page_ref = ctx.request().page_reference().or_raise(make_error)?;
+        let site_id = ctx.request().site_id().or_raise(make_error)?;
 
-        let page_model = Self::get(ctx, permission_context.site_id, page_ref.clone())
+        info!(
+            "Checking edit permission for page {:?} in site ID {:?}",
+            page_ref, site_id
+        );
+
+        let page_model = Self::get(ctx, site_id, page_ref.clone())
             .await
             .or_raise(make_error)?;
 
-        PermissionService::check_user_can(
-            ctx,
-            permission_context,
-            Permission {
-                resource_type: Resource::Page,
-                resource_category: Some(Reference::Id(page_model.page_category_id)),
-                action,
-            },
-        )
+        ctx.user_has_permission(Permission {
+            resource_type: Resource::Page,
+            resource_category: Some(Reference::Id(page_model.page_category_id)),
+            action,
+        })
         .await
         .or_raise(make_error)
     }

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -423,7 +423,7 @@ impl PermissionService {
         let mut results = [false; N];
 
         for (i, permission) in permissions.into_iter().enumerate() {
-            results[i] = Self::_has_permission(
+            results[i] = Self::permission_in_set_helper(
                 ctx,
                 user_id,
                 &user_permissions,
@@ -438,7 +438,7 @@ impl PermissionService {
     }
 
     /// Helper function to check if a permission is present in (the user's) permission set.
-    pub async fn _has_permission(
+    pub(crate) async fn permission_in_set_helper(
         ctx: &ServiceContext<'_>,
         user_id: Option<i64>,
         user_permissions: &HashSet<Permission<'static>>,

--- a/deepwell/src/services/permission/service.rs
+++ b/deepwell/src/services/permission/service.rs
@@ -422,110 +422,123 @@ impl PermissionService {
 
         let mut results = [false; N];
 
-        for (
-            i,
-            Permission {
-                resource_type: resource,
-                resource_category,
-                action,
-            },
-        ) in permissions.into_iter().enumerate()
-        {
-            info!(
-                "Checking permission for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                user_id, site_id, resource, resource_category, action,
-            );
-
-            // Check if this permission is cacheable
-            let cacheable = PermissionCache::is_cacheable(resource, action);
-
-            // Resolve category reference to ID for permission checking
-            let resource_category_id = match &resource_category {
-                Some(reference) => {
-                    resolve_category_reference(ctx, site_id, resource, reference).await?
-                }
-                None => None,
-            };
-
-            if cacheable {
-                // Check if this permission has been cached
-                let has_permission = PermissionCache::check_user_permission(
-                    ctx,
-                    Some(site_id),
-                    user_id,
-                    resource,
-                    resource_category_id,
-                    action,
-                )
-                .await
-                .or_raise(make_error)?;
-
-                // If we have a cached result, use it
-                if let Some(has_permission) = has_permission {
-                    info!(
-                        "Cache hit for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                        user_id, site_id, resource, resource_category, action,
-                    );
-                    results[i] = has_permission;
-                    continue;
-                } else {
-                    info!(
-                        "Cache miss for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
-                        user_id, site_id, resource, resource_category, action,
-                    );
-                }
-            }
-
-            // If permission is not cacheable, or is not cached, compute it fresh
-
-            // Does this category have permissions scoped to it?
-            let has_scoped_permissions = match resource_category_id {
-                Some(category_id) => Self::check_category_scoped(
-                    ctx,
-                    site_id,
-                    resource,
-                    category_id,
-                    action,
-                )
-                .await
-                .or_raise(make_error)?,
-                None => false,
-            };
-
-            let has_permission = if has_scoped_permissions {
-                user_permissions.contains(&Permission {
-                    resource_type: resource,
-                    resource_category: resource_category_id.map(Reference::Id),
-                    action,
-                })
-            } else {
-                // If category does not have scoped permissions, fallback to _default
-                user_permissions.contains(&Permission {
-                    resource_type: resource,
-                    resource_category: None,
-                    action,
-                })
-            };
-
-            // Cache result if cacheable
-            if cacheable {
-                PermissionCache::set_user_permission(
-                    ctx,
-                    Some(site_id),
-                    user_id,
-                    resource,
-                    resource_category_id,
-                    action,
-                    has_permission,
-                )
-                .await
-                .or_raise(make_error)?;
-            }
-
-            results[i] = has_permission;
+        for (i, permission) in permissions.into_iter().enumerate() {
+            results[i] = Self::_has_permission(
+                ctx,
+                user_id,
+                &user_permissions,
+                site_id,
+                permission,
+            )
+            .await
+            .or_raise(make_error)?;
         }
 
         Ok(results)
+    }
+
+    /// Helper function to check if a permission is present in (the user's) permission set.
+    pub async fn _has_permission(
+        ctx: &ServiceContext<'_>,
+        user_id: Option<i64>,
+        user_permissions: &HashSet<Permission<'static>>,
+        site_id: i64,
+        Permission {
+            resource_type: resource,
+            resource_category,
+            action,
+        }: Permission<'_>,
+    ) -> Result<bool> {
+        let make_error =
+            || Error::new("failed to check permission", ErrorType::Permission);
+
+        info!(
+            "Checking permission for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+            user_id, site_id, resource, resource_category, action,
+        );
+
+        // Check if this permission is cacheable
+        let cacheable = PermissionCache::is_cacheable(resource, action);
+
+        // Resolve category reference to ID for permission checking
+        let resource_category_id = match &resource_category {
+            Some(reference) => {
+                resolve_category_reference(ctx, site_id, resource, reference).await?
+            }
+            None => None,
+        };
+
+        if cacheable {
+            // Check if this permission has been cached
+            let has_permission = PermissionCache::check_user_permission(
+                ctx,
+                Some(site_id),
+                user_id,
+                resource,
+                resource_category_id,
+                action,
+            )
+            .await
+            .or_raise(make_error)?;
+
+            // If we have a cached result, use it
+            if let Some(has_permission) = has_permission {
+                info!(
+                    "Cache hit for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+                    user_id, site_id, resource, resource_category, action,
+                );
+                return Ok(has_permission);
+            } else {
+                info!(
+                    "Cache miss for user ID {:?} on site ID {} for resource {} of category {:?} with action {}",
+                    user_id, site_id, resource, resource_category, action,
+                );
+            }
+        }
+
+        // If permission is not cacheable, or is not cached, compute it fresh
+
+        // Does this category have permissions scoped to it?
+        let has_scoped_permissions = match resource_category_id {
+            Some(category_id) => {
+                Self::check_category_scoped(ctx, site_id, resource, category_id, action)
+                    .await
+                    .or_raise(make_error)?
+            }
+            None => false,
+        };
+
+        let has_permission = if has_scoped_permissions {
+            user_permissions.contains(&Permission {
+                resource_type: resource,
+                resource_category: resource_category_id.map(Reference::Id),
+                action,
+            })
+        } else {
+            // If category does not have scoped permissions, fallback to _default
+            user_permissions.contains(&Permission {
+                resource_type: resource,
+                resource_category: None,
+                action,
+            })
+        };
+
+        // Cache result if cacheable
+        if cacheable {
+            PermissionCache::set_user_permission(
+                ctx,
+                Some(site_id),
+                user_id,
+                resource,
+                resource_category_id,
+                action,
+                has_permission,
+            )
+            .await
+            .or_raise(make_error)?;
+        }
+
+        Ok(has_permission)
     }
 
     /// Fetches permissions for `role_id`.
@@ -569,7 +582,7 @@ impl PermissionService {
             .collect())
     }
 
-    async fn get_permissions_for_user(
+    pub async fn get_permissions_for_user(
         ctx: &ServiceContext<'_>,
         user_id: Option<i64>,
         site_id: i64,

--- a/deepwell/tests/common/runner.rs
+++ b/deepwell/tests/common/runner.rs
@@ -127,6 +127,6 @@ impl TestRunner {
 
     #[allow(unused)]
     pub fn set_request_context(&mut self, req_ctx: RequestContext) {
-        self.with_dependent_mut(|_owner, ctx| ctx._set_request(req_ctx));
+        self.with_dependent_mut(|_owner, ctx| ctx.set_request_for_test(req_ctx));
     }
 }

--- a/deepwell/tests/common/runner.rs
+++ b/deepwell/tests/common/runner.rs
@@ -127,6 +127,6 @@ impl TestRunner {
 
     #[allow(unused)]
     pub fn set_request_context(&mut self, req_ctx: RequestContext) {
-        self.with_dependent_mut(|_owner, ctx| ctx.set_request(req_ctx));
+        self.with_dependent_mut(|_owner, ctx| ctx._set_request(req_ctx));
     }
 }

--- a/deepwell/tests/page.rs
+++ b/deepwell/tests/page.rs
@@ -24,12 +24,13 @@ mod common;
 use self::common::TestRunner;
 use deepwell::constants::ADMIN_USER_ID;
 use deepwell::error::prelude::*;
-use deepwell::types::PageRevisionType;
+use deepwell::services::RequestContext;
+use deepwell::types::{PageRevisionType, Reference};
 use serde_json::json;
 
 #[tokio::test]
 async fn basic_edit() {
-    let runner = TestRunner::setup().await;
+    let mut runner = TestRunner::setup().await;
 
     const SITE_SLUG: &str = "test";
     const PAGE_SLUG: &str = "my-page";
@@ -41,6 +42,15 @@ async fn basic_edit() {
 
     let site_id = output.site.site_id;
     assert_eq!(output.site.slug, SITE_SLUG, "Site slug doesn't match");
+
+    // Set request context to populate params for the internal permission check.
+    // TODO: Figure out a better way to handle this gap.
+    runner.set_request_context(RequestContext {
+        session: None,
+        user_id: Some(ADMIN_USER_ID),
+        site_id: Some(site_id),
+        page_reference: Some(Reference::Slug(PAGE_SLUG.into())),
+    });
 
     // Create page
 
@@ -173,7 +183,7 @@ async fn basic_edit() {
 
 #[tokio::test]
 async fn basic_move() {
-    let runner = TestRunner::setup().await;
+    let mut runner = TestRunner::setup().await;
 
     const SITE_SLUG: &str = "test";
     const PAGE_SLUG_1: &str = "alpha";
@@ -186,6 +196,14 @@ async fn basic_move() {
 
     let site_id = output.site.site_id;
     assert_eq!(output.site.slug, SITE_SLUG, "Site slug doesn't match");
+
+    // Set request context to populate params for the internal permission check.
+    runner.set_request_context(RequestContext {
+        session: None,
+        user_id: Some(ADMIN_USER_ID),
+        site_id: Some(site_id),
+        page_reference: Some(Reference::Slug(PAGE_SLUG_1.into())),
+    });
 
     // Create page
 
@@ -287,6 +305,12 @@ async fn basic_move() {
     assert_contains_error!(error, ErrorType::PageNotFound);
 
     // Page edit (success)
+    runner.set_request_context(RequestContext {
+        session: None,
+        user_id: Some(ADMIN_USER_ID),
+        site_id: Some(site_id),
+        page_reference: Some(Reference::Slug(PAGE_SLUG_2.into())),
+    });
 
     let output = run_endpoint!(
         runner,

--- a/deepwell/tests/page.rs
+++ b/deepwell/tests/page.rs
@@ -44,7 +44,6 @@ async fn basic_edit() {
     assert_eq!(output.site.slug, SITE_SLUG, "Site slug doesn't match");
 
     // Set request context to populate params for the internal permission check.
-    // TODO: Figure out a better way to handle this gap.
     runner.set_request_context(RequestContext {
         session: None,
         user_id: Some(ADMIN_USER_ID),

--- a/framerail/src/app.d.ts
+++ b/framerail/src/app.d.ts
@@ -170,5 +170,9 @@ declare global {
       [anyError: any]: unknown
     }
     // interface Platform {}
+
+    interface Locals {
+      requestContext: RequestContext
+    }
   }
 }

--- a/framerail/src/hooks.server.ts
+++ b/framerail/src/hooks.server.ts
@@ -1,0 +1,20 @@
+// Hook that runs on every request, including form actions.
+
+import { storeRequestContext } from "$lib/server/load/request-ctx"
+import { loadSiteInfo } from "$lib/server/load/site-info"
+import type { Handle } from "@sveltejs/kit"
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const { request, cookies, locals, params } = event
+
+  // Gather common request metadata into a shared context.
+  const { siteId } = loadSiteInfo(request.headers)
+  const page_slug = params.slug
+  const sessionToken = cookies.get("wikijump_token")
+
+  storeRequestContext(locals, sessionToken, siteId, page_slug)
+
+  // Continue processing the request
+  const response = await resolve(event)
+  return response
+}

--- a/framerail/src/lib/server/deepwell/index.ts
+++ b/framerail/src/lib/server/deepwell/index.ts
@@ -4,18 +4,11 @@ import { JSONRPCClient } from "json-rpc-2.0"
 
 import type { Nullable } from "$lib/types"
 import type { JSONRPCRequest } from "json-rpc-2.0"
+import type { RequestContext } from "../load/request-ctx"
 
 export const DEEPWELL_HOST = process.env.DEEPWELL_HOST || "localhost"
 export const DEEPWELL_PORT = process.env.DEEPWELL_PORT || 2747
 export const DEEPWELL_URL = `http://${DEEPWELL_HOST}:${DEEPWELL_PORT}/jsonrpc`
-
-interface RequestContextOptional {
-  sessionToken?: string
-  siteId?: number
-  page?: string | number
-}
-
-export type RequestContext = RequestContextOptional | void
 
 export const client = new JSONRPCClient<RequestContext>(processRawRequest)
 

--- a/framerail/src/lib/server/deepwell/page.ts
+++ b/framerail/src/lib/server/deepwell/page.ts
@@ -1,6 +1,6 @@
 import defaults from "$lib/defaults"
 
-import { client, type RequestContext } from "$lib/server/deepwell"
+import { client } from "$lib/server/deepwell"
 import { Layout } from "$lib/types"
 
 import type {
@@ -10,6 +10,7 @@ import type {
   PageVoteModel,
   ParseError
 } from "$lib/types"
+import type { RequestContext } from "../load/request-ctx"
 
 /* ----- Page Delete ----- */
 interface PageDelete {

--- a/framerail/src/lib/server/load/page.ts
+++ b/framerail/src/lib/server/load/page.ts
@@ -52,7 +52,7 @@ import {
 import type { PageView, PreloadDataAsync } from "$lib/server/deepwell/views"
 import type { Optional, TranslateKeys } from "$lib/types"
 import type { Cookies, RequestEvent } from "@sveltejs/kit"
-import type { RequestContext } from "../deepwell"
+import { getRequestContext } from "./request-ctx"
 
 export async function loadPage(
   slug: Optional<string>,
@@ -367,26 +367,9 @@ const pageDeleteSchema = variant("option", [
 ])
 
 /* ----- Page Edit Check Permission ----- */
-export async function pageEditPermissionAction({
-  request,
-  params,
-  cookies
-}: RequestEvent) {
-  const requestData: { siteId: number; pageId: number } = await request.json()
-
-  const sessionToken = cookies.get("wikijump_token")
-
+export async function pageEditPermissionAction({ locals }: RequestEvent) {
   try {
-    const { siteId, pageId } = requestData
-    const { slug } = params
-
-    const requestContext: RequestContext = {
-      sessionToken,
-      siteId,
-      page: pageId || slug
-    }
-
-    const res = await pageEditPermission(requestContext)
+    const res = await pageEditPermission(getRequestContext(locals))
     return { res }
   } catch (e) {
     const error = e as DeepwellError

--- a/framerail/src/lib/server/load/request-ctx.ts
+++ b/framerail/src/lib/server/load/request-ctx.ts
@@ -1,0 +1,26 @@
+// Helper functions and types for request context, a set of common metadata for each request to Deepwell.
+
+interface RequestContextOptional {
+  sessionToken?: string
+  siteId?: number
+  page?: string | number
+}
+
+export type RequestContext = RequestContextOptional | void
+
+export function storeRequestContext(
+  locals: App.Locals,
+  sessionToken?: string,
+  siteId?: number,
+  page?: string | number
+) {
+  locals.requestContext = {
+    sessionToken,
+    siteId,
+    page
+  }
+}
+
+export function getRequestContext(locals: App.Locals): RequestContext {
+  return locals.requestContext
+}

--- a/framerail/src/routes/[slug]/[...extra]/page.svelte
+++ b/framerail/src/routes/[slug]/[...extra]/page.svelte
@@ -33,10 +33,7 @@
     // Check edit permission first
     const res = await fetch("?/editPermission", {
       method: "POST",
-      body: JSON.stringify({
-        siteId: data.site.site_id,
-        pageId: data.page?.page_id
-      })
+      body: ""
     }).then((res) => res.text())
 
     const result = deserialize<


### PR DESCRIPTION
Following up from #2893 

On the framerail side, I've added a request hook ([doc](https://svelte.dev/docs/kit/hooks)) that runs before every framerail request, gathering user token, site ID and page slug to persist into `ServerLoadEvent.locals`, allowing that context to be accessed throughout the request's call chain. This is possible because the required data is persisted on the browser through one way or another:
- `session_token` via cookies
- `site_id` via Caddy headers
- `page` slug via URL params

Additionally, I've implemented the proposed `user_has_permission` in `ServiceContext` as it now contains all necessary data.

Again as a POC, I've modified the `page_edit_permission` call chain to make use of this. Now the full chain becomes:
```
Browser calls `pageEditPermission` via form submission
↓
Framerail hook runs, populating RequestContext in locals
↓
pageEditPermissionAction gets the RequestContext from locals and passes it to deepwell's RPC client
↓
deepwell RPC client serializes RequestContext fields into headers, which is intercepted by deepwell middleware to inject into ServiceContext
↓
Downstream consumers access RequestContext from ctx
```
Request body no longer needs to pass these fields, and handlers no longer need to drill these values down the chain.