### PR TITLE
Add more audit logging

### DIFF
--- a/deepwell/src/database/seeder/mod.rs
+++ b/deepwell/src/database/seeder/mod.rs
@@ -215,6 +215,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                     target_id: user_id,
                     created_by: SYSTEM_USER_ID,
                     bypass_filter: true,
+                    ip_address: SEED_IP_ADDRESS,
                 },
             )
             .await
@@ -255,6 +256,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                     target_id: site_id,
                     created_by: SYSTEM_USER_ID,
                     bypass_filter: true,
+                    ip_address: SEED_IP_ADDRESS,
                 },
             )
             .await
@@ -428,6 +430,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                             revision_comments: str!(),
                             user_id: SYSTEM_USER_ID,
                             bypass_filter: true,
+                            ip_address: SEED_IP_ADDRESS,
                         },
                     )
                     .await
@@ -456,6 +459,7 @@ pub async fn seed(state: &ServerState) -> Result<()> {
                                     uploaded_blob_id: Maybe::Set(str!()),
                                     direct_upload: Maybe::Set(data),
                                 },
+                                ip_address: SEED_IP_ADDRESS,
                             },
                         )
                         .await

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -26,6 +26,7 @@ use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{FilterService, SiteService, UserService};
 use crate::types::{AliasType, Reference};
 use crate::utils::get_regular_slug;
+use std::net::IpAddr;
 
 #[derive(Debug)]
 pub struct AliasService;
@@ -54,6 +55,7 @@ impl AliasService {
             target_id,
             created_by,
             bypass_filter,
+            ip_address,
         }: CreateAlias,
         verify: bool,
     ) -> Result<CreateAliasOutput> {
@@ -74,7 +76,7 @@ impl AliasService {
 
         // Perform filter validation
         if !bypass_filter {
-            Self::run_filter(ctx, alias_type, &slug)
+            Self::run_filter(ctx, alias_type, &slug, ip_address)
                 .await
                 .or_raise(make_error)?;
         }
@@ -473,6 +475,7 @@ impl AliasService {
         ctx: &ServiceContext<'_>,
         alias_type: AliasType,
         slug: &str,
+        ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking alias name against filters...");
 
@@ -493,7 +496,7 @@ impl AliasService {
                 .or_raise(make_error)?;
 
         filter_matcher
-            .verify(ctx, "slug", slug)
+            .verify(ctx, "slug", slug, ip_address)
             .await
             .or_raise(make_error)?;
 

--- a/deepwell/src/services/alias/service.rs
+++ b/deepwell/src/services/alias/service.rs
@@ -22,6 +22,7 @@ use super::prelude::*;
 use crate::models::alias::{self, Entity as Alias, Model as AliasModel};
 use crate::models::site::{self, Entity as Site};
 use crate::models::user::{self, Entity as User};
+use crate::services::audit::{AuditEvent, AuditService, ObjectScope};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{FilterService, SiteService, UserService};
 use crate::types::{AliasType, Reference};
@@ -76,7 +77,7 @@ impl AliasService {
 
         // Perform filter validation
         if !bypass_filter {
-            Self::run_filter(ctx, alias_type, &slug, ip_address)
+            Self::run_filter(ctx, alias_type, &slug, target_id, ip_address)
                 .await
                 .or_raise(make_error)?;
         }
@@ -475,14 +476,15 @@ impl AliasService {
         ctx: &ServiceContext<'_>,
         alias_type: AliasType,
         slug: &str,
+        target_id: i64,
         ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking alias name against filters...");
 
         let make_error = || Error::new("failed to run filters", ErrorType::Alias);
 
-        let filter_type = match alias_type {
-            AliasType::User => FilterType::User,
+        let (filter_type, target_object) = match alias_type {
+            AliasType::User => (FilterType::User, ObjectScope::User(target_id)),
             AliasType::Site => {
                 // No filter with this type, skip verification
                 debug!("No need to run filter verification for site alias");
@@ -496,7 +498,7 @@ impl AliasService {
                 .or_raise(make_error)?;
 
         filter_matcher
-            .verify(ctx, "slug", slug, ip_address)
+            .verify(ctx, "slug", slug, target_object, ip_address)
             .await
             .or_raise(make_error)?;
 

--- a/deepwell/src/services/alias/structs.rs
+++ b/deepwell/src/services/alias/structs.rs
@@ -19,6 +19,7 @@
  */
 
 use crate::types::AliasType;
+use std::net::IpAddr;
 
 #[derive(Deserialize, Debug)]
 pub struct CreateAlias {
@@ -29,6 +30,7 @@ pub struct CreateAlias {
 
     #[serde(default)]
     pub bypass_filter: bool,
+    pub ip_address: IpAddr,
 }
 
 #[derive(Serialize, Debug)]

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -161,6 +161,11 @@ pub enum AuditEvent<'a> {
         object_type: AuthorizedObject,
         description: &'a str,
     },
+    AuthorizationTokenVerify {
+        token: &'a str,
+        token_id: i32,
+        object_type: AuthorizedObject,
+    },
 }
 
 impl<'a> AuditEvent<'a> {
@@ -565,6 +570,22 @@ impl<'a> AuditEvent<'a> {
                     extra_string_2: Some(Cow::Owned(metadata_json)),
                     extra_number: None,
                 }
+            }
+            AuditEvent::AuthorizationTokenVerify {
+                token,
+                token_id,
+                object_type,
+            } => RawAuditEvent {
+                event_type: "authorization_token.verify",
+                ip_address,
+                user_id: None,
+                site_id: None,
+                page_id: None,
+                extra_id_1: Some(i64::from(token_id)),
+                extra_id_2: None,
+                extra_string_1: Some(Cow::Borrowed(object_type.name())),
+                extra_string_2: Some(Cow::Owned(str!(token))),
+                extra_number: None,
             }
         };
 

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -21,6 +21,7 @@
 use super::prelude::*;
 use crate::license::License;
 use crate::services::authorization_token::AuthorizedObject;
+use crate::services::filter::FilterSummary;
 use crate::types::{PageLockType, Permission};
 use ftml::layout::Layout;
 use sea_orm::prelude::TimeDateTimeWithTimeZone;
@@ -104,6 +105,12 @@ pub enum AuditEvent<'a> {
         site_id: i64,
         page_id: i64,
         layout: Option<Layout>,
+    },
+    FilterViolation {
+        // TODO object being filtered
+        info: &'a FilterSummary,
+        field: &'a str,
+        value: &'a str,
     },
     RoleCreate {
         site_id: i64,
@@ -389,6 +396,12 @@ impl<'a> AuditEvent<'a> {
                 extra_string_2: None,
                 extra_number: None,
             },
+            AuditEvent::FilterViolation {
+                // TODO
+                ..
+            } => {
+                todo!()
+            }
             AuditEvent::RoleCreate {
                 site_id,
                 role_id,

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -107,7 +107,7 @@ pub enum AuditEvent<'a> {
         layout: Option<Layout>,
     },
     FilterViolation {
-        // TODO object being filtered
+        object: ObjectScope,
         info: &'a FilterSummary,
         field: &'a str,
         value: &'a str,
@@ -397,10 +397,47 @@ impl<'a> AuditEvent<'a> {
                 extra_number: None,
             },
             AuditEvent::FilterViolation {
-                // TODO
-                ..
+                object,
+                info,
+                field,
+                value,
             } => {
-                todo!()
+                #[derive(Serialize, Debug)]
+                struct Metadata<'a> {
+                    #[serde(flatten)]
+                    info: &'a FilterSummary,
+                    field: &'a str,
+                    value: &'a str,
+                }
+
+                let mut user_id = None;
+                let mut site_id = None;
+                let mut page_id = None;
+                let mut extra_id_1 = None;
+
+                match object {
+                    ObjectScope::User(id) => user_id = Some(id),
+                    ObjectScope::Site(id) => site_id = Some(id),
+                    ObjectScope::Page(id) => page_id = Some(id),
+                    ObjectScope::File(id) => extra_id_1 = Some(id),
+                }
+
+                let metadata_json =
+                    serde_json::to_string(&Metadata { info, field, value })
+                        .or_raise(make_error)?;
+
+                RawAuditEvent {
+                    event_type: "filter.violation",
+                    ip_address,
+                    user_id,
+                    site_id,
+                    page_id,
+                    extra_id_1,
+                    extra_id_2: None,
+                    extra_string_1: Some(Cow::Owned(metadata_json)),
+                    extra_string_2: None,
+                    extra_number: None,
+                }
             }
             AuditEvent::RoleCreate {
                 site_id,
@@ -599,7 +636,7 @@ impl<'a> AuditEvent<'a> {
                 extra_string_1: Some(Cow::Borrowed(object_type.name())),
                 extra_string_2: Some(Cow::Owned(str!(token))),
                 extra_number: None,
-            }
+            },
         };
 
         Ok(raw_event)
@@ -622,6 +659,14 @@ pub struct RawAuditEvent<'a> {
 }
 
 // Ancillary structures
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ObjectScope {
+    User(i64),
+    Site(i64),
+    Page(i64),
+    File(i64),
+}
 
 #[derive(Serialize, Debug, Clone, Default)]
 #[serde(default)]

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -420,6 +420,7 @@ impl<'a> AuditEvent<'a> {
                     ObjectScope::Site(id) => site_id = Some(id),
                     ObjectScope::Page(id) => page_id = Some(id),
                     ObjectScope::File(id) => extra_id_1 = Some(id),
+                    ObjectScope::Other => (),
                 }
 
                 let metadata_json =
@@ -666,6 +667,7 @@ pub enum ObjectScope {
     Site(i64),
     Page(i64),
     File(i64),
+    Other,
 }
 
 #[derive(Serialize, Debug, Clone, Default)]

--- a/deepwell/src/services/audit/structs.rs
+++ b/deepwell/src/services/audit/structs.rs
@@ -20,6 +20,7 @@
 
 use super::prelude::*;
 use crate::license::License;
+use crate::services::authorization_token::AuthorizedObject;
 use crate::types::{PageLockType, Permission};
 use ftml::layout::Layout;
 use sea_orm::prelude::TimeDateTimeWithTimeZone;
@@ -154,6 +155,11 @@ pub enum AuditEvent<'a> {
         page_id: i64,
         page_lock_id: i64,
         lock_type: PageLockType,
+    },
+    AuthorizationTokenCreate {
+        user_id: i64,
+        object_type: AuthorizedObject,
+        description: &'a str,
     },
 }
 
@@ -534,6 +540,32 @@ impl<'a> AuditEvent<'a> {
                 extra_string_2: None,
                 extra_number: None,
             },
+            AuditEvent::AuthorizationTokenCreate {
+                user_id,
+                object_type,
+                description,
+            } => {
+                #[derive(Serialize, Debug)]
+                struct Metadata<'a> {
+                    description: &'a str,
+                }
+
+                let metadata_json = serde_json::to_string(&Metadata { description })
+                    .or_raise(make_error)?;
+
+                RawAuditEvent {
+                    event_type: "authorization_token.create",
+                    ip_address,
+                    user_id: Some(user_id),
+                    site_id: None,
+                    page_id: None,
+                    extra_id_1: None,
+                    extra_id_2: None,
+                    extra_string_1: Some(Cow::Borrowed(object_type.name())),
+                    extra_string_2: Some(Cow::Owned(metadata_json)),
+                    extra_number: None,
+                }
+            }
         };
 
         Ok(raw_event)

--- a/deepwell/src/services/authorization_token/service.rs
+++ b/deepwell/src/services/authorization_token/service.rs
@@ -163,8 +163,17 @@ impl AuthorizationTokenService {
             .await
             .or_raise(make_error)?;
 
-        // TODO audit log
-        let _ = ip_address;
+        AuditService::log(
+            ctx,
+            ip_address,
+            AuditEvent::AuthorizationTokenVerify {
+                object_type,
+                token: &token,
+                token_id,
+            },
+        )
+        .await
+        .or_raise(make_error)?;
 
         Ok(())
     }

--- a/deepwell/src/services/authorization_token/service.rs
+++ b/deepwell/src/services/authorization_token/service.rs
@@ -168,7 +168,7 @@ impl AuthorizationTokenService {
             ip_address,
             AuditEvent::AuthorizationTokenVerify {
                 object_type,
-                token: &token,
+                token,
                 token_id,
             },
         )

--- a/deepwell/src/services/authorization_token/service.rs
+++ b/deepwell/src/services/authorization_token/service.rs
@@ -22,6 +22,7 @@ use super::prelude::*;
 use crate::models::authorization_token::{
     self, Entity as AuthorizationToken, Model as AuthorizationTokenModel,
 };
+use crate::services::audit::{AuditEvent, AuditService};
 use crate::types::ArrayLength;
 use std::net::IpAddr;
 use uuid::Uuid;
@@ -55,6 +56,18 @@ impl AuthorizationTokenService {
             )
         };
 
+        AuditService::log(
+            ctx,
+            ip_address,
+            AuditEvent::AuthorizationTokenCreate {
+                user_id: creating_user_id,
+                object_type,
+                description: &description,
+            },
+        )
+        .await
+        .or_raise(make_error)?;
+
         let txn = ctx.transaction();
         let model = authorization_token::ActiveModel {
             token_value: Set(token.clone()),
@@ -62,9 +75,6 @@ impl AuthorizationTokenService {
             description: Set(description),
             ..Default::default()
         };
-
-        // TODO audit log
-        let _ = ip_address;
 
         AuthorizationToken::insert(model)
             .exec(txn)

--- a/deepwell/src/services/authorization_token/structs.rs
+++ b/deepwell/src/services/authorization_token/structs.rs
@@ -35,6 +35,15 @@ pub enum AuthorizedObject {
 
 impl AuthorizedObject {
     #[inline]
+    pub fn name(self) -> &'static str {
+        match self {
+            AuthorizedObject::Site => "site",
+            AuthorizedObject::User => "user",
+            AuthorizedObject::BotUser => "bot-user",
+        }
+    }
+
+    #[inline]
     pub fn code(self) -> char {
         match self {
             AuthorizedObject::Site => 'S',

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -24,6 +24,7 @@ use crate::models::file::{self, Entity as File, Model as FileModel};
 use crate::models::file_revision::{
     self, Entity as FileRevision, Model as FileRevisionModel,
 };
+use crate::services::audit::{AuditEvent, AuditService, ObjectScope};
 use crate::services::blob::{EMPTY_BLOB_HASH, EMPTY_BLOB_MIME, FinalizeBlobUploadOutput};
 use crate::services::file_revision::{
     CreateFileRevision, CreateFileRevisionBody, CreateFirstFileRevision,
@@ -88,7 +89,7 @@ impl FileService {
 
         // Perform filter validation
         if !bypass_filter {
-            Self::run_filter(ctx, site_id, Some(&name), ip_address)
+            Self::run_filter(ctx, site_id, None, Some(&name), ip_address)
                 .await
                 .or_raise(make_error)?;
         }
@@ -206,7 +207,7 @@ impl FileService {
                 .or_raise(make_error)?;
 
             if !bypass_filter {
-                Self::run_filter(ctx, site_id, Some(name), ip_address)
+                Self::run_filter(ctx, site_id, Some(file_id), Some(name), ip_address)
                     .await
                     .or_raise(make_error)?;
             }
@@ -664,7 +665,7 @@ impl FileService {
                 .or_raise(make_error)?;
 
             if !bypass_filter {
-                Self::run_filter(ctx, site_id, Some(&name), ip_address)
+                Self::run_filter(ctx, site_id, Some(file_id), Some(&name), ip_address)
                     .await
                     .or_raise(make_error)?;
             }
@@ -969,6 +970,7 @@ impl FileService {
     async fn run_filter(
         ctx: &ServiceContext<'_>,
         site_id: i64,
+        file_id: Option<i64>,
         name: Option<&str>,
         ip_address: IpAddr,
     ) -> Result<()> {
@@ -993,8 +995,13 @@ impl FileService {
             .await
             .or_raise(make_error)?;
 
+            let object = match file_id {
+                Some(id) => ObjectScope::File(id),
+                None => ObjectScope::Other,
+            };
+
             filter_matcher
-                .verify(ctx, "filename", name, ip_address)
+                .verify(ctx, "filename", name, object, ip_address)
                 .await
                 .or_raise(make_error)?;
         }

--- a/deepwell/src/services/file/service.rs
+++ b/deepwell/src/services/file/service.rs
@@ -35,6 +35,7 @@ use crate::services::{BlobService, FileRevisionService, FilterService, PageServi
 use crate::types::{FileOrder, FileRevisionType};
 use crate::utils::trim_spaces_in_place;
 use sea_orm::ActiveValue;
+use std::net::IpAddr;
 
 pub const MAXIMUM_FILE_NAME_LENGTH: usize = 256;
 
@@ -59,6 +60,7 @@ impl FileService {
             revision_comments,
             user_id,
             bypass_filter,
+            ip_address,
         }: CreateFile,
     ) -> Result<CreateFileOutput> {
         info!("Creating file with name '{name}'");
@@ -86,7 +88,7 @@ impl FileService {
 
         // Perform filter validation
         if !bypass_filter {
-            Self::run_filter(ctx, site_id, Some(&name))
+            Self::run_filter(ctx, site_id, Some(&name), ip_address)
                 .await
                 .or_raise(make_error)?;
         }
@@ -142,6 +144,8 @@ impl FileService {
         .await
         .or_raise(make_error)?;
 
+        // TODO audit log
+
         Ok(output)
     }
 
@@ -157,6 +161,7 @@ impl FileService {
             revision_comments,
             bypass_filter,
             body,
+            ip_address,
         }: EditFile,
     ) -> Result<Option<EditFileOutput>> {
         info!("Editing file with ID {file_id}");
@@ -201,7 +206,7 @@ impl FileService {
                 .or_raise(make_error)?;
 
             if !bypass_filter {
-                Self::run_filter(ctx, site_id, Some(name))
+                Self::run_filter(ctx, site_id, Some(name), ip_address)
                     .await
                     .or_raise(make_error)?;
             }
@@ -588,6 +593,7 @@ impl FileService {
             revision_comments,
             user_id,
             bypass_filter,
+            ip_address,
         }: RollbackFile<'_>,
     ) -> Result<Option<EditFileOutput>> {
         let txn = ctx.transaction();
@@ -658,7 +664,7 @@ impl FileService {
                 .or_raise(make_error)?;
 
             if !bypass_filter {
-                Self::run_filter(ctx, site_id, Some(&name))
+                Self::run_filter(ctx, site_id, Some(&name), ip_address)
                     .await
                     .or_raise(make_error)?;
             }
@@ -964,6 +970,7 @@ impl FileService {
         ctx: &ServiceContext<'_>,
         site_id: i64,
         name: Option<&str>,
+        ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking file data against filters...");
 
@@ -987,7 +994,7 @@ impl FileService {
             .or_raise(make_error)?;
 
             filter_matcher
-                .verify(ctx, "filename", name)
+                .verify(ctx, "filename", name, ip_address)
                 .await
                 .or_raise(make_error)?;
         }

--- a/deepwell/src/services/file/structs.rs
+++ b/deepwell/src/services/file/structs.rs
@@ -23,6 +23,7 @@ use crate::services::file_revision::{
 };
 use crate::types::{Bytes, FileDetails, FileRevisionType, Maybe, Reference};
 use serde_json::Value as JsonValue;
+use std::net::IpAddr;
 use time::OffsetDateTime;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -36,6 +37,7 @@ pub struct CreateFile {
 
     #[serde(default)]
     pub bypass_filter: bool,
+    pub ip_address: IpAddr,
 
     /// Allows internal users to upload directly.
     /// When this is present, the value of `uploaded_blob_id` is ignored.
@@ -113,6 +115,7 @@ pub struct EditFile {
 
     #[serde(default)]
     pub bypass_filter: bool,
+    pub ip_address: IpAddr,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -195,4 +198,5 @@ pub struct RollbackFile<'a> {
 
     #[serde(default)]
     pub bypass_filter: bool,
+    pub ip_address: IpAddr,
 }

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -58,6 +58,7 @@ impl FilterMatcher {
         ctx: &ServiceContext<'_>,
         field: &'static str,
         value: &str,
+        ip_address: IpAddr,
     ) -> Result<()> {
         let make_error = || {
             Error::new(
@@ -83,7 +84,6 @@ impl FilterMatcher {
                 info.filter_id, info.regex, info.description,
             );
 
-            let ip_address = todo!();
             AuditService::log(
                 ctx,
                 ip_address,

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -19,7 +19,9 @@
  */
 
 use super::prelude::*;
+use crate::services::audit::{AuditEvent, AuditService};
 use regex::RegexSet;
+use std::net::IpAddr;
 
 /// Describes one filter which a `FilterMatcher` can verify against.
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
@@ -55,9 +57,19 @@ impl FilterMatcher {
         &self,
         ctx: &ServiceContext<'_>,
         field: &'static str,
-        text: &str,
+        value: &str,
     ) -> Result<()> {
-        let matches = self.regex_set.matches(text);
+        let make_error = || {
+            Error::new(
+                format!(
+                    "failed to verify filter (field '{}', value '{}')",
+                    field, value,
+                ),
+                ErrorType::Filter,
+            )
+        };
+
+        let matches = self.regex_set.matches(value);
         if !matches.matched_any() {
             info!("String passed all filters, is clear");
             return Ok(());
@@ -70,18 +82,24 @@ impl FilterMatcher {
                 "String failed filter ID {} (regex '{}'): {}",
                 info.filter_id, info.regex, info.description,
             );
-            failed.push(info.clone());
 
-            // TODO audit log, with contextual data (what it's checking)
-            //      (will need to add extra args)
-            let _ = ctx;
+            let ip_address = todo!();
+            AuditService::log(
+                ctx,
+                ip_address,
+                AuditEvent::FilterViolation { info, field, value },
+            )
+            .await
+            .or_raise(make_error)?;
+
+            failed.push(info.clone());
         }
 
         bail!(Error::new(
             format!("filter failure for field '{field}'"),
             ErrorType::FilterViolation {
                 field: str!(field),
-                value: str!(text),
+                value: str!(value),
                 failed,
             },
         ));

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -84,10 +84,16 @@ impl FilterMatcher {
                 info.filter_id, info.regex, info.description,
             );
 
+            let object = todo!();
             AuditService::log(
                 ctx,
                 ip_address,
-                AuditEvent::FilterViolation { info, field, value },
+                AuditEvent::FilterViolation {
+                    object,
+                    info,
+                    field,
+                    value,
+                },
             )
             .await
             .or_raise(make_error)?;

--- a/deepwell/src/services/filter/matcher.rs
+++ b/deepwell/src/services/filter/matcher.rs
@@ -19,7 +19,7 @@
  */
 
 use super::prelude::*;
-use crate::services::audit::{AuditEvent, AuditService};
+use crate::services::audit::{AuditEvent, AuditService, ObjectScope};
 use regex::RegexSet;
 use std::net::IpAddr;
 
@@ -58,6 +58,7 @@ impl FilterMatcher {
         ctx: &ServiceContext<'_>,
         field: &'static str,
         value: &str,
+        object: ObjectScope,
         ip_address: IpAddr,
     ) -> Result<()> {
         let make_error = || {
@@ -84,7 +85,6 @@ impl FilterMatcher {
                 info.filter_id, info.regex, info.description,
             );
 
-            let object = todo!();
             AuditService::log(
                 ctx,
                 ip_address,

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -41,6 +41,7 @@ use crate::utils::{get_category_name, trim_default};
 use ftml::layout::Layout;
 use ref_map::*;
 use sea_orm::ActiveValue;
+use std::net::IpAddr;
 use wikidot_normalize::normalize;
 
 #[derive(Debug)]
@@ -90,6 +91,7 @@ impl PageService {
                 Some(&wikitext),
                 Some(&title),
                 alt_title.as_ref(),
+                ip_address,
             )
             .await
             .or_raise(make_error)?;
@@ -226,6 +228,7 @@ impl PageService {
                 Maybe::Set(Some(ref alt_title)) => Some(alt_title),
                 _ => None,
             },
+            ip_address,
         )
         .await
         .or_raise(make_error)?;
@@ -1204,6 +1207,7 @@ impl PageService {
         wikitext: Option<S>,
         title: Option<S>,
         alt_title: Option<S>,
+        ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking page data against filters...");
 
@@ -1222,10 +1226,15 @@ impl PageService {
                 async {
                     match $field {
                         None => Ok(()),
-                        Some(value) => filter_matcher
-                            .verify(ctx, stringify!($field), value.as_ref())
-                            .await
-                            .or_raise(make_error),
+                        Some(value) => {
+                            let field = stringify!($field);
+                            let value = value.as_ref();
+
+                            filter_matcher
+                                .verify(ctx, field, value, ip_address)
+                                .await
+                                .or_raise(make_error)
+                        }
                     }
                 }
             };

--- a/deepwell/src/services/page/service.rs
+++ b/deepwell/src/services/page/service.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::page::{self, Entity as Page, Model as PageModel};
 use crate::models::page_category::Model as PageCategoryModel;
 use crate::models::page_revision::Model as PageRevisionModel;
-use crate::services::audit::{AuditEvent, AuditService};
+use crate::services::audit::{AuditEvent, AuditService, ObjectScope};
 use crate::services::filter::{FilterClass, FilterType};
 use crate::services::page_revision::{
     CreateFirstPageRevision, CreateFirstPageRevisionOutput, CreatePageRevision,
@@ -88,6 +88,7 @@ impl PageService {
             Self::run_filter(
                 ctx,
                 site_id,
+                None,
                 Some(&wikitext),
                 Some(&title),
                 alt_title.as_ref(),
@@ -221,6 +222,7 @@ impl PageService {
         Self::run_filter(
             ctx,
             site_id,
+            Some(page_id),
             wikitext.to_option(),
             title.to_option(),
             // Flatten what is essentially Option<Option<_>>
@@ -1204,6 +1206,7 @@ impl PageService {
     async fn run_filter<S: AsRef<str>>(
         ctx: &ServiceContext<'_>,
         site_id: i64,
+        page_id: Option<i64>,
         wikitext: Option<S>,
         title: Option<S>,
         alt_title: Option<S>,
@@ -1229,9 +1232,13 @@ impl PageService {
                         Some(value) => {
                             let field = stringify!($field);
                             let value = value.as_ref();
+                            let object = match page_id {
+                                Some(id) => ObjectScope::Page(id),
+                                None => ObjectScope::Other,
+                            };
 
                             filter_matcher
-                                .verify(ctx, field, value, ip_address)
+                                .verify(ctx, field, value, object, ip_address)
                                 .await
                                 .or_raise(make_error)
                         }

--- a/deepwell/src/services/site/service.rs
+++ b/deepwell/src/services/site/service.rs
@@ -254,7 +254,7 @@ impl SiteService {
         }
 
         if let Maybe::Set(new_slug) = input.slug {
-            Self::update_slug(ctx, &site, &new_slug, updating_user_id)
+            Self::update_slug(ctx, &site, &new_slug, updating_user_id, ip_address)
                 .await
                 .or_raise(make_error)?;
 
@@ -379,6 +379,7 @@ impl SiteService {
         site: &SiteModel,
         new_slug: &str,
         user_id: i64,
+        ip_address: IpAddr,
     ) -> Result<()> {
         info!("Updating slug for site {}, adding alias", site.site_id);
         let old_slug = &site.slug;
@@ -424,6 +425,7 @@ impl SiteService {
                         target_id: site.site_id,
                         created_by: user_id,
                         bypass_filter: true, // sites don't have filters
+                        ip_address,
                     },
                     false,
                 )

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -121,8 +121,8 @@ impl UserService {
         // Perform filter validation
         if should_check_filter(bypass_filter, user_type, None) {
             let (result1, result2) = join!(
-                Self::run_name_filter(ctx, &name, &slug),
-                Self::run_email_filter(ctx, &email),
+                Self::run_name_filter(ctx, &name, &slug, ip_address),
+                Self::run_email_filter(ctx, &email, ip_address),
             );
             raise_multiple!(result1, result2; make_error);
         }
@@ -485,14 +485,21 @@ impl UserService {
         // Add each field
         if let Maybe::Set(name) = input.name {
             // NOTE: Name filter validation occurs in update_name(), not here
-            Self::update_name(ctx, name, &user, &mut model, should_check_filter)
-                .await
-                .or_raise(make_error)?;
+            Self::update_name(
+                ctx,
+                name,
+                &user,
+                &mut model,
+                should_check_filter,
+                ip_address,
+            )
+            .await
+            .or_raise(make_error)?;
         }
 
         if let Maybe::Set(email) = input.email {
             if should_check_filter {
-                Self::run_email_filter(ctx, &email)
+                Self::run_email_filter(ctx, &email, ip_address)
                     .await
                     .or_raise(make_error)?;
             }
@@ -615,6 +622,7 @@ impl UserService {
         user: &UserModel,
         model: &mut user::ActiveModel,
         should_check_filter: bool,
+        ip_address: IpAddr,
     ) -> Result<()> {
         // Regardless of the number of name change tokens,
         // the user can always change their name if the slug is
@@ -633,7 +641,7 @@ impl UserService {
 
         // Perform filter validation
         if should_check_filter {
-            Self::run_name_filter(ctx, &new_name, &new_slug)
+            Self::run_name_filter(ctx, &new_name, &new_slug, ip_address)
                 .await
                 .or_raise(make_error)?;
         }
@@ -707,6 +715,7 @@ impl UserService {
                 target_id: user.user_id,
                 created_by: user.user_id,
                 bypass_filter: !should_check_filter,
+                ip_address,
             },
             false,
         )
@@ -890,6 +899,7 @@ impl UserService {
         ctx: &ServiceContext<'_>,
         name: &str,
         slug: &str,
+        ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking user name data against filters...");
 
@@ -901,15 +911,19 @@ impl UserService {
                 .or_raise(make_error)?;
 
         let (result1, result2) = join!(
-            filter_matcher.verify(ctx, "name", name),
-            filter_matcher.verify(ctx, "slug", slug),
+            filter_matcher.verify(ctx, "name", name, ip_address),
+            filter_matcher.verify(ctx, "slug", slug, ip_address),
         );
         raise_multiple!(result1, result2; make_error);
 
         Ok(())
     }
 
-    async fn run_email_filter(ctx: &ServiceContext<'_>, email: &str) -> Result<()> {
+    async fn run_email_filter(
+        ctx: &ServiceContext<'_>,
+        email: &str,
+        ip_address: IpAddr,
+    ) -> Result<()> {
         info!("Checking user email data against filters...");
 
         let make_error = || Error::new("user failed email filter", ErrorType::User);
@@ -920,7 +934,7 @@ impl UserService {
                 .or_raise(make_error)?;
 
         filter_matcher
-            .verify(ctx, "email", email)
+            .verify(ctx, "email", email, ip_address)
             .await
             .or_raise(make_error)?;
 

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -22,7 +22,7 @@ use super::prelude::*;
 use crate::models::known_user::{self, Model as KnownUserModel};
 use crate::models::user::{self, Entity as User, Model as UserModel};
 use crate::services::alias::CreateAlias;
-use crate::services::audit::{AuditEvent, AuditService};
+use crate::services::audit::{AuditEvent, AuditService, ObjectScope};
 use crate::services::blob::{BlobService, FinalizeBlobUploadOutput};
 use crate::services::email::{EmailClassification, EmailService, EmailValidationOutput};
 use crate::services::filter::{FilterClass, FilterType};
@@ -120,9 +120,10 @@ impl UserService {
 
         // Perform filter validation
         if should_check_filter(bypass_filter, user_type, None) {
+            let object = ObjectScope::User(user_id);
             let (result1, result2) = join!(
-                Self::run_name_filter(ctx, &name, &slug, ip_address),
-                Self::run_email_filter(ctx, &email, ip_address),
+                Self::run_name_filter(ctx, &name, &slug, object, ip_address),
+                Self::run_email_filter(ctx, &email, object, ip_address),
             );
             raise_multiple!(result1, result2; make_error);
         }
@@ -499,9 +500,14 @@ impl UserService {
 
         if let Maybe::Set(email) = input.email {
             if should_check_filter {
-                Self::run_email_filter(ctx, &email, ip_address)
-                    .await
-                    .or_raise(make_error)?;
+                Self::run_email_filter(
+                    ctx,
+                    &email,
+                    ObjectScope::User(user.user_id),
+                    ip_address,
+                )
+                .await
+                .or_raise(make_error)?;
             }
 
             // Validate email
@@ -634,16 +640,22 @@ impl UserService {
 
         let make_error = || {
             Error::new(
-                format!("failed to update name '{}' -> '{}'", old_slug, new_slug,),
+                format!("failed to update name '{}' -> '{}'", old_slug, new_slug),
                 ErrorType::User,
             )
         };
 
         // Perform filter validation
         if should_check_filter {
-            Self::run_name_filter(ctx, &new_name, &new_slug, ip_address)
-                .await
-                .or_raise(make_error)?;
+            Self::run_name_filter(
+                ctx,
+                &new_name,
+                &new_slug,
+                ObjectScope::User(user.user_id),
+                ip_address,
+            )
+            .await
+            .or_raise(make_error)?;
         }
 
         if new_slug == user.slug {
@@ -899,6 +911,7 @@ impl UserService {
         ctx: &ServiceContext<'_>,
         name: &str,
         slug: &str,
+        object: ObjectScope,
         ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking user name data against filters...");
@@ -911,8 +924,8 @@ impl UserService {
                 .or_raise(make_error)?;
 
         let (result1, result2) = join!(
-            filter_matcher.verify(ctx, "name", name, ip_address),
-            filter_matcher.verify(ctx, "slug", slug, ip_address),
+            filter_matcher.verify(ctx, "name", name, object, ip_address),
+            filter_matcher.verify(ctx, "slug", slug, object, ip_address),
         );
         raise_multiple!(result1, result2; make_error);
 
@@ -922,6 +935,7 @@ impl UserService {
     async fn run_email_filter(
         ctx: &ServiceContext<'_>,
         email: &str,
+        object: ObjectScope,
         ip_address: IpAddr,
     ) -> Result<()> {
         info!("Checking user email data against filters...");
@@ -934,7 +948,7 @@ impl UserService {
                 .or_raise(make_error)?;
 
         filter_matcher
-            .verify(ctx, "email", email, ip_address)
+            .verify(ctx, "email", email, object, ip_address)
             .await
             .or_raise(make_error)?;
 


### PR DESCRIPTION
This adds more audit log events & invocations to the code, removing some TODOs.

For the filter violation event, I added `ObjectScope` as a general enum to describe what object is being affected by a general operation (such as filtering).