### PR TITLE
Add handling for some S3 errors with no error message

### DIFF
--- a/deepwell/src/services/blob/service.rs
+++ b/deepwell/src/services/blob/service.rs
@@ -1202,7 +1202,13 @@ impl BlobService {
 #[must_use]
 fn s3_error(response: &ResponseData, action: &str) -> Error {
     let error_message = match str::from_utf8(response.bytes()) {
-        Ok("") => "(no content)",
+        Ok("") => match response.status_code() {
+            // handling for specific error codes
+            // (for when S3 doesn't provide messages)
+            // add as needed
+            507 => "insufficient storage",
+            _ => "(no content)",
+        },
         Ok(m) => m,
         Err(_) => "(invalid UTF-8)",
     };


### PR DESCRIPTION
When using minio locally, it's possible for it to report failure with HTTP 507, which is a bit cryptic until you look up the status code, at which point it becomes obvious.

This adds a `match` arm which we can extend as needed to enrich S3 error messages to aid debugging.