### PR TITLE
Serve user avatar through wws

### DIFF
--- a/deepwell/src/api.rs
+++ b/deepwell/src/api.rs
@@ -303,6 +303,9 @@ async fn build_module(app_state: ServerState) -> Result<RpcModule<ServerState>> 
     register!("basic_error_file_fetch", basic_error_file_fetch);
     register!("basic_error_text_block", basic_error_text_block);
     register!("basic_error_file_root", basic_error_file_root);
+    register!("basic_error_blob_fetch", basic_error_blob_fetch);
+    register!("basic_error_user_fetch", basic_error_user_fetch);
+    register!("basic_error_user_avatar", basic_error_user_avatar);
 
     // Authentication
     register!("login", auth_login);

--- a/deepwell/src/endpoints/basic_error.rs
+++ b/deepwell/src/endpoints/basic_error.rs
@@ -227,3 +227,63 @@ pub async fn basic_error_file_root(
         .await
         .or_raise(make_error)
 }
+
+pub async fn basic_error_blob_fetch(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<BasicErrorOutput> {
+    #[derive(Deserialize, Debug)]
+    struct Input {
+        locales: Vec<String>,
+        s3_hash: String,
+    }
+
+    let Input { locales, s3_hash } = parse!(params, BasicError);
+
+    let make_error = make_make_error!(blob_fetch);
+    let locales = parse_locales(&locales).or_raise(make_error)?;
+
+    BasicErrorService::blob_fetch(ctx, &locales, &s3_hash)
+        .await
+        .or_raise(make_error)
+}
+
+pub async fn basic_error_user_fetch(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<BasicErrorOutput> {
+    #[derive(Deserialize, Debug)]
+    struct Input {
+        locales: Vec<String>,
+        user_id: i64,
+    }
+
+    let Input { locales, user_id } = parse!(params, BasicError);
+
+    let make_error = make_make_error!(user_fetch);
+    let locales = parse_locales(&locales).or_raise(make_error)?;
+
+    BasicErrorService::user_fetch(ctx, &locales, user_id)
+        .await
+        .or_raise(make_error)
+}
+
+pub async fn basic_error_user_avatar(
+    ctx: &ServiceContext<'_>,
+    params: Params<'static>,
+) -> Result<BasicErrorOutput> {
+    #[derive(Deserialize, Debug)]
+    struct Input {
+        locales: Vec<String>,
+        user_id: i64,
+    }
+
+    let Input { locales, user_id } = parse!(params, BasicError);
+
+    let make_error = make_make_error!(user_avatar);
+    let locales = parse_locales(&locales).or_raise(make_error)?;
+
+    BasicErrorService::user_avatar(ctx, &locales, user_id)
+        .await
+        .or_raise(make_error)
+}

--- a/deepwell/src/services/basic_error.rs
+++ b/deepwell/src/services/basic_error.rs
@@ -392,4 +392,116 @@ impl BasicErrorService {
             body: body.to_string(),
         })
     }
+
+    pub async fn blob_fetch(
+        ctx: &ServiceContext<'_>,
+        locales: &[LanguageIdentifier],
+        s3_hash: &str,
+    ) -> Result<BasicErrorOutput> {
+        let make_error = || {
+            Error::new(
+                format!(
+                    "failed to generate blob_fetch basic error for hash '{}'",
+                    s3_hash,
+                ),
+                ErrorType::BasicError,
+            )
+        };
+
+        assert!(!locales.is_empty(), "No languages specified");
+        let mut args = FluentArgs::new();
+
+        args.set("s3_hash", fluent_str!(s3_hash));
+
+        let title = ctx
+            .localization()
+            .translate(locales, "basic-error-blob-fetch.title", &args)
+            .or_raise(make_error)?;
+
+        let body = ctx
+            .localization()
+            .translate(locales, "basic-error-blob-fetch", &args)
+            .or_raise(make_error)?;
+
+        Ok(BasicErrorOutput {
+            title: title.to_string(),
+            body: body.to_string(),
+        })
+    }
+
+    pub async fn user_fetch(
+        ctx: &ServiceContext<'_>,
+        locales: &[LanguageIdentifier],
+        user_id: i64,
+    ) -> Result<BasicErrorOutput> {
+        let make_error = || {
+            Error::new(
+                format!(
+                    "failed to generate user_fetch basic error for user '{}'",
+                    user_id,
+                ),
+                ErrorType::BasicError,
+            )
+        };
+
+        assert!(!locales.is_empty(), "No languages specified");
+        let mut args = FluentArgs::new();
+
+        let user = user_id.to_string();
+
+        args.set("user_id", fluent_str!(user));
+
+        let title = ctx
+            .localization()
+            .translate(locales, "basic-error-user-fetch.title", &args)
+            .or_raise(make_error)?;
+
+        let body = ctx
+            .localization()
+            .translate(locales, "basic-error-user-fetch", &args)
+            .or_raise(make_error)?;
+
+        Ok(BasicErrorOutput {
+            title: title.to_string(),
+            body: body.to_string(),
+        })
+    }
+
+    pub async fn user_avatar(
+        ctx: &ServiceContext<'_>,
+        locales: &[LanguageIdentifier],
+        user_id: i64,
+    ) -> Result<BasicErrorOutput> {
+        let make_error = || {
+            Error::new(
+                format!(
+                    "failed to generate user_avatar basic error for user '{}'",
+                    user_id,
+                ),
+                ErrorType::BasicError,
+            )
+        };
+
+        assert!(!locales.is_empty(), "No languages specified");
+        let mut args = FluentArgs::new();
+
+        let user = user_id.to_string();
+
+        args.set("user_id", fluent_str!(user));
+
+        let title = ctx
+            .localization()
+            .translate(locales, "basic-error-user-avatar.title", &args)
+            .or_raise(make_error)?;
+
+        let body = ctx
+            .localization()
+            .translate(locales, "basic-error-user-avatar", &args)
+            .or_raise(make_error)?;
+
+        Ok(BasicErrorOutput {
+            title: title.to_string(),
+            body: body.to_string(),
+        })
+    }
 }

--- a/deepwell/src/services/caddy/caddyfile.j2
+++ b/deepwell/src/services/caddy/caddyfile.j2
@@ -151,6 +151,7 @@ deploy{{ files_domain }} {
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/src/services/user/service.rs
+++ b/deepwell/src/services/user/service.rs
@@ -32,6 +32,7 @@ use crate::services::filter::{FilterClass, FilterType};
 use crate::services::{AliasService, FilterService, PasswordService};
 use crate::types::{AliasType, UserType};
 use crate::utils::regex_replace_in_place;
+use redis::AsyncCommands;
 use regex::Regex;
 use sea_orm::ActiveValue;
 use sea_query::OnConflict;
@@ -872,6 +873,12 @@ impl UserService {
                     Some(s3_hash.to_vec())
                 }
             };
+
+            // Clear cached avatar hash
+            let _ = ctx
+                .redis()
+                .del::<_, String>(format!("user_avatar:{}", user.user_id))
+                .await;
 
             model.avatar_s3_hash = Set(s3_hash);
         }

--- a/deepwell/tests/caddy/Caddyfile.basic_local
+++ b/deepwell/tests/caddy/Caddyfile.basic_local
@@ -68,6 +68,7 @@
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/tests/caddy/Caddyfile.basic_localdev
+++ b/deepwell/tests/caddy/Caddyfile.basic_localdev
@@ -71,6 +71,7 @@
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/tests/caddy/Caddyfile.basic_prod
+++ b/deepwell/tests/caddy/Caddyfile.basic_prod
@@ -86,6 +86,7 @@ deploy.wjfiles.test {
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/tests/caddy/Caddyfile.full_prod
+++ b/deepwell/tests/caddy/Caddyfile.full_prod
@@ -86,6 +86,7 @@ deploy.wjfiles.test {
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/tests/caddy/Caddyfile.long
+++ b/deepwell/tests/caddy/Caddyfile.long
@@ -66,6 +66,7 @@
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/deepwell/tests/caddy/Caddyfile.proxies
+++ b/deepwell/tests/caddy/Caddyfile.proxies
@@ -78,6 +78,7 @@ deploy.wjfiles.test {
 		path /-/files/*
 		path /-/file/*
 		path /-/download/*
+		path /-/avatar/*
 		path /-/code/*
 		path /-/html/*
 	}

--- a/framerail/src/lib/server/deepwell/file.ts
+++ b/framerail/src/lib/server/deepwell/file.ts
@@ -1,17 +1,5 @@
 import { client } from "$lib/server/deepwell"
 
-export async function getFileByHash(
-  /** Either a Uint8Array or a hex string */
-  fileHash: Uint8Array | string
-): Promise<Blob> {
-  const res = await client.request(
-    "blob_get",
-    typeof fileHash === "string" ? fileHash : Buffer.from(fileHash).toString("hex")
-  )
-
-  return new Blob([new Uint8Array(res.data)], { type: res.mime })
-}
-
 export async function startBlobUpload(userId: number, blobSize: number) {
   return await client.request("blob_upload", {
     user_id: userId,

--- a/framerail/src/lib/server/load/user.ts
+++ b/framerail/src/lib/server/load/user.ts
@@ -1,7 +1,6 @@
 import defaults from "$lib/defaults"
 
 import { authGetSession } from "$lib/server/auth/getSession"
-import { getFileByHash } from "$lib/server/deepwell/file"
 import { translate } from "$lib/server/deepwell/translate"
 import { userEdit, userView } from "$lib/server/deepwell/user"
 import { loadSiteInfo } from "$lib/server/load/site-info"
@@ -75,17 +74,6 @@ export async function loadUser(
       parentData.user_session?.user?.user_id !== response.data.user.user_id
 
     viewData.user = sanitizeUserData(response.data.user, isViewingAnotherUser)
-
-    // Get user avatar image
-    if (response.data.user.avatar_s3_hash !== null) {
-      const avatar = await getFileByHash(
-        new Uint8Array(response.data.user.avatar_s3_hash)
-      )
-      const dataurl = `data:${avatar.type};base64,${Buffer.from(
-        await avatar.arrayBuffer()
-      ).toString("base64")}`
-      viewData.user.avatar = dataurl
-    }
 
     translateKeys = {
       ...translateKeys,

--- a/framerail/src/routes/[x+2d]/user/[slug]/page.svelte
+++ b/framerail/src/routes/[x+2d]/user/[slug]/page.svelte
@@ -8,7 +8,12 @@
     userData
   }: { data: PageData; userData: InferOutput<typeof userEditSchema> } = $props()
 
-  let avatar = $derived<string | undefined>(data.user?.avatar)
+  // svelte-ignore state_referenced_locally
+  let avatar = $state(
+    data.user?.avatar_s3_hash
+      ? `https://${data.site_file_domain}/-/avatar/${data.user.user_id}`
+      : null
+  )
 
   $effect(() => {
     let url: string | undefined

--- a/locales/fluent/basic-error/en.ftl
+++ b/locales/fluent/basic-error/en.ftl
@@ -96,3 +96,24 @@ basic-error-file-root = <h1>Invalid route</h1>
     </p>
 
     .title = { -service-name }
+
+basic-error-blob-fetch = <h1>Unable to fetch blob data</h1>
+    <p>
+      Server error: Blob with S3 hash <code>{ $s3_hash }</code> could not be loaded.
+    </p>
+
+    .title = Server Error
+
+basic-error-user-fetch = <h1>Unable to fetch user data</h1>
+    <p>
+      Server error: User with id <code>{ $user_id }</code> could not be loaded.
+    </p>
+
+    .title = Server Error
+
+basic-error-user-avatar = <h1>Unable to fetch user avatar</h1>
+    <p>
+      Server error: User avatar with user id <code>{ $user_id }</code> could not be loaded.
+    </p>
+
+    .title = Server Error

--- a/locales/fluent/basic-error/zh_Hans.ftl
+++ b/locales/fluent/basic-error/zh_Hans.ftl
@@ -1,6 +1,6 @@
 ### 基本错误 HTML 模板
 
-basic-error-site-slug = <h1>该网址不存在 { -service-name } 站点。</h1>
+basic-error-site-slug = <h1>该网址不存在 { -service-name } 站点</h1>
     <p>
       <a href="https://{ $slug }.{ $main_domain }/"><code>{ $slug }.{ $main_domain }</code></a> 不存在。
     </p>
@@ -11,7 +11,7 @@ basic-error-site-slug = <h1>该网址不存在 { -service-name } 站点。</h1>
 
     .title = 站点不存在 - { -service-name }
 
-basic-error-site-custom = <h1>该网址不存在 { -service-name } 站点。</h1>
+basic-error-site-custom = <h1>该网址不存在 { -service-name } 站点</h1>
     <p>
       没有网站使用此自定义域名 <a href="https://{ $custom_domain }/"><code>{ $custom_domain }</code></a>。
     </p>
@@ -21,6 +21,70 @@ basic-error-site-custom = <h1>该网址不存在 { -service-name } 站点。</h1
     </p>
 
     .title = 站点不存在 - { -service-name }
+
+basic-error-page-slug = <h1>此页面并不存在</h1>
+    <p>
+      页面 <a href="https://{ $domain }/{ $page_slug }"><code>{ $domain }/{ $page_slug }</code></a> 并不存在。
+    </p>
+
+    <p>
+      返回<a href="https://{ $domain }/">网站主页面</a>。
+    </p>
+
+    .title = 此页面不存在 - { $domain }
+
+basic-error-page-fetch = <h1>无法载入页面</h1>
+    <p>
+      服务器错误：页面 <a href="https://{ $domain }/{ $page_slug }"><code>{ $domain }/{ $page_slug }</code></a> 无法被载入。
+    </p>
+
+    <p>
+      返回<a href="https://{ $domain }/{ $page_slug }">页面/a>，或<a href="https://{ $domain }/">网站主页面</a>.
+    </p>
+
+    .title = 服务器错误 - { $domain }
+
+basic-error-file-name = <h1>此文件并不存在</h1>
+    <p>
+      页面 <code>{ $domain }/{ $page_slug }</code> 不存在文件 <code>{ $filename }</code>。
+    </p>
+
+    <p>
+      返回<a href="https://{ $domain }/{ $page_slug }">页面</a>，或<a href="https://{ $domain }/">网站主页面</a>。
+    </p>
+
+    .title = 此页面不存在 - { $domain }
+
+basic-error-file-fetch = <h1>无法载入文件</h1>
+    <p>
+      服务器错误：位于页面 <code>{ $domain }/{ $page_slug }</code> 的文件 <code>{ $filename }</code> 无法被载入。
+    </p>
+
+    <p>
+      返回<a href="https://{ $domain }/{ $page_slug }">页面</a>，或<a href="https://{ $domain }/">网站主页面</a>。
+    </p>
+
+    .title = 服务器错误 - { $domain }
+
+basic-error-text-block = <h1>无效文字块</h1>
+    <p>
+      { $reason ->
+        [missing] 编号为 <code>{ $index }</code> 的 { $type ->
+          [code] 源代码
+          [html] HTML
+          *[error] 文字
+        } 块并不存在。
+        [invalid] 无效编号 <code>{ $index }</code> 。
+        [fetch] 此文字块无法被载入。
+        *[error] 未知基本错误原因：{ $reason }
+      }
+    </p>
+
+    <p>
+      返回<a href="https://{ $domain }/">网站主页面</a>。
+    </p>
+
+    .title = 文字块错误 - { $domain }
 
 basic-error-file-root = <h1>无效路径</h1>
     <p>

--- a/locales/fluent/basic-error/zh_Hans.ftl
+++ b/locales/fluent/basic-error/zh_Hans.ftl
@@ -32,3 +32,24 @@ basic-error-file-root = <h1>无效路径</h1>
     </p>
 
     .title = { -service-name }
+
+basic-error-blob-fetch = <h1>无法载入文件</h1>
+    <p>
+      服务器错误：S3 哈希值为 <code>{ $s3_hash }</code> 的文件无法被载入。
+    </p>
+
+    .title = 服务器错误
+
+basic-error-user-fetch = <h1>无法载入用户</h1>
+    <p>
+      服务器错误：编号为 <code>{ $user_id }</code> 的用户无法被载入。
+    </p>
+
+    .title = 服务器错误
+
+basic-error-user-avatar = <h1>无法载入用户头像</h1>
+    <p>
+      服务器错误：编号为 <code>{ $user_id }</code> 的用户头像无法被载入。
+    </p>
+
+    .title = 服务器错误

--- a/wws/src/cache.rs
+++ b/wws/src/cache.rs
@@ -48,6 +48,9 @@ macro_rules! redis_key {
     (file_name => $site_id:expr, $page_id:expr, $filename:expr $(,)?) => {
         format!("file_name:{}:{}:{}", $site_id, $page_id, $filename)
     };
+    (user_avatar => $user_id:expr $(,)?) => {
+        format!("user_avatar:{}", $user_id)
+    };
 }
 
 macro_rules! set {
@@ -165,6 +168,21 @@ impl Cache {
         hset!(conn, key, "mime", &data.mime);
         hset!(conn, key, "size", data.size);
         hset!(conn, key, "s3_hash", &data.s3_hash);
+        Ok(())
+    }
+
+    /// Gets the avatar hash for a user ID.
+    pub async fn get_avatar(&self, user_id: i64) -> Result<Option<String>> {
+        let mut conn = get_connection!(self.client);
+        let key = redis_key!(user_avatar => user_id);
+        let value = conn.get(key).await?;
+        Ok(value)
+    }
+
+    pub async fn set_avatar(&self, user_id: i64, avatar_s3_hash: &str) -> Result<()> {
+        let mut conn = get_connection!(self.client);
+        let key = redis_key!(user_avatar => user_id);
+        set!(conn, key, avatar_s3_hash);
         Ok(())
     }
 }

--- a/wws/src/deepwell.rs
+++ b/wws/src/deepwell.rs
@@ -377,7 +377,6 @@ pub struct BlobData {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct UserData {
-    pub user_id: i64,
     pub avatar_s3_hash: Vec<u8>,
 }
 

--- a/wws/src/deepwell.rs
+++ b/wws/src/deepwell.rs
@@ -370,6 +370,12 @@ pub struct FileData {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+pub struct BlobData {
+    pub mime: String,
+    pub size: i64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct UserData {
     pub user_id: i64,
     pub avatar_s3_hash: Vec<u8>,

--- a/wws/src/deepwell.rs
+++ b/wws/src/deepwell.rs
@@ -114,6 +114,15 @@ impl Deepwell {
         Ok(file_data)
     }
 
+    pub async fn get_user(&self, user_id: i64) -> Result<Option<UserData>> {
+        let params = rpc_object! {
+            "user" => user_id,
+        };
+
+        let user_data: Option<UserData> = self.client.request("user_get", params).await?;
+        Ok(user_data)
+    }
+
     pub async fn get_text_block_index(
         &self,
         page_id: i64,
@@ -358,6 +367,12 @@ pub struct FileData {
     pub mime: String,
     pub size: i64,
     pub s3_hash: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct UserData {
+    pub user_id: i64,
+    pub avatar_s3_hash: Vec<u8>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/wws/src/deepwell.rs
+++ b/wws/src/deepwell.rs
@@ -291,6 +291,60 @@ impl Deepwell {
 
         Ok(html)
     }
+
+    pub async fn basic_error_blob_fetch(
+        &self,
+        locales: &[String],
+        s3_hash: &str,
+    ) -> Result<BasicErrorHtml> {
+        let params = rpc_object! {
+            "locales" => locales,
+            "s3_hash" => s3_hash,
+        };
+
+        let html: BasicErrorHtml = self
+            .client
+            .request("basic_error_blob_fetch", params)
+            .await?;
+
+        Ok(html)
+    }
+
+    pub async fn basic_error_user_fetch(
+        &self,
+        locales: &[String],
+        user_id: i64,
+    ) -> Result<BasicErrorHtml> {
+        let params = rpc_object! {
+            "locales" => locales,
+            "user_id" => user_id,
+        };
+
+        let html: BasicErrorHtml = self
+            .client
+            .request("basic_error_user_fetch", params)
+            .await?;
+
+        Ok(html)
+    }
+
+    pub async fn basic_error_user_avatar(
+        &self,
+        locales: &[String],
+        user_id: i64,
+    ) -> Result<BasicErrorHtml> {
+        let params = rpc_object! {
+            "locales" => locales,
+            "user_id" => user_id,
+        };
+
+        let html: BasicErrorHtml = self
+            .client
+            .request("basic_error_user_avatar", params)
+            .await?;
+
+        Ok(html)
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/wws/src/error/basic.rs
+++ b/wws/src/error/basic.rs
@@ -58,6 +58,15 @@ pub enum BasicError<'a> {
         page_slug: &'a str,
         filename: &'a str,
     },
+    BlobFetch {
+        s3_hash: &'a str,
+    },
+    UserFetch {
+        user_id: i64,
+    },
+    UserAvatar {
+        user_id: i64,
+    },
     TextBlock {
         site_id: i64,
         index: &'a str,
@@ -169,6 +178,15 @@ pub async fn build_basic_error_response(
             filename,
         } => {
             deepwell_fetch!(file_fetch, site_id, page_slug, filename => INTERNAL_SERVER_ERROR)
+        }
+        BasicError::BlobFetch { s3_hash } => {
+            deepwell_fetch!(blob_fetch, s3_hash => NOT_FOUND)
+        }
+        BasicError::UserFetch { user_id } => {
+            deepwell_fetch!(user_fetch, user_id => NOT_FOUND)
+        }
+        BasicError::UserAvatar { user_id } => {
+            deepwell_fetch!(user_avatar, user_id => NOT_FOUND)
         }
         BasicError::TextBlock {
             site_id,

--- a/wws/src/handler/avatar.rs
+++ b/wws/src/handler/avatar.rs
@@ -85,8 +85,8 @@ async fn fetch_blob(
 
     Ok((
         BlobData {
-            size: file_size.unwrap_or(0),
-            mime: mime_type.unwrap_or("text/plain".into()),
+            size: file_size.expect("File size should be known"),
+            mime: mime_type.expect("File mime type should be known"),
         },
         body,
     ))

--- a/wws/src/handler/avatar.rs
+++ b/wws/src/handler/avatar.rs
@@ -115,6 +115,7 @@ pub async fn handle_user_avatar(
     };
 
     let result = Response::builder()
+        .header(header::CONTENT_LENGTH, file_info.size)
         .header(header::CONTENT_TYPE, &file_info.mime)
         .header(header::ETAG, format!("\"{}\"", avatar_s3_hash)) // E-Tags have to be surrounded in double quotes
         .body(body);

--- a/wws/src/handler/avatar.rs
+++ b/wws/src/handler/avatar.rs
@@ -47,7 +47,7 @@ async fn fetch_blob(
             (result.content_length, result.content_type)
         }
         Err(error) => {
-            error!(s3_hash = s3_hash, "Cannot get blob metadata: {error}",);
+            error!(s3_hash = s3_hash, "Cannot get blob metadata: {error}");
 
             let response = build_basic_error_response(
                 state,
@@ -97,7 +97,7 @@ pub async fn handle_user_avatar(
     Path(user_id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    info!(user_id = user_id, "Returning user avatar",);
+    info!(user_id = user_id, "Returning user avatar");
 
     let Ok(user_id_i64) = user_id.parse::<i64>() else {
         error!("Unable to parse user id into i64: {user_id}");

--- a/wws/src/handler/avatar.rs
+++ b/wws/src/handler/avatar.rs
@@ -1,0 +1,129 @@
+/*
+ * handler/avatar.rs
+ *
+ * Wilson's Web Server - Serves a zoo of user-generated content
+ * Copyright (C) 2019-2026 Wikijump Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::{
+    deepwell::BlobData,
+    error::{BasicError, ResponseResult, build_basic_error_response},
+    state::ServerState,
+};
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::StatusCode,
+    http::header::{self, HeaderMap},
+    response::{IntoResponse, Response},
+};
+use s3::request::request_trait::ResponseDataStream;
+
+async fn fetch_blob(
+    state: &ServerState,
+    headers: &HeaderMap,
+    s3_hash: &str,
+) -> ResponseResult<(BlobData, Body)> {
+    let (file_size, mime_type) = match state.s3_files_bucket.head_object(&s3_hash).await {
+        Ok((result, status_code)) => {
+            assert_eq!(
+                status_code,
+                StatusCode::OK,
+                "head_object() succeeded but did not reply 200",
+            );
+            (result.content_length, result.content_type)
+        }
+        Err(error) => {
+            error!(s3_hash = s3_hash, "Cannot get blob metadata: {error}",);
+
+            let response = build_basic_error_response(
+                state,
+                headers,
+                BasicError::BlobFetch { s3_hash },
+            )
+            .await;
+
+            return Err(response);
+        }
+    };
+
+    let body = match state.s3_files_bucket.get_object_stream(s3_hash).await {
+        Ok(ResponseDataStream { bytes, status_code }) => {
+            assert_eq!(
+                status_code,
+                StatusCode::OK,
+                "get_object_stream() succeeded but did not reply 200",
+            );
+            Body::from_stream(bytes)
+        }
+        Err(error) => {
+            error!(s3_hash = s3_hash, "Cannot get blob data: {error}",);
+
+            let response = build_basic_error_response(
+                state,
+                headers,
+                BasicError::BlobFetch { s3_hash },
+            )
+            .await;
+
+            return Err(response);
+        }
+    };
+
+    Ok((
+        BlobData {
+            size: file_size.unwrap_or(0),
+            mime: mime_type.unwrap_or("text/plain".into()),
+        },
+        body,
+    ))
+}
+
+pub async fn handle_user_avatar(
+    State(state): State<ServerState>,
+    Path(user_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    info!(user_id = user_id, "Returning user avatar",);
+
+    let Ok(user_id_i64) = user_id.parse::<i64>() else {
+        error!("Unable to parse user id into i64: {user_id}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    };
+
+    let avatar_s3_hash = match state.get_avatar_or_response(&headers, user_id_i64).await {
+        Ok(output) => output,
+        Err(response) => return response,
+    };
+
+    let (file_info, body) = match fetch_blob(&state, &headers, &avatar_s3_hash).await {
+        Ok(output) => output,
+        Err(response) => return response,
+    };
+
+    let result = Response::builder()
+        .header(header::CONTENT_TYPE, &file_info.mime)
+        .header(header::ETAG, format!("\"{}\"", avatar_s3_hash)) // E-Tags have to be surrounded in double quotes
+        .body(body);
+
+    match result {
+        Ok(response) => response,
+        Err(error) => {
+            error!("Unable to convert response: {error}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}

--- a/wws/src/handler/avatar.rs
+++ b/wws/src/handler/avatar.rs
@@ -99,12 +99,12 @@ pub async fn handle_user_avatar(
 ) -> Response {
     info!(user_id = user_id, "Returning user avatar");
 
-    let Ok(user_id_i64) = user_id.parse::<i64>() else {
+    let Ok(user_id) = user_id.parse::<i64>() else {
         error!("Unable to parse user id into i64: {user_id}");
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
 
-    let avatar_s3_hash = match state.get_avatar_or_response(&headers, user_id_i64).await {
+    let avatar_s3_hash = match state.get_avatar_or_response(&headers, user_id).await {
         Ok(output) => output,
         Err(response) => return response,
     };

--- a/wws/src/handler/basic_error.rs
+++ b/wws/src/handler/basic_error.rs
@@ -19,8 +19,8 @@
  */
 
 use super::{
-    HEADER_BASIC_ERROR, HEADER_FILENAME, HEADER_PAGE_SLUG, get_header, get_site_id,
-    get_site_slug,
+    HEADER_BASIC_ERROR, HEADER_BLOB_HASH, HEADER_FILENAME, HEADER_PAGE_SLUG,
+    HEADER_USER_ID, get_header, get_site_id, get_site_slug,
 };
 use crate::error::{BasicError, FallbackError, build_basic_error_response};
 use crate::state::ServerState;
@@ -46,6 +46,26 @@ fn get_filename(headers: &HeaderMap) -> &str {
         "No filename header in request",
         "Filename header is not UTF-8",
     )
+}
+
+fn get_blob_hash(headers: &HeaderMap) -> &str {
+    get_header(
+        headers,
+        HEADER_BLOB_HASH,
+        "No blob s3 hash header in request",
+        "Blob s3 hash header is not UTF-8",
+    )
+}
+
+fn get_user_id(headers: &HeaderMap) -> i64 {
+    get_header(
+        headers,
+        HEADER_USER_ID,
+        "No user ID header in request",
+        "User ID header is not UTF-8",
+    )
+    .parse()
+    .expect("User ID is not a valid integer")
 }
 
 pub async fn handle_basic_error(
@@ -117,6 +137,21 @@ pub async fn handle_basic_error(
         }
         // No required headers
         "file-root" => BasicError::FileRoot,
+        // Required headers:
+        // - x-wikijump-s3-hash
+        "blob-fetch" => BasicError::BlobFetch {
+            s3_hash: get_blob_hash(&headers),
+        },
+        // Required headers:
+        // - x-wikijump-user-id
+        "user-fetch" => BasicError::UserFetch {
+            user_id: get_user_id(&headers),
+        },
+        // Required headers:
+        // - x-wikijump-user-id
+        "user-avatar" => BasicError::UserAvatar {
+            user_id: get_user_id(&headers),
+        },
         // Invalid
         _ => {
             // XF-1000

--- a/wws/src/handler/mod.rs
+++ b/wws/src/handler/mod.rs
@@ -40,6 +40,8 @@ pub const HEADER_SITE_ID: HeaderName = HeaderName::from_static("x-wikijump-site-
 pub const HEADER_SITE_SLUG: HeaderName = HeaderName::from_static("x-wikijump-site-slug");
 pub const HEADER_PAGE_SLUG: HeaderName = HeaderName::from_static("x-wikijump-page-slug");
 pub const HEADER_FILENAME: HeaderName = HeaderName::from_static("x-wikijump-filename");
+pub const HEADER_BLOB_HASH: HeaderName = HeaderName::from_static("x-wikijump-s3-hash");
+pub const HEADER_USER_ID: HeaderName = HeaderName::from_static("x-wikijump-user-id");
 pub const HEADER_TARGET_SERVER: HeaderName =
     HeaderName::from_static("x-wikijump-target-server");
 pub const HEADER_BASIC_ERROR: HeaderName =

--- a/wws/src/handler/mod.rs
+++ b/wws/src/handler/mod.rs
@@ -18,6 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+mod avatar;
 mod basic_error;
 mod file;
 mod misc;
@@ -26,6 +27,7 @@ mod robots;
 mod text_block;
 mod well_known;
 
+pub use self::avatar::*;
 pub use self::basic_error::*;
 pub use self::file::*;
 pub use self::misc::*;

--- a/wws/src/route.rs
+++ b/wws/src/route.rs
@@ -68,6 +68,8 @@ pub fn build_router(state: ServerState) -> Router {
             "/-/download/{page_slug}/{filename}",
             any(handle_invalid_method),
         )
+        .route("/-/avatar/{user_id}", get(handle_user_avatar))
+        .route("/-/avatar/{user_id}", any(handle_invalid_method))
         // Code and HTML
         .route("/-/code/{page_slug}/{index}", get(handle_code_block))
         .route("/-/code/{page_slug}/{index}", any(handle_invalid_method))

--- a/wws/src/state.rs
+++ b/wws/src/state.rs
@@ -20,7 +20,7 @@
 
 use crate::cache::Cache;
 use crate::config::Secrets;
-use crate::deepwell::{Deepwell, FileData, PageData};
+use crate::deepwell::{Deepwell, FileData, PageData, UserData};
 use crate::error::{
     BasicError, FallbackError, ResponseResult, Result, build_basic_error_response,
 };
@@ -248,6 +248,60 @@ impl ServerStateInner {
                         page_slug,
                         filename,
                     },
+                )
+                .await;
+
+                Err(response)
+            }
+        }
+    }
+
+    pub async fn get_avatar(&self, user_id: i64) -> Result<Option<String>> {
+        match self.cache.get_avatar(user_id).await? {
+            Some(avatar_s3_hash) => Ok(Some(avatar_s3_hash)),
+            None => match self.deepwell.get_user(user_id).await? {
+                None => Ok(None),
+                Some(UserData { avatar_s3_hash, .. }) => {
+                    let s3_hash: String = avatar_s3_hash
+                        .iter()
+                        .map(|b| format!("{:02x}", b).to_string())
+                        .collect();
+                    self.cache.set_avatar(user_id, &s3_hash).await?;
+                    Ok(Some(s3_hash))
+                }
+            },
+        }
+    }
+
+    pub async fn get_avatar_or_response(
+        &self,
+        headers: &HeaderMap,
+        user_id: i64,
+    ) -> ResponseResult<String> {
+        match self.get_avatar(user_id).await {
+            Ok(Some(avatar_s3_hash)) => Ok(avatar_s3_hash),
+            Ok(None) => {
+                error!(
+                    user_id = user_id,
+                    "Cannot complete request, no such user or no avatar set",
+                );
+
+                let response = build_basic_error_response(
+                    self,
+                    headers,
+                    BasicError::UserAvatar { user_id },
+                )
+                .await;
+
+                Err(response)
+            }
+            Err(error) => {
+                error!(user_id = user_id, "Cannot get user info: {error}",);
+
+                let response = build_basic_error_response(
+                    self,
+                    headers,
+                    BasicError::UserFetch { user_id },
                 )
                 .await;
 

--- a/wws/src/state.rs
+++ b/wws/src/state.rs
@@ -296,7 +296,7 @@ impl ServerStateInner {
                 Err(response)
             }
             Err(error) => {
-                error!(user_id = user_id, "Cannot get user info: {error}",);
+                error!(user_id = user_id, "Cannot get user info: {error}");
 
                 let response = build_basic_error_response(
                     self,

--- a/wws/src/state.rs
+++ b/wws/src/state.rs
@@ -261,7 +261,7 @@ impl ServerStateInner {
             Some(avatar_s3_hash) => Ok(Some(avatar_s3_hash)),
             None => match self.deepwell.get_user(user_id).await? {
                 None => Ok(None),
-                Some(UserData { avatar_s3_hash, .. }) => {
+                Some(UserData { avatar_s3_hash }) => {
                     let s3_hash: String = avatar_s3_hash
                         .iter()
                         .map(|b| format!("{:02x}", b).to_string())


### PR DESCRIPTION
This allow user avatars to be served through wws by user id (with s3 hash caching), such that the blob data need not be fetched though deepwell.