### PR TITLE
[WJ-1168] Fix create_fn => private_only for null metadata

### DIFF
--- a/deepwell/relation-impl-derive/src/expand.rs
+++ b/deepwell/relation-impl-derive/src/expand.rs
@@ -261,16 +261,14 @@ fn generate_create_defs(
             }
         }
         None => {
-            if generate_pub_struct {
-                create_struct_def = Some(quote! {
-                    #[derive(Deserialize, Debug, Clone)]
-                    pub struct #create_struct {
-                        pub #dest_name: i64,
-                        pub #from_name: i64,
-                        pub created_by: i64,
-                    }
-                });
-            }
+            create_struct_def = Some(quote! {
+                #[derive(Deserialize, Debug, Clone)]
+                #fn_visibility struct #create_struct {
+                    pub #dest_name: i64,
+                    pub #from_name: i64,
+                    pub created_by: i64,
+                }
+            });
         }
     };
 

--- a/deepwell/relation-impl-derive/src/expand.rs
+++ b/deepwell/relation-impl-derive/src/expand.rs
@@ -261,9 +261,15 @@ fn generate_create_defs(
             }
         }
         None => {
+            let vis = if generate_pub_struct {
+                public()
+            } else {
+                private()
+            };
+
             create_struct_def = Some(quote! {
                 #[derive(Deserialize, Debug, Clone)]
-                #fn_visibility struct #create_struct {
+                #vis struct #create_struct {
                     pub #dest_name: i64,
                     pub #from_name: i64,
                     pub created_by: i64,


### PR DESCRIPTION
Follow-up to #3039.

This fixes the case, described [here](https://github.com/scpwiki/wikijump/pull/3039#discussion_r3970598910), where `create_fn => private_only` for the no-metadata case. I tested by changing an existing relation to `private_only` and observing that the generated creation struct was no longer `pub`.