### PR TITLE
Add procedure to clean up disk usage automatically

### DIFF
--- a/install/dev/komodo/docker-compose.yaml
+++ b/install/dev/komodo/docker-compose.yaml
@@ -61,7 +61,9 @@ services:
       context: .
       dockerfile_inline: |
         FROM ghcr.io/moghtech/komodo-periphery:latest
-        RUN apt-get update && apt-get install -y amazon-ecr-credential-helper
+        RUN apt-get update && \
+          apt-get install -y amazon-ecr-credential-helper && \
+          apt-get install -y docker-buildx-plugin docker-ce-cli docker-compose-plugin
     restart: unless-stopped
     labels:
       komodo.skip:

--- a/install/dev/komodo/system.toml
+++ b/install/dev/komodo/system.toml
@@ -23,3 +23,16 @@ enabled = true
 executions = [
     { execution.type = "GlobalAutoUpdate", execution.params = {}, enabled = true },
 ]
+
+[[procedure]]
+name = "Auto Disk Cleanup"
+description = "Regularly delete incomplete or temporary artifacts to free up disk space."
+tags = ["system"]
+config.schedule = "Every Tuesday at midnight"
+
+[[procedure.config.stage]]
+name = "Prune Data"
+enabled = true
+executions = [
+  { execution.type = "PruneSystem", execution.params.server = "Local", enabled = true }
+]


### PR DESCRIPTION
So far I've been periodically running this manually. We can avoid this by adding a weekly job to clean up dead images and partial build artifacts.

Tested by adding to Komodo and running the procedure manually.