### PR TITLE
Fix html for wws basic errors

### DIFF
--- a/deepwell/Cargo.toml
+++ b/deepwell/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "database", "web-programming::http-server"]
 exclude = [".gitignore", ".editorconfig"]
 
-version = "2026.7.22"
+version = "2026.8.20"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/deepwell/src/services/basic_error.rs
+++ b/deepwell/src/services/basic_error.rs
@@ -34,7 +34,7 @@
 
 use super::prelude::*;
 use crate::services::{DomainService, SiteService};
-use crate::utils::parse_locales;
+use crate::utils::{parse_locales, strip_fluent_control_chars};
 use fluent::{FluentArgs, FluentValue};
 use serde::Deserialize;
 use unic_langid::LanguageIdentifier;
@@ -77,14 +77,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-site-slug.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-site-slug", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -116,14 +119,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-site-custom.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-site-custom", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -166,14 +172,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-page-slug.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-page-slug", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -211,14 +220,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-page-fetch.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-page-fetch", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -256,14 +268,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-file-name.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-file-name", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -301,14 +316,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-file-fetch.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-file-fetch", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -348,14 +366,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-text-block.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-text-block", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -382,14 +403,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-file-root.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-file-root", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -418,14 +442,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-blob-fetch.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-blob-fetch", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -456,14 +483,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-user-fetch.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-user-fetch", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 
@@ -494,14 +524,17 @@ impl BasicErrorService {
             .translate(locales, "basic-error-user-avatar.title", &args)
             .or_raise(make_error)?;
 
-        let body = ctx
+        let mut body = ctx
             .localization()
             .translate(locales, "basic-error-user-avatar", &args)
-            .or_raise(make_error)?;
+            .or_raise(make_error)?
+            .to_string();
+
+        strip_fluent_control_chars(&mut body);
 
         Ok(BasicErrorOutput {
             title: title.to_string(),
-            body: body.to_string(),
+            body,
         })
     }
 }

--- a/wws/Cargo.toml
+++ b/wws/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["wikijump", "api", "backend", "wiki"]
 categories = ["asynchronous", "caching", "web-programming::http-server"]
 exclude = [".gitignore"]
 
-version = "2026.3.21"
+version = "2026.8.20"
 authors = ["Emmie Smith <emmie.maeda@gmail.com>"]
 edition = "2024"
 

--- a/wws/src/error/basic.rs
+++ b/wws/src/error/basic.rs
@@ -211,7 +211,7 @@ pub async fn build_basic_error_response(
     //         which in turn come from Fluent translation lines.
     //         As such, they can be trusted to not contain malicious HTML.
 
-    const HTML_START: &str = r#"<html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>"#;
+    const HTML_START: &str = r#"<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>"#;
     const HTML_MIDDLE: &str = "</title></head><body><article>";
     const HTML_END: &str = "</article></body></html>\n";
 


### PR DESCRIPTION
Removes fluent control characters from basic error html content, as they interfere with anchor links.