### PR TITLE
change docker-compose to docker compose for the new version in deploy.py

### DIFF
--- a/install/local/deploy.py
+++ b/install/local/deploy.py
@@ -46,7 +46,8 @@ if __name__ == "__main__":
 
     # Build command-line argument list
     cmdline = [
-        "docker-compose",
+        "docker",
+        "compose",
         "-p",
         "wikijump",
         "-f",


### PR DESCRIPTION
minor patch, but this did take me like 10 minutes to figure out. as it says, the new docker compose version 2 uses docker compose as appose to docker-compose, and python hated telling me the source of the error.