### PR TITLE
Use std::assert_matches! and debug_assert_matches!

### DIFF
--- a/deepwell/src/services/file_revision/service.rs
+++ b/deepwell/src/services/file_revision/service.rs
@@ -29,6 +29,7 @@ use crate::services::{BlobService, OutdateService, PageService};
 use crate::types::{Bytes, FetchDirection, RerenderDepth};
 use sea_orm::FromQueryResult;
 use sea_orm::prelude::*;
+use std::debug_assert_matches;
 use std::num::NonZeroI32;
 use std::sync::LazyLock;
 
@@ -76,15 +77,11 @@ impl FileRevisionService {
             )
         };
 
-        // Replace with debug_assert_matches! when stablized.
-        // This should correspond to each use of FileRevisionService::create() in FileService.
-        debug_assert!(
-            matches!(
-                revision_type,
-                FileRevisionType::Regular
-                    | FileRevisionType::Move
-                    | FileRevisionType::Rollback,
-            ),
+        debug_assert_matches!(
+            revision_type,
+            FileRevisionType::Regular
+                | FileRevisionType::Move
+                | FileRevisionType::Rollback,
             "Invalid revision type for standard revision creation",
         );
 

--- a/deepwell/src/services/page_revision/service.rs
+++ b/deepwell/src/services/page_revision/service.rs
@@ -38,6 +38,7 @@ use ref_map::*;
 use sea_query::{Order, Query};
 use std::num::NonZeroI32;
 use std::sync::LazyLock;
+use std::{assert_matches, debug_assert_matches};
 
 /// The changes for the first revision.
 /// The first revision is always considered to have changed everything.
@@ -118,15 +119,12 @@ impl PageRevisionService {
             )
         };
 
-        // Replace with debug_assert_matches! when stablized
-        debug_assert!(
-            matches!(
-                revision_type,
-                PageRevisionType::Regular
-                    | PageRevisionType::Move
-                    | PageRevisionType::Rollback
-                    | PageRevisionType::Undo,
-            ),
+        debug_assert_matches!(
+            revision_type,
+            PageRevisionType::Regular
+                | PageRevisionType::Move
+                | PageRevisionType::Rollback
+                | PageRevisionType::Undo,
             "Invalid revision type for standard revision creation",
         );
 
@@ -331,14 +329,11 @@ impl PageRevisionService {
                     ),
                 )?;
 
-                // TODO replace with assert_matches! when it's stable
-                assert!(
-                    matches!(
-                        revision_type,
-                        PageRevisionType::Regular
-                            | PageRevisionType::Rollback
-                            | PageRevisionType::Undo
-                    ),
+                assert_matches!(
+                    revision_type,
+                    PageRevisionType::Regular
+                        | PageRevisionType::Rollback
+                        | PageRevisionType::Undo,
                     "Revision type is not standard for non-moves",
                 );
             }


### PR DESCRIPTION
These macros are now stabilized, so we can use them and remove these TODOs.